### PR TITLE
[codex] Polish subscription import and app routing

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/AccessControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/AccessControlActivity.kt
@@ -6,9 +6,11 @@ import android.content.ClipboardManager
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.widget.Toast
 import androidx.core.content.getSystemService
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.design.AccessControlDesign
+import com.github.kr328.clash.design.R
 import com.github.kr328.clash.design.model.AppInfo
 import com.github.kr328.clash.design.util.toAppInfo
 import com.github.kr328.clash.service.model.AccessControlMode
@@ -16,9 +18,11 @@ import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.util.RussianBypassDefaults
 import com.github.kr328.clash.util.startClashService
 import com.github.kr328.clash.util.stopClashService
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 
@@ -54,6 +58,9 @@ class AccessControlActivity : BaseActivity<AccessControlDesign>() {
                 val changedMode = currentMode != latestMode
                 service.accessControlPackages = selected
                 service.accessControlMode = currentMode
+                if (changedPackages || changedMode) {
+                    service.russianBypassSeeded = true
+                }
                 if (clashRunning && (changedPackages || changedMode)) {
                     stopClashService()
                     while (clashRunning) {
@@ -70,6 +77,9 @@ class AccessControlActivity : BaseActivity<AccessControlDesign>() {
 
         design.setMode(currentMode)
         design.requests.send(AccessControlDesign.Request.ReloadApps)
+        maybePromptRussianBypass(service, design, selected) { mode ->
+            currentMode = mode
+        }
 
         while (isActive) {
             select<Unit> {
@@ -84,17 +94,6 @@ class AccessControlActivity : BaseActivity<AccessControlDesign>() {
 
                         AccessControlDesign.Request.ChangeMode -> {
                             design.pendingMode?.let { mode ->
-                                withContext(Dispatchers.IO) {
-                                    if (mode == AccessControlMode.DenySelected &&
-                                        !service.russianBypassSeeded
-                                    ) {
-                                        val seed = RussianBypassDefaults.installed(packageManager)
-                                        if (seed.isNotEmpty()) {
-                                            selected.addAll(seed)
-                                        }
-                                        service.russianBypassSeeded = true
-                                    }
-                                }
                                 currentMode = mode
                                 design.setMode(currentMode)
                                 design.patchApps(loadApps(selected))
@@ -158,6 +157,47 @@ class AccessControlActivity : BaseActivity<AccessControlDesign>() {
                 }
             }
         }
+    }
+
+    private suspend fun maybePromptRussianBypass(
+        service: ServiceStore,
+        design: AccessControlDesign,
+        selected: MutableSet<String>,
+        setMode: (AccessControlMode) -> Unit,
+    ) {
+        val shouldPrompt = withContext(Dispatchers.IO) {
+            !service.russianBypassSeeded && service.accessControlPackages.isEmpty()
+        }
+        if (!shouldPrompt) return
+
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.ru_bypass_routing_prompt_title)
+            .setMessage(R.string.ru_bypass_routing_prompt_message)
+            .setPositiveButton(R.string.ru_bypass_routing_prompt_apply) { _, _ ->
+                launch {
+                    val count = withContext(Dispatchers.IO) {
+                        val before = selected.size
+                        selected.addAll(RussianBypassDefaults.installed(packageManager))
+                        service.accessControlMode = AccessControlMode.DenySelected
+                        service.accessControlPackages = selected
+                        service.russianBypassSeeded = true
+                        selected.size - before
+                    }
+                    val mode = AccessControlMode.DenySelected
+                    setMode(mode)
+                    design.setMode(mode)
+                    design.patchApps(loadApps(selected))
+                    if (count > 0) {
+                        Toast.makeText(
+                            this@AccessControlActivity,
+                            getString(R.string.ru_bypass_prompt_seeded, count),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+            .setNegativeButton(R.string.ru_bypass_routing_prompt_later, null)
+            .show()
     }
 
     private suspend fun loadApps(selected: Set<String>): List<AppInfo> =

--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -37,8 +37,10 @@ import com.github.kr328.clash.core.model.ProxyGroup
 import com.github.kr328.clash.core.model.TunnelState
 import com.github.kr328.clash.design.MainDesign
 import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.dialog.withModelProgressBar
 import com.github.kr328.clash.design.model.DarkMode
 import com.github.kr328.clash.design.ui.ToastDuration
+import com.github.kr328.clash.design.util.applyFetchStatus
 import com.github.kr328.clash.design.util.showExceptionToast
 import com.github.kr328.clash.remote.Remote
 import com.github.kr328.clash.remote.StatusClient
@@ -59,6 +61,7 @@ import io.github.g00fy2.quickie.QRResult.QRSuccess
 import io.github.g00fy2.quickie.QRResult.QRUserCanceled
 import io.github.g00fy2.quickie.ScanQRCode
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
@@ -659,12 +662,12 @@ class MainActivity : BaseActivity<MainDesign>() {
      */
     private suspend fun importSubscriptionFromUrl(design: MainDesign, url: String) {
         design.showToast(R.string.import_resolving, ToastDuration.Short)
-        val name = SubscriptionNameGuesser.guess(this, url)
+        val name = SubscriptionNameGuesser.guessFast(url)
         val uuid = withProfile {
             create(Profile.Type.Url, name, url)
         }
         try {
-            withProfile { commit(uuid) }
+            commitProfileWithProgress(uuid)
         } catch (e: Exception) {
             showImportCommitFailureDialog(uuid, e)
             return
@@ -677,6 +680,27 @@ class MainActivity : BaseActivity<MainDesign>() {
             launchProperties(uuid)
         }
         design.fetch()
+    }
+
+    private suspend fun commitProfileWithProgress(uuid: UUID) {
+        withModelProgressBar {
+            configure {
+                isIndeterminate = true
+                text = getString(R.string.initializing)
+            }
+
+            coroutineScope {
+                withProfile {
+                    commit(uuid) { status ->
+                        launch {
+                            configure {
+                                applyFetchStatus(this@MainActivity, status)
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private suspend fun launchProperties(uuid: UUID) {
@@ -1322,6 +1346,36 @@ class MainActivity : BaseActivity<MainDesign>() {
                 }
                 .show()
             cont.invokeOnCancellation { runCatching { dialog.dismiss() } }
+        }
+    }
+
+    override fun onProfileUpdateCompleted(uuid: UUID?) {
+        super.onProfileUpdateCompleted(uuid)
+        if (uuid == null) return
+
+        launch {
+            val name = withProfile { queryByUUID(uuid)?.name } ?: return@launch
+            design?.showToast(
+                getString(R.string.toast_profile_updated_complete, name),
+                ToastDuration.Long
+            )
+        }
+    }
+
+    override fun onProfileUpdateFailed(uuid: UUID?, reason: String?) {
+        super.onProfileUpdateFailed(uuid, reason)
+        if (uuid == null) return
+
+        launch {
+            val name = withProfile { queryByUUID(uuid)?.name } ?: return@launch
+            design?.showToast(
+                getString(R.string.toast_profile_updated_failed, name, reason ?: "Unknown"),
+                ToastDuration.Long
+            ) {
+                setAction(R.string.edit) {
+                    startActivity(PropertiesActivity::class.intent.setUUID(uuid))
+                }
+            }
         }
     }
 

--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
@@ -15,6 +15,15 @@ import kotlin.text.Charsets
  * Uses response headers (incl. subscription-userinfo) and structured fields in the body.
  */
 object SubscriptionNameGuesser {
+    fun guessFast(urlString: String): String {
+        val trimmed = urlString.trim()
+        if (isMierusLinkForSubscriptionTitle(trimmed)) {
+            parseFragmentName(trimmed)?.let { return sanitizeName(it) }
+            return "mieru"
+        }
+        parseFragmentName(trimmed)?.let { return sanitizeName(it) }
+        return fallbackName(stripUrlFragment(trimmed))
+    }
 
     suspend fun guess(context: Context, urlString: String): String =
         withContext(Dispatchers.IO) {

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -25,6 +25,12 @@ type Status struct {
 	MaxProgress int      `json:"max"`
 }
 
+type providerFetchTask struct {
+	name string
+	url  *U.URL
+	path string
+}
+
 func openUrl(ctx context.Context, url string) (io.ReadCloser, error) {
 	response, err := clashHttp.HttpRequest(ctx, url, http.MethodGet, http.Header{"User-Agent": {"ClashMetaForAndroid/" + app.VersionName()}}, nil)
 
@@ -127,16 +133,8 @@ func FetchAndValid(
 		return err
 	}
 
+	providerFetchTasks := make([]providerFetchTask, 0)
 	forEachProviders(rawCfg, func(index int, total int, name string, provider map[string]any, prefix string) {
-		bytes, _ := json.Marshal(&Status{
-			Action:      "FetchProviders",
-			Args:        []string{name},
-			Progress:    index,
-			MaxProgress: total,
-		})
-
-		reportStatus(string(bytes))
-
 		u, uok := provider["url"]
 		p, pok := provider["path"]
 
@@ -160,8 +158,25 @@ func FetchAndValid(
 			return
 		}
 
-		_ = fetch(url, ps)
+		providerFetchTasks = append(providerFetchTasks, providerFetchTask{
+			name: name,
+			url:  url,
+			path: ps,
+		})
 	})
+
+	for index, task := range providerFetchTasks {
+		bytes, _ := json.Marshal(&Status{
+			Action:      "FetchProviders",
+			Args:        []string{task.name},
+			Progress:    index,
+			MaxProgress: len(providerFetchTasks),
+		})
+
+		reportStatus(string(bytes))
+
+		_ = fetch(task.url, task.path)
+	}
 
 	bytes, _ := json.Marshal(&Status{
 		Action:      "Verifying",

--- a/design/src/main/java/com/github/kr328/clash/design/util/FetchStatusProgress.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/util/FetchStatusProgress.kt
@@ -1,0 +1,27 @@
+package com.github.kr328.clash.design.util
+
+import android.content.Context
+import com.github.kr328.clash.core.model.FetchStatus
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.dialog.ModelProgressBarConfigure
+
+fun ModelProgressBarConfigure.applyFetchStatus(context: Context, status: FetchStatus) {
+    when (status.action) {
+        FetchStatus.Action.FetchConfiguration -> {
+            text = context.getString(R.string.format_fetching_configuration, status.args[0])
+            isIndeterminate = true
+        }
+        FetchStatus.Action.FetchProviders -> {
+            text = context.getString(R.string.format_fetching_provider, status.args[0])
+            isIndeterminate = false
+            max = status.max
+            progress = status.progress
+        }
+        FetchStatus.Action.Verifying -> {
+            text = context.getString(R.string.verifying)
+            isIndeterminate = false
+            max = status.max
+            progress = status.progress
+        }
+    }
+}

--- a/design/src/main/res/layout/design_access_control.xml
+++ b/design/src/main/res/layout/design_access_control.xml
@@ -71,7 +71,12 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:contentDescription="@string/allow_all_apps_description"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:minWidth="0dp"
                         android:onClick="@{() -> self.requestModeAcceptAll()}"
+                        android:textAllCaps="false"
                         android:text="@string/allow_all_apps" />
 
                     <com.google.android.material.button.MaterialButton
@@ -80,7 +85,12 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:contentDescription="@string/allow_selected_apps_description"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:minWidth="0dp"
                         android:onClick="@{() -> self.requestModeAcceptSelected()}"
+                        android:textAllCaps="false"
                         android:text="@string/allow_selected_apps" />
 
                     <com.google.android.material.button.MaterialButton
@@ -89,7 +99,12 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:contentDescription="@string/deny_selected_apps_description"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:minWidth="0dp"
                         android:onClick="@{() -> self.requestModeDenySelected()}"
+                        android:textAllCaps="false"
                         android:text="@string/deny_selected_apps" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -585,8 +585,8 @@
     <string name="geofile_unknown_db_format">Неизвестный формат базы</string>
     <string name="geofile_unknown_db_format_message">Поддерживаются только: %1$s</string>
     <string name="geofile_imported">Импортировано: %1$s</string>
-    <string name="toast_profile_updated_complete">Update profile %s completed</string>
-    <string name="toast_profile_updated_failed">Update profile %1$s failed: %2$s</string>
+    <string name="toast_profile_updated_complete">Подписка «%s» обновлена</string>
+    <string name="toast_profile_updated_failed">Не удалось обновить «%1$s»: %2$s</string>
     <string name="external_control_activity">External Control</string>
     <string name="external_control_started">Clash.Meta service started</string>
     <string name="external_control_stopped">Clash.Meta service stopped</string>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -154,6 +154,10 @@
     <string name="ru_bypass_prompt_apply">Применить</string>
     <string name="ru_bypass_prompt_skip">Пропустить</string>
     <string name="ru_bypass_prompt_seeded">Добавлено %1$d российских приложений.</string>
+    <string name="ru_bypass_routing_prompt_title">Настроить обход РФ-приложений?</string>
+    <string name="ru_bypass_routing_prompt_message">ClashFest может включить режим обхода и выбрать установленные российские приложения, чтобы они шли напрямую через провайдера. После настройки список можно изменить вручную.</string>
+    <string name="ru_bypass_routing_prompt_apply">Настроить обход</string>
+    <string name="ru_bypass_routing_prompt_later">Не сейчас</string>
     <string name="expires_on">до %1$s</string>
     <string name="sub_meta_lock_user">Игнорировать оператора</string>
     <string name="sub_meta_lock_user_summary">Не давать серверу подписки перезаписывать локальные URL поддержки и объявления.</string>
@@ -447,9 +451,12 @@
     <string name="always_dark">Всегда тёмная</string>
     <string name="always_light">Всегда светлая</string>
 
-    <string name="allow_all_apps">Все приложения</string>
-    <string name="allow_selected_apps">Только выбранные</string>
-    <string name="deny_selected_apps">Кроме выбранных</string>
+    <string name="allow_all_apps">Все</string>
+    <string name="allow_all_apps_description">Все приложения идут через VPN</string>
+    <string name="allow_selected_apps">В VPN</string>
+    <string name="allow_selected_apps_description">Только выбранные приложения идут через VPN</string>
+    <string name="deny_selected_apps">В обход</string>
+    <string name="deny_selected_apps_description">Выбранные приложения обходят VPN</string>
     <string name="app_routing_counter">Выбрано: %1$d / %2$d</string>
     <string name="app_routing_selected">Выбрано</string>
     <string name="app_routing_not_selected">Не выбрано</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -730,8 +730,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="geofile_unknown_db_format">Unknown Database format</string>
     <string name="geofile_unknown_db_format_message">Only %1$s are supported</string>
     <string name="geofile_imported">%1$s imported</string>
-    <string name="toast_profile_updated_complete">Update profile %s completed</string>
-    <string name="toast_profile_updated_failed">Update profile %1$s failed: %2$s</string>
+    <string name="toast_profile_updated_complete">Subscription "%s" updated</string>
+    <string name="toast_profile_updated_failed">Could not update "%1$s": %2$s</string>
     <string name="external_control_activity">External Control</string>
     <string name="external_control_started">Clash.Meta service started</string>
     <string name="external_control_stopped">Clash.Meta service stopped</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -141,6 +141,10 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="ru_bypass_prompt_apply">Apply</string>
     <string name="ru_bypass_prompt_skip">Skip</string>
     <string name="ru_bypass_prompt_seeded">%1$d Russian apps added to bypass list.</string>
+    <string name="ru_bypass_routing_prompt_title">Set up Russian app bypass?</string>
+    <string name="ru_bypass_routing_prompt_message">ClashFest can switch this screen to bypass mode and select installed Russian apps so they go directly through your ISP. You can edit the list after setup.</string>
+    <string name="ru_bypass_routing_prompt_apply">Set up bypass</string>
+    <string name="ru_bypass_routing_prompt_later">Not now</string>
     <string name="sub_meta_lock_user">Ignore operator overrides</string>
     <string name="sub_meta_lock_user_summary">Don’t let the subscription server overwrite locally edited support URL or announcement.</string>
     <string name="per_app_mode_all">All apps</string>
@@ -578,9 +582,12 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="tun_stack_gvisor">Gvisor Stack</string>
     <string name="tun_stack_mixed">Mixed Stack</string>
 
-    <string name="allow_all_apps">All apps</string>
-    <string name="allow_selected_apps">Only selected</string>
-    <string name="deny_selected_apps">Except selected</string>
+    <string name="allow_all_apps">All</string>
+    <string name="allow_all_apps_description">All apps use the VPN</string>
+    <string name="allow_selected_apps">VPN</string>
+    <string name="allow_selected_apps_description">Only selected apps use the VPN</string>
+    <string name="deny_selected_apps">Bypass</string>
+    <string name="deny_selected_apps_description">Selected apps bypass the VPN</string>
     <string name="app_routing_counter">%1$d / %2$d selected</string>
     <string name="app_routing_selected">Selected</string>
     <string name="app_routing_not_selected">Not selected</string>


### PR DESCRIPTION
## Summary

- Show subscription import progress and avoid redundant profile fetch work while importing/updating subscriptions.
- Add explicit setup flow for Russian app bypass from the per-app routing screen.
- Preserve manual per-app routing choices so automatic bypass setup does not re-add apps after the user customizes the list.
- Shorten app routing mode labels and keep full meanings available through accessibility descriptions.

## Validation

- git diff --check
- ./gradlew.bat assembleAlphaDebug

## Notes

The branch was rebased on the latest origin/feat/init-clashfest; the existing upstream RU bypass consent changes were preserved, and this PR adds the per-app routing screen prompt/UI polish on top.