### PR TITLE
fix(proxy): корректный selector/fallback и обновление proxy-groups

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -563,10 +563,12 @@ class MainActivity : BaseActivity<MainDesign>() {
                             return@launch
                         }
                         design.markProxySelectionPending(profile, group, name)
-                        withClash {
+                        val patched = withClash {
                             patchSelector(group, name)
                         }
-                        uiStore.proxyLastGroup = group
+                        if (patched) {
+                            uiStore.proxyLastGroup = group
+                        }
                         scheduleProxyDetailsRefresh(profile, group)
                     }
                 }

--- a/core/src/main/golang/native/tunnel/proxies.go
+++ b/core/src/main/golang/native/tunnel/proxies.go
@@ -155,6 +155,8 @@ func PatchSelector(selector, name string) bool {
 
 	if err := s.Set(name); err != nil {
 		log.Warnln("Patch selector `%s`: %s", selector, err.Error())
+
+		return false
 	}
 
 	log.Infoln("Patch selector %s -> %s", selector, name)

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -913,18 +913,40 @@ class ProfileAdapter(
         return null
     }
 
-    private fun resolvedSelectedProxyName(profile: Profile, groupName: String): String? {
-        val first = proxyGroupForRow(profile, groupName)
+    private fun resolvedSelectedProxyName(profile: Profile, groupName: String): String? =
+        resolvedSelectedProxyName(profile, groupName, linkedSetOf())
+
+    private fun resolvedSelectedProxyName(
+        profile: Profile,
+        groupName: String,
+        seen: MutableSet<String>,
+    ): String? {
+        if (!seen.add(groupName)) return null
+
+        val selected = proxyGroupForRow(profile, groupName)
             ?.now
             ?.takeIf { it.isNotBlank() }
             ?: return null
-        if (shouldHideProxyName(groupName, first)) return null
-        val nested = if (useEngineFor(profile)) {
-            proxyDetails[first]
-        } else {
-            null
+        if (shouldHideProxyName(groupName, selected)) return null
+
+        if (selectedLooksLikeGroup(profile, groupName, selected)) {
+            resolvedSelectedProxyName(profile, selected, seen)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { return it }
         }
-        return nested?.now?.takeIf { it.isNotBlank() } ?: first
+
+        return selected
+    }
+
+    private fun selectedLooksLikeGroup(profile: Profile, groupName: String, selected: String): Boolean {
+        val selectedProxy = proxyGroupForRow(profile, groupName)
+            ?.proxies
+            ?.firstOrNull { it.name == selected }
+        return if (useEngineFor(profile)) {
+            selectedProxy?.type?.group == true || selected in proxyDetails
+        } else {
+            selected in offlinePreviewByProfile[profile.uuid].orEmpty()
+        }
     }
 
     private fun formatNodeHeadline(raw: String, context: Context): Pair<String, String?> {

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -59,36 +59,67 @@ class ClashManager(private val context: Context) : IClashManager,
         return Clash.queryOverride(slot)
     }
 
-    /**
-     * In **Global** mode all traffic uses the [GLOBAL] adapter only. Changing a leaf inside
-     * another group (e.g. MainGroup → Sweden) has no effect until [GLOBAL]’s active child is that
-     * group — otherwise the engine keeps routing through whatever [GLOBAL] had selected (often the
-     * first subscription). When the user picks a node in a non-GLOBAL group that is listed under
-     * GLOBAL, we first patch GLOBAL to that group, then patch the leaf.
-     */
     override fun patchSelector(group: String, name: String): Boolean {
-        var syncedGlobal = false
-        if (group != "GLOBAL") {
-            val state = Clash.queryTunnelState()
-            if (state.mode == TunnelState.Mode.Global) {
-                val global = Clash.queryGroup("GLOBAL", ProxySort.Default)
-                val children = global.proxies.map { it.name }.toSet()
-                if (group in children) {
-                    syncedGlobal = Clash.patchSelector("GLOBAL", group)
-                }
-            }
-        }
         val ok = Clash.patchSelector(group, name)
-        val current = store.activeProfile ?: return ok
-        if (ok) {
-            SelectionDao().setSelected(Selection(current, group, name))
-            if (syncedGlobal) {
-                SelectionDao().setSelected(Selection(current, "GLOBAL", group))
-            }
-        } else {
-            SelectionDao().removeSelected(current, group)
+        val current = store.activeProfile
+        if (!ok) {
+            current?.let { SelectionDao().removeSelected(it, group) }
+
+            return false
         }
+
+        current?.let { SelectionDao().setSelected(Selection(it, group, name)) }
+        syncSelectorAncestors(current, group)
+
         return ok
+    }
+
+    private fun syncSelectorAncestors(current: java.util.UUID?, selectedGroup: String) {
+        if (selectedGroup.isBlank() || selectedGroup == "GLOBAL") return
+
+        val groupNames = runCatching { Clash.queryGroupNames(false) }
+            .getOrDefault(emptyList())
+        val queriedGroups = linkedMapOf<String, ProxyGroup>()
+
+        fun queryGroup(name: String): ProxyGroup? {
+            queriedGroups[name]?.let { return it }
+            return runCatching { Clash.queryGroup(name, ProxySort.Default) }
+                .getOrNull()
+                ?.also { queriedGroups[name] = it }
+        }
+
+        val visited = linkedSetOf<String>()
+        var child = selectedGroup
+
+        while (visited.add(child)) {
+            val parent = groupNames.firstNotNullOfOrNull { candidate ->
+                val parentGroup = queryGroup(candidate)
+                if (candidate == "GLOBAL" || candidate == child || parentGroup == null) {
+                    null
+                } else if (parentGroup.proxies.none { it.name == child }) {
+                    null
+                } else {
+                    candidate to parentGroup
+                }
+            } ?: break
+
+            val (parentName, parentGroup) = parent
+            if (parentGroup.type == Proxy.Type.Selector) {
+                if (parentGroup.now != child && !Clash.patchSelector(parentName, child)) break
+                current?.let { SelectionDao().setSelected(Selection(it, parentName, child)) }
+            }
+            child = parentName
+        }
+
+        val state = runCatching { Clash.queryTunnelState() }.getOrNull()
+        if (state?.mode != TunnelState.Mode.Global) return
+
+        val global = runCatching { Clash.queryGroup("GLOBAL", ProxySort.Default) }.getOrNull()
+            ?: return
+        if (global.proxies.none { it.name == child } || global.now == child) return
+        if (Clash.patchSelector("GLOBAL", child)) {
+            current?.let { SelectionDao().setSelected(Selection(it, "GLOBAL", child)) }
+        }
     }
 
     override fun patchOverride(slot: Clash.OverrideSlot, configuration: ConfigurationOverride) {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -249,7 +249,11 @@ object ProfileProcessor {
                 }
 
                 if (!preserved.isEmpty() && configFile.isFile) {
-                    val merged = SubscriptionUpdateMerge.mergeAfterFetch(configFile.readText(), preserved)
+                    val merged = SubscriptionUpdateMerge.mergeAfterFetch(
+                        configFile.readText(),
+                        preserved,
+                        context.processingDir,
+                    )
                     configFile.writeText(merged)
                     Log.d("Subscription merge preserved local overlays: rules/rule-providers/proxy-providers reapplied for ${snapshot.uuid}")
                 }

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
@@ -154,7 +154,8 @@ object ProxyDialerYamlEdit {
         return false
     }
 
-    private fun resolveProviderPath(profileDir: File, path: String): File {
+    /** [proxy-providers] entry `path` relative to [profileDir]. */
+    internal fun resolveProviderPath(profileDir: File, path: String): File {
         val n = path.trim().removePrefix("./")
         return File(profileDir, n)
     }

--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -53,8 +53,7 @@ object SubscriptionUpdateMerge {
                 mergeProxyProviderMaps(root["proxy-providers"], preserved.proxyProviders)
         }
         if (preserved.proxyGroups != null) {
-            root["proxy-groups"] =
-                mergeProxyGroupsLists(root["proxy-groups"], preserved.proxyGroups)
+            root["proxy-groups"] = mergeProxyGroupsLists(root, preserved)
         }
         return YamlFormatting.blockYaml().dump(root)
     }
@@ -77,49 +76,96 @@ object SubscriptionUpdateMerge {
     }
 
     /**
-     * Start from [fetched] proxy-groups list; append groups from [preserved] whose **name**
-     * is not already present in the fetched list (keeps local relay / custom groups).
+     * Start from the fetched `proxy-groups` list; append preserved local/custom groups only when
+     * every referenced proxy, provider, or child group still resolves after the subscription refresh.
+     * This prevents deleted subscription groups from being resurrected with stale members, e.g.
+     * `proxy group[n]: ...: 'old country group' not found`.
      *
      * **GLOBAL:** the remote profile almost always defines its own `GLOBAL` entry. We must merge
      * `proxies` with the preserved copy: locally added merged groups (e.g. `MainGroup` appended by
      * [com.github.kr328.clash.service.util.ProxyGroupsYamlEdit]) only exist in the old `GLOBAL`
      * list; without this union, Global mode cannot select them and traffic never uses that group.
      */
-    private fun mergeProxyGroupsLists(fetched: Any?, preserved: Any?): Any? {
-        if (preserved == null) return fetched
+    private fun mergeProxyGroupsLists(
+        root: MutableMap<String, Any?>,
+        preserved: PreservedOverlay,
+    ): Any? {
+        val fetched = root["proxy-groups"]
         val out = mutableListOf<Any?>()
         when (fetched) {
             is List<*> -> out.addAll(fetched)
             null -> Unit
             else -> out.add(fetched)
         }
-        val preservedList: List<*> = when (preserved) {
-            is List<*> -> preserved
+        val preservedList: List<*> = when (preserved.proxyGroups) {
+            is List<*> -> preserved.proxyGroups
             else -> emptyList<Any?>()
         }
+        val knownNames = collectKnownProxyNames(root, preserved.proxyProviders)
+        val pendingGroups = preservedList
+            .mapNotNull { it as? Map<*, *> }
+            .filter { (it["name"]?.toString()).isNullOrEmpty().not() }
+            .filterNot { it["name"]?.toString() in knownNames }
+            .toMutableList()
+
+        var changed = true
+        while (changed) {
+            changed = false
+            val iter = pendingGroups.iterator()
+            while (iter.hasNext()) {
+                val group = iter.next()
+                val name = group["name"]?.toString() ?: continue
+                if (isProxyGroupResolvable(group, knownNames)) {
+                    out.add(group)
+                    knownNames.add(name)
+                    iter.remove()
+                    changed = true
+                }
+            }
+        }
+
         val preservedGlobalProxies = preservedList
             .mapNotNull { it as? Map<*, *> }
             .firstOrNull { it["name"]?.toString() == "GLOBAL" }
             ?.get("proxies") as? List<*>
         if (preservedGlobalProxies != null) {
-            mergeExtraProxiesIntoGlobalGroup(out, preservedGlobalProxies)
-        }
-        val fetchedNames = out.mapNotNull { (it as? Map<*, *>)?.get("name")?.toString() }.toSet()
-        for (item in preservedList) {
-            val g = item as? Map<*, *> ?: continue
-            val name = g["name"]?.toString() ?: continue
-            if (name !in fetchedNames) {
-                out.add(item)
-            }
+            mergeExtraProxiesIntoGlobalGroup(out, preservedGlobalProxies, knownNames)
         }
         return out
+    }
+
+    private fun collectKnownProxyNames(
+        root: Map<String, Any?>,
+        preservedProxyProviders: Any?,
+    ): MutableSet<String> {
+        val names = linkedSetOf("DIRECT", "REJECT", "REJECT-DROP", "PASS", "COMPATIBLE", "GLOBAL")
+        (root["proxies"] as? List<*>)?.mapNotNullTo(names) {
+            (it as? Map<*, *>)?.get("name")?.toString()
+        }
+        (root["proxy-groups"] as? List<*>)?.mapNotNullTo(names) {
+            (it as? Map<*, *>)?.get("name")?.toString()
+        }
+        (root["proxy-providers"] as? Map<*, *>)?.keys?.mapNotNullTo(names) { it?.toString() }
+        (preservedProxyProviders as? Map<*, *>)?.keys?.mapNotNullTo(names) { it?.toString() }
+        return names
+    }
+
+    private fun isProxyGroupResolvable(group: Map<*, *>, knownNames: Set<String>): Boolean {
+        val proxies = (group["proxies"] as? List<*>).orEmpty().mapNotNull { it?.toString() }
+        val providers = (group["use"] as? List<*>).orEmpty().mapNotNull { it?.toString() }
+        if (proxies.isEmpty() && providers.isEmpty()) return true
+        return proxies.all { it in knownNames } && providers.all { it in knownNames }
     }
 
     /**
      * Appends proxy names from the pre-fetch GLOBAL group that are missing from the current GLOBAL
      * entry (subscription order preserved; extras keep preserved order after the last fetched name).
      */
-    private fun mergeExtraProxiesIntoGlobalGroup(out: MutableList<Any?>, preservedProxies: List<*>) {
+    private fun mergeExtraProxiesIntoGlobalGroup(
+        out: MutableList<Any?>,
+        preservedProxies: List<*>,
+        knownNames: Set<String>,
+    ) {
         val globalIdx = out.indexOfFirst { (it as? Map<*, *>)?.get("name")?.toString() == "GLOBAL" }
         if (globalIdx < 0) return
         val global = out[globalIdx] as? Map<*, *> ?: return
@@ -130,7 +176,7 @@ object SubscriptionUpdateMerge {
         val existing = current.toSet()
         for (p in preservedProxies) {
             val name = p?.toString() ?: continue
-            if (name !in existing) {
+            if (name !in existing && name in knownNames) {
                 current.add(name)
             }
         }

--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -1,5 +1,7 @@
 package com.github.kr328.clash.service.util
 
+import java.io.File
+
 /**
  * After a subscription fetch, native code replaces [config.yaml] with the remote file.
  * Local additions under [rule-providers], [rules], [proxy-providers], and extra [proxy-groups]
@@ -39,7 +41,11 @@ object SubscriptionUpdateMerge {
         return PreservedOverlay(rp, rules, pp, pg)
     }
 
-    fun mergeAfterFetch(fetchedYaml: String, preserved: PreservedOverlay): String {
+    /**
+     * @param profileDir directory with [config.yaml] and provider paths after fetch; used to collect
+     * proxy `name` entries from provider YAML on disk (not only inline `proxies:`).
+     */
+    fun mergeAfterFetch(fetchedYaml: String, preserved: PreservedOverlay, profileDir: File? = null): String {
         if (preserved.isEmpty()) return fetchedYaml
         val root = YamlFormatting.parseRootMap(fetchedYaml) ?: return fetchedYaml
         if (preserved.ruleProviders != null) {
@@ -53,7 +59,7 @@ object SubscriptionUpdateMerge {
                 mergeProxyProviderMaps(root["proxy-providers"], preserved.proxyProviders)
         }
         if (preserved.proxyGroups != null) {
-            root["proxy-groups"] = mergeProxyGroupsLists(root, preserved)
+            root["proxy-groups"] = mergeProxyGroupsLists(root, preserved, profileDir)
         }
         return YamlFormatting.blockYaml().dump(root)
     }
@@ -89,6 +95,7 @@ object SubscriptionUpdateMerge {
     private fun mergeProxyGroupsLists(
         root: MutableMap<String, Any?>,
         preserved: PreservedOverlay,
+        profileDir: File?,
     ): Any? {
         val fetched = root["proxy-groups"]
         val out = mutableListOf<Any?>()
@@ -101,7 +108,7 @@ object SubscriptionUpdateMerge {
             is List<*> -> preserved.proxyGroups
             else -> emptyList<Any?>()
         }
-        val knownNames = collectKnownProxyNames(root, preserved.proxyProviders)
+        val knownNames = collectKnownProxyNames(root, preserved.proxyProviders, profileDir)
         val pendingGroups = preservedList
             .mapNotNull { it as? Map<*, *> }
             .filter { (it["name"]?.toString()).isNullOrEmpty().not() }
@@ -137,6 +144,7 @@ object SubscriptionUpdateMerge {
     private fun collectKnownProxyNames(
         root: Map<String, Any?>,
         preservedProxyProviders: Any?,
+        profileDir: File?,
     ): MutableSet<String> {
         val names = linkedSetOf("DIRECT", "REJECT", "REJECT-DROP", "PASS", "COMPATIBLE", "GLOBAL")
         (root["proxies"] as? List<*>)?.mapNotNullTo(names) {
@@ -147,6 +155,18 @@ object SubscriptionUpdateMerge {
         }
         (root["proxy-providers"] as? Map<*, *>)?.keys?.mapNotNullTo(names) { it?.toString() }
         (preservedProxyProviders as? Map<*, *>)?.keys?.mapNotNullTo(names) { it?.toString() }
+        val dir = profileDir ?: return names
+        val pp = root["proxy-providers"] as? Map<*, *> ?: return names
+        for ((_, v) in pp) {
+            val prov = v as? Map<*, *> ?: continue
+            val pathStr = prov["path"] as? String ?: continue
+            val f = ProxyDialerYamlEdit.resolveProviderPath(dir, pathStr)
+            if (!f.isFile) continue
+            val pRoot = runCatching { YamlFormatting.parseRootMap(f.readText()) }.getOrNull() ?: continue
+            (pRoot["proxies"] as? List<*>)?.mapNotNullTo(names) {
+                (it as? Map<*, *>)?.get("name")?.toString()
+            }
+        }
         return names
     }
 


### PR DESCRIPTION
## Что изменено

### 1. Обновление подписки без протухших proxy-groups
- При обновлении YAML подписки сохранённые локальные `proxy-groups` теперь возвращаются только если все ссылки внутри них реально существуют в свежем профиле.
- Если сервер/группа удалены из подписки, старый блок больше не подмешивается обратно и не ломает запуск mihomo ошибками вида `not found`.

### 2. Реальный realtime-выбор серверов в selector/fallback/url-test
- Нативный `PatchSelector` теперь возвращает `false`, если mihomo отказал в выборе (`proxy not exist` и подобные ошибки), вместо ложного успешного результата.
- UI больше не сохраняет неуспешный выбор как активный.
- При выборе вложенной группы/узла сервис синхронизирует родительские `selector`-группы и `GLOBAL`, чтобы выбранная ветка реально участвовала в маршрутизации.
- `fallback` и `url-test` не форсируются вручную как selector: их авто-логика сохраняется. Например, `⚡ Авто` по-прежнему должен уходить в `🛡 Режим белых списков (БПЛА)` только когда обычная ветка недоступна по health-check.
- Карточка профиля теперь рекурсивно раскрывает цепочку `select -> fallback/url-test -> proxy` и показывает конечный реально выбранный сервер, а не только промежуточную группу.

## Проверка
- `./gradlew.bat --no-daemon :service:compileAlphaDebugKotlin`
- `./gradlew.bat --no-daemon :app:compileAlphaDebugKotlin :design:compileAlphaDebugKotlin :service:compileAlphaDebugKotlin`
- `./gradlew.bat --no-daemon assembleAlphaDebug`

Все команды прошли успешно.
