### PR TITLE
Refresh rule providers after subscription update

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/RuleSnippetActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/RuleSnippetActivity.kt
@@ -47,7 +47,10 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                         RuleSnippetDesign.Request.OpenCreateSheet -> launch { showCreateSheet(design) }
                         RuleSnippetDesign.Request.OpenManualRules ->
                             startActivity(EffectiveRulesActivity::class.intent)
-                        RuleSnippetDesign.Request.UpdateAllRuleSets -> launch { updateAllRuleSets(design) }
+                        RuleSnippetDesign.Request.RefreshProviders -> launch { refreshExistingProviders(design) }
+                        RuleSnippetDesign.Request.UpdateAllRuleSets -> launch { updateRuleProviders(design, null) }
+                        is RuleSnippetDesign.Request.UpdateProvider -> launch { updateRuleProviders(design, it.name) }
+                        is RuleSnippetDesign.Request.EditProvider -> launch { showCreateSheet(design, it.provider) }
                     }
                 }
             }
@@ -62,14 +65,16 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         design.patchExistingProviders(state.providers)
     }
 
-    private suspend fun updateAllRuleSets(design: RuleSnippetDesign) {
+    private suspend fun updateRuleProviders(design: RuleSnippetDesign, name: String?) {
         if (!clashRunning) {
             design.showToast(DesignR.string.rule_rule_sets_need_vpn, ToastDuration.Long)
             return
         }
         try {
             withClash {
-                val ruleProviders = queryProviders().filter { it.type == Provider.Type.Rule }
+                val ruleProviders = queryProviders()
+                    .filter { it.type == Provider.Type.Rule }
+                    .filter { name == null || it.name == name }
                 if (ruleProviders.isEmpty()) {
                     design.showToast(DesignR.string.rule_rule_sets_none_loaded, ToastDuration.Short)
                     return@withClash
@@ -84,7 +89,10 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         }
     }
 
-    private suspend fun showCreateSheet(design: RuleSnippetDesign) {
+    private suspend fun showCreateSheet(
+        design: RuleSnippetDesign,
+        editingProvider: RuleProviderItem? = null,
+    ) {
         val uuid = withProfile { queryActive()?.uuid }
         if (uuid == null) {
             design.showToast(DesignR.string.no_profile_selected, ToastDuration.Long)
@@ -176,7 +184,11 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         view.findViewById<AutoCompleteTextView>(R.id.spinner_manual_custom_kind).setAdapter(
             ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, customKindOptions))
 
-        title.text = getString(DesignR.string.rule_add_new)
+        title.text = if (editingProvider == null) {
+            getString(DesignR.string.rule_add_new)
+        } else {
+            getString(DesignR.string.edit)
+        }
 
         fun insertModeFromSpinner(s: AutoCompleteTextView): String {
             val pos = (s.adapter as ArrayAdapter<String>).getPosition(s.text.toString())
@@ -285,6 +297,28 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
             buildPreview()
         }
 
+        if (editingProvider != null) {
+            typeSpinner.setText(typeOptions[1], false)
+            typeSpinner.isEnabled = false
+            providerGroup.visibility = View.VISIBLE
+            presetGroup.visibility = View.GONE
+            manualGroup.visibility = View.GONE
+            view.findViewById<TextInputEditText>(R.id.input_provider_name).setText(editingProvider.name)
+            view.findViewById<TextInputEditText>(R.id.input_provider_url).setText(editingProvider.url)
+            val behaviorView = view.findViewById<AutoCompleteTextView>(R.id.spinner_provider_behavior)
+            behaviorView.setText(editingProvider.behavior.ifBlank { "classical" }, false)
+            val policy = state.rules
+                .firstOrNull {
+                    it.type.equals("RULE-SET", true) &&
+                        (it.providerName.equals(editingProvider.name, true) || it.value.equals(editingProvider.name, true))
+                }
+                ?.policy
+                ?: validPolicy
+            val policyView = view.findViewById<AutoCompleteTextView>(R.id.spinner_provider_policy)
+            policyView.setText(policy, false)
+            view.findViewById<SwitchMaterial>(R.id.switch_provider_enabled).isChecked = editingProvider.enabled
+        }
+
         applyButton.setOnClickListener {
             launch {
                 val typePos = (typeSpinner.adapter as ArrayAdapter<String>).getPosition(typeSpinner.text.toString())
@@ -304,7 +338,7 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                         }
                     }
                     1 -> {
-                        applyProviderFromSheet(uuid, state, null, view)
+                        applyProviderFromSheet(uuid, state, editingProvider, view)
                     }
                     else -> {
                         val line = manualLineFromSheet(view) ?: ""
@@ -327,7 +361,11 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                 }
             }
         }
-        syncGroups()
+        if (editingProvider == null) {
+            syncGroups()
+        } else {
+            buildPreview()
+        }
         dialog.show()
     }
 

--- a/app/src/main/java/com/github/kr328/clash/RuleSnippetActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/RuleSnippetActivity.kt
@@ -16,6 +16,7 @@ import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.service.model.RuleItem
 import com.github.kr328.clash.service.model.RuleProviderItem
 import com.github.kr328.clash.service.model.RuleState
+import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.util.clashDir
 import com.github.kr328.clash.service.util.ProxyGroupsYamlPreview
 import com.github.kr328.clash.util.withClash
@@ -23,9 +24,11 @@ import com.github.kr328.clash.util.withProfile
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.util.UUID
@@ -47,10 +50,8 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                         RuleSnippetDesign.Request.OpenCreateSheet -> launch { showCreateSheet(design) }
                         RuleSnippetDesign.Request.OpenManualRules ->
                             startActivity(EffectiveRulesActivity::class.intent)
-                        RuleSnippetDesign.Request.RefreshProviders -> launch { refreshExistingProviders(design) }
                         RuleSnippetDesign.Request.UpdateAllRuleSets -> launch { updateRuleProviders(design, null) }
                         is RuleSnippetDesign.Request.UpdateProvider -> launch { updateRuleProviders(design, it.name) }
-                        is RuleSnippetDesign.Request.EditProvider -> launch { showCreateSheet(design, it.provider) }
                     }
                 }
             }
@@ -62,7 +63,40 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         val state = withProfile { readRuleState(uuid) }
             ?.let { runCatching { json.decodeFromString(RuleState.serializer(), it) }.getOrNull() }
             ?: return
-        design.patchExistingProviders(state.providers)
+        val counts = withContext(Dispatchers.IO) {
+            state.providers.mapNotNull { provider ->
+                countProviderEntries(uuid, provider)?.let { provider.name to it }
+            }.toMap()
+        }
+        design.patchExistingProviders(state.providers, counts)
+    }
+
+    /**
+     * Counts `- entry` lines under the `payload:` block of a downloaded provider file.
+     * Returns null when the file does not exist yet (provider was never fetched) or is not
+     * in a readable YAML rule-set format.
+     */
+    private fun countProviderEntries(profileUuid: UUID, provider: RuleProviderItem): Int? {
+        val rel = provider.path.removePrefix("./").ifBlank { "ruleset/${provider.name}.yaml" }
+        val file = File(this.importedDir, "$profileUuid/$rel")
+        if (!file.isFile || file.length() == 0L) return null
+        return runCatching {
+            var inPayload = false
+            var count = 0
+            file.bufferedReader().useLines { lines ->
+                for (raw in lines) {
+                    val leading = raw.takeWhile { it == ' ' || it == '\t' }.length
+                    val trimmed = raw.substring(leading)
+                    if (!inPayload) {
+                        if (trimmed.startsWith("payload:")) inPayload = true
+                    } else {
+                        if (trimmed.startsWith("- ")) count++
+                        else if (trimmed.isNotEmpty() && leading == 0) break
+                    }
+                }
+            }
+            count.takeIf { it > 0 }
+        }.getOrNull()
     }
 
     private suspend fun updateRuleProviders(design: RuleSnippetDesign, name: String?) {
@@ -89,10 +123,7 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         }
     }
 
-    private suspend fun showCreateSheet(
-        design: RuleSnippetDesign,
-        editingProvider: RuleProviderItem? = null,
-    ) {
+    private suspend fun showCreateSheet(design: RuleSnippetDesign) {
         val uuid = withProfile { queryActive()?.uuid }
         if (uuid == null) {
             design.showToast(DesignR.string.no_profile_selected, ToastDuration.Long)
@@ -184,11 +215,7 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
         view.findViewById<AutoCompleteTextView>(R.id.spinner_manual_custom_kind).setAdapter(
             ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, customKindOptions))
 
-        title.text = if (editingProvider == null) {
-            getString(DesignR.string.rule_add_new)
-        } else {
-            getString(DesignR.string.edit)
-        }
+        title.text = getString(DesignR.string.rule_add_new)
 
         fun insertModeFromSpinner(s: AutoCompleteTextView): String {
             val pos = (s.adapter as ArrayAdapter<String>).getPosition(s.text.toString())
@@ -297,28 +324,6 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
             buildPreview()
         }
 
-        if (editingProvider != null) {
-            typeSpinner.setText(typeOptions[1], false)
-            typeSpinner.isEnabled = false
-            providerGroup.visibility = View.VISIBLE
-            presetGroup.visibility = View.GONE
-            manualGroup.visibility = View.GONE
-            view.findViewById<TextInputEditText>(R.id.input_provider_name).setText(editingProvider.name)
-            view.findViewById<TextInputEditText>(R.id.input_provider_url).setText(editingProvider.url)
-            val behaviorView = view.findViewById<AutoCompleteTextView>(R.id.spinner_provider_behavior)
-            behaviorView.setText(editingProvider.behavior.ifBlank { "classical" }, false)
-            val policy = state.rules
-                .firstOrNull {
-                    it.type.equals("RULE-SET", true) &&
-                        (it.providerName.equals(editingProvider.name, true) || it.value.equals(editingProvider.name, true))
-                }
-                ?.policy
-                ?: validPolicy
-            val policyView = view.findViewById<AutoCompleteTextView>(R.id.spinner_provider_policy)
-            policyView.setText(policy, false)
-            view.findViewById<SwitchMaterial>(R.id.switch_provider_enabled).isChecked = editingProvider.enabled
-        }
-
         applyButton.setOnClickListener {
             launch {
                 val typePos = (typeSpinner.adapter as ArrayAdapter<String>).getPosition(typeSpinner.text.toString())
@@ -338,7 +343,7 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                         }
                     }
                     1 -> {
-                        applyProviderFromSheet(uuid, state, editingProvider, view)
+                        applyProviderFromSheet(uuid, state, null, view)
                     }
                     else -> {
                         val line = manualLineFromSheet(view) ?: ""
@@ -361,11 +366,7 @@ class RuleSnippetActivity : BaseActivity<RuleSnippetDesign>() {
                 }
             }
         }
-        if (editingProvider == null) {
-            syncGroups()
-        } else {
-            buildPreview()
-        }
+        syncGroups()
         dialog.show()
     }
 

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -247,6 +247,27 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeFetchAndValid(JNIEnv *env, 
     fetchAndValid(_completable, _path, _url, force, _headers);
 }
 
+JNIEXPORT void JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeFetchProvidersAndValid(JNIEnv *env, jobject thiz,
+                                                                            jobject callback,
+                                                                            jstring path,
+                                                                            jboolean force,
+                                                                            jstring headersJson) {
+    TRACE_METHOD();
+
+    jobject _completable = new_global(callback);
+    scoped_string _path = get_string(path);
+    char *_headers_raw;
+    if (headersJson == NULL) {
+        _headers_raw = strdup("");
+    } else {
+        _headers_raw = get_string(headersJson);
+    }
+    scoped_string _headers = _headers_raw;
+
+    fetchProvidersAndValid(_completable, _path, force, _headers);
+}
+
 JNIEXPORT jstring JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeQueryProviders(JNIEnv *env, jobject thiz) {
     TRACE_METHOD();

--- a/core/src/main/golang/native/config.go
+++ b/core/src/main/golang/native/config.go
@@ -43,6 +43,27 @@ func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, h
 	}(C.GoString(path), C.GoString(url), C.GoString(headersJson), callback)
 }
 
+//export fetchProvidersAndValid
+func fetchProvidersAndValid(callback unsafe.Pointer, path C.c_string, force C.int, headersJson C.c_string) {
+	go func(path, headers string, callback unsafe.Pointer) {
+		subscriptionFetchSessionMu.Lock()
+		defer subscriptionFetchSessionMu.Unlock()
+
+		app.SetSubscriptionFetchHeadersJSON(headers)
+		defer app.ClearSubscriptionFetchHeaders()
+
+		cb := &remoteValidCallback{callback: callback}
+
+		err := config.FetchProvidersAndValid(path, force != 0, cb.reportStatus)
+
+		C.fetch_complete(callback, marshalString(err))
+
+		C.release_object(callback)
+
+		runtime.GC()
+	}(C.GoString(path), C.GoString(headersJson), callback)
+}
+
 //export load
 func load(completable unsafe.Pointer, path C.c_string) {
 	go func(path string) {

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -136,7 +136,10 @@ func FetchAndValid(
 		return err
 	}
 
-	if err := fetchProviders(rawCfg, force, reportStatus); err != nil {
+	// Provider files re-fetch is driven separately via FetchProvidersAndValid;
+	// here we only pick up providers that have no cached file on disk yet,
+	// regardless of the config-level force flag.
+	if err := fetchProviders(rawCfg, false, reportStatus); err != nil {
 		return err
 	}
 

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -16,6 +16,7 @@ import (
 	"cfa/native/app"
 
 	clashHttp "github.com/metacubex/mihomo/component/http"
+	"github.com/metacubex/mihomo/config"
 )
 
 type Status struct {
@@ -135,6 +136,65 @@ func FetchAndValid(
 		return err
 	}
 
+	if err := fetchProviders(rawCfg, force, reportStatus); err != nil {
+		return err
+	}
+
+	bytes, _ := json.Marshal(&Status{
+		Action:      "Verifying",
+		Args:        []string{},
+		Progress:    0xffff,
+		MaxProgress: 0xffff,
+	})
+
+	reportStatus(string(bytes))
+
+	cfg, err := Parse(rawCfg)
+	if err != nil {
+		return err
+	}
+
+	destroyProviders(cfg)
+
+	return nil
+}
+
+func FetchProvidersAndValid(
+	path string,
+	force bool,
+	reportStatus func(string),
+) error {
+	defer runtime.GC()
+
+	rawCfg, err := UnmarshalAndPatch(path)
+	if err != nil {
+		return err
+	}
+
+	if err := fetchProviders(rawCfg, force, reportStatus); err != nil {
+		return err
+	}
+
+	bytes, _ := json.Marshal(&Status{
+		Action:      "Verifying",
+		Args:        []string{},
+		Progress:    0xffff,
+		MaxProgress: 0xffff,
+	})
+
+	reportStatus(string(bytes))
+
+	cfg, err := Parse(rawCfg)
+	if err != nil {
+		return err
+	}
+
+	destroyProviders(cfg)
+
+	return nil
+}
+
+func fetchProviders(rawCfg *config.RawConfig, force bool, reportStatus func(string)) error {
 	providerFetchTasks := make([]providerFetchTask, 0)
 	forEachProviders(rawCfg, func(index int, total int, name string, provider map[string]any, prefix string) {
 		u, uok := provider["url"]
@@ -151,8 +211,10 @@ func FetchAndValid(
 			return
 		}
 
-		if _, err := os.Stat(ps); err == nil {
-			return
+		if !force {
+			if _, err := os.Stat(ps); err == nil {
+				return
+			}
 		}
 
 		url, err := U.Parse(us)
@@ -179,22 +241,6 @@ func FetchAndValid(
 
 		_ = fetch(task.url, task.path)
 	}
-
-	bytes, _ := json.Marshal(&Status{
-		Action:      "Verifying",
-		Args:        []string{},
-		Progress:    0xffff,
-		MaxProgress: 0xffff,
-	})
-
-	reportStatus(string(bytes))
-
-	cfg, err := Parse(rawCfg)
-	if err != nil {
-		return err
-	}
-
-	destroyProviders(cfg)
 
 	return nil
 }

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -167,6 +167,38 @@ object Clash {
         }
     }
 
+    fun fetchProvidersAndValid(
+        path: File,
+        force: Boolean,
+        subscriptionHeadersJson: String = SubscriptionDeviceHeaders.toJson(Global.application),
+        reportStatus: (FetchStatus) -> Unit,
+    ): CompletableDeferred<Unit> {
+        return CompletableDeferred<Unit>().apply {
+            Bridge.nativeFetchProvidersAndValid(
+                object : FetchCallback {
+                    override fun report(statusJson: String) {
+                        reportStatus(
+                            Json.Default.decodeFromString(
+                                FetchStatus.serializer(),
+                                statusJson
+                            )
+                        )
+                    }
+
+                    override fun complete(error: String?) {
+                        if (error != null)
+                            completeExceptionally(ClashException(error))
+                        else
+                            complete(Unit)
+                    }
+                },
+                path.absolutePath,
+                force,
+                subscriptionHeadersJson,
+            )
+        }
+    }
+
     fun load(path: File): CompletableDeferred<Unit> {
         return CompletableDeferred<Unit>().apply {
             Bridge.nativeLoad(this, path.absolutePath)

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -36,6 +36,13 @@ object Bridge {
         subscriptionHeadersJson: String,
     )
 
+    external fun nativeFetchProvidersAndValid(
+        completable: FetchCallback,
+        path: String,
+        force: Boolean,
+        subscriptionHeadersJson: String,
+    )
+
     external fun nativeLoad(completable: CompletableDeferred<Unit>, path: String)
     external fun nativeQueryProviders(): String
     external fun nativeQueryConnectionsSnapshot(): String

--- a/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.design
 
 import android.content.Context
 import android.text.TextUtils
+import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -10,14 +11,19 @@ import com.github.kr328.clash.design.R
 import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.design.util.root
 import com.github.kr328.clash.service.model.RuleProviderItem
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.color.MaterialColors
+import kotlin.math.roundToInt
 
 class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(context) {
     sealed class Request {
         object OpenCreateSheet : Request()
         object OpenManualRules : Request()
+        object RefreshProviders : Request()
         object UpdateAllRuleSets : Request()
+        data class UpdateProvider(val name: String) : Request()
+        data class EditProvider(val provider: RuleProviderItem) : Request()
     }
 
     private val binding = DesignRuleSnippetBinding
@@ -32,6 +38,7 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
         binding.toolbar.title = ""
         binding.btnOpenCreateSheet.setOnClickListener { requests.trySend(Request.OpenCreateSheet) }
         binding.btnOpenManualRules.setOnClickListener { requests.trySend(Request.OpenManualRules) }
+        binding.btnRefreshRuleProviders.setOnClickListener { requests.trySend(Request.RefreshProviders) }
         binding.btnUpdateAllRuleSets.setOnClickListener { requests.trySend(Request.UpdateAllRuleSets) }
     }
 
@@ -40,13 +47,43 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
         val container = binding.providerItemsContainer
         container.removeAllViews()
         if (existingProviders.isNotEmpty()) {
-            existingProviders.forEach { provider ->
-                container.addView(
-                    buildExistingProviderRow(
-                        title = provider.name,
-                        subtitle = provider.url,
-                    ),
-                )
+            val columns = when {
+                context.resources.configuration.screenWidthDp >= 840 -> 4
+                context.resources.configuration.screenWidthDp >= 600 -> 2
+                else -> 1
+            }
+            existingProviders.chunked(columns).forEach { rowProviders ->
+                val row = LinearLayout(context).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    setBaselineAligned(false)
+                }
+                rowProviders.forEach { provider ->
+                    row.addView(
+                        buildExistingProviderCard(provider).apply {
+                            layoutParams = LinearLayout.LayoutParams(
+                                0,
+                                LinearLayout.LayoutParams.WRAP_CONTENT,
+                                1f,
+                            ).apply {
+                                setMargins(0, 10.dp(), 10.dp(), 0)
+                            }
+                        },
+                    )
+                }
+                repeat(columns - rowProviders.size) {
+                    row.addView(
+                        View(context).apply {
+                            layoutParams = LinearLayout.LayoutParams(
+                                0,
+                                1,
+                                1f,
+                            ).apply {
+                                setMargins(0, 10.dp(), 10.dp(), 0)
+                            }
+                        },
+                    )
+                }
+                container.addView(row)
             }
             return
         }
@@ -57,39 +94,55 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
         })
     }
 
-    /** Read-only: name + URL (no edit/delete; manage RULE-SET in Routing). */
-    private fun buildExistingProviderRow(
-        title: String,
-        subtitle: String?,
-    ): View {
+    private fun buildExistingProviderCard(provider: RuleProviderItem): View {
         val content = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(16, 14, 16, 14)
+            setPadding(14.dp(), 12.dp(), 12.dp(), 12.dp())
         }
-        content.addView(
+        val header = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        header.addView(
             TextView(context).apply {
-                text = title
+                text = provider.name
                 setTextAppearance(R.style.TextAppearance_App_TitleSmall)
                 setTextColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnSurface))
+                maxLines = 1
+                ellipsize = TextUtils.TruncateAt.END
+                layoutParams = LinearLayout.LayoutParams(
+                    0,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    1f,
+                )
             },
         )
-        if (!subtitle.isNullOrBlank()) {
-            content.addView(
-                TextView(context).apply {
-                    text = subtitle
-                    setPadding(0, 4, 0, 0)
-                    setTextAppearance(R.style.TextAppearance_App_BodySmall)
-                    setTextColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnSurfaceVariant))
-                    maxLines = 2
-                    ellipsize = TextUtils.TruncateAt.END
-                },
-            )
-        }
+        header.addView(
+            iconButton(
+                icon = R.drawable.ic_baseline_sync,
+                description = context.getString(R.string.update),
+                onClick = { requests.trySend(Request.UpdateProvider(provider.name)) },
+            ),
+        )
+        header.addView(
+            iconButton(
+                icon = R.drawable.ic_baseline_edit,
+                description = context.getString(R.string.edit),
+                onClick = { requests.trySend(Request.EditProvider(provider)) },
+            ),
+        )
+        content.addView(header)
+        content.addView(
+            TextView(context).apply {
+                text = "${provider.behavior.replaceFirstChar { it.uppercaseChar() }} · ${provider.type.uppercase()} · ${provider.interval}"
+                setPadding(0, 10.dp(), 0, 0)
+                setTextAppearance(R.style.TextAppearance_App_BodySmall)
+                setTextColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnSurfaceVariant))
+                maxLines = 1
+                ellipsize = TextUtils.TruncateAt.END
+            },
+        )
         return MaterialCardView(context).apply {
-            layoutParams = LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-            ).apply { topMargin = 10 }
             radius = 18f
             cardElevation = 0f
             setCardBackgroundColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorSurfaceContainer))
@@ -98,4 +151,36 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
             addView(content)
         }
     }
+
+    private fun iconButton(
+        icon: Int,
+        description: String,
+        onClick: () -> Unit,
+    ): MaterialButton {
+        return MaterialButton(
+            context,
+            null,
+            com.google.android.material.R.attr.materialButtonOutlinedStyle,
+        ).apply {
+            text = ""
+            setIconResource(icon)
+            contentDescription = description
+            minWidth = 0
+            minimumWidth = 0
+            minHeight = 0
+            minimumHeight = 0
+            insetTop = 0
+            insetBottom = 0
+            iconPadding = 0
+            iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
+            setPadding(10.dp(), 0, 10.dp(), 0)
+            layoutParams = LinearLayout.LayoutParams(40.dp(), 36.dp()).apply {
+                marginStart = 6.dp()
+            }
+            setOnClickListener { onClick() }
+        }
+    }
+
+    private fun Int.dp(): Int =
+        (this * context.resources.displayMetrics.density).roundToInt()
 }

--- a/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
@@ -20,15 +20,14 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
     sealed class Request {
         object OpenCreateSheet : Request()
         object OpenManualRules : Request()
-        object RefreshProviders : Request()
         object UpdateAllRuleSets : Request()
         data class UpdateProvider(val name: String) : Request()
-        data class EditProvider(val provider: RuleProviderItem) : Request()
     }
 
     private val binding = DesignRuleSnippetBinding
         .inflate(context.layoutInflater, context.root, false)
     private var existingProviders: List<RuleProviderItem> = emptyList()
+    private var providerEntryCounts: Map<String, Int> = emptyMap()
 
     override val root: View
         get() = binding.root
@@ -38,12 +37,15 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
         binding.toolbar.title = ""
         binding.btnOpenCreateSheet.setOnClickListener { requests.trySend(Request.OpenCreateSheet) }
         binding.btnOpenManualRules.setOnClickListener { requests.trySend(Request.OpenManualRules) }
-        binding.btnRefreshRuleProviders.setOnClickListener { requests.trySend(Request.RefreshProviders) }
         binding.btnUpdateAllRuleSets.setOnClickListener { requests.trySend(Request.UpdateAllRuleSets) }
     }
 
-    fun patchExistingProviders(providers: List<RuleProviderItem>) {
+    fun patchExistingProviders(
+        providers: List<RuleProviderItem>,
+        entryCounts: Map<String, Int> = emptyMap(),
+    ) {
         existingProviders = providers
+        providerEntryCounts = entryCounts
         val container = binding.providerItemsContainer
         container.removeAllViews()
         if (existingProviders.isNotEmpty()) {
@@ -124,18 +126,30 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
                 onClick = { requests.trySend(Request.UpdateProvider(provider.name)) },
             ),
         )
-        header.addView(
-            iconButton(
-                icon = R.drawable.ic_baseline_edit,
-                description = context.getString(R.string.edit),
-                onClick = { requests.trySend(Request.EditProvider(provider)) },
-            ),
-        )
         content.addView(header)
+        if (provider.url.isNotBlank()) {
+            content.addView(
+                TextView(context).apply {
+                    text = provider.url
+                    setPadding(0, 8.dp(), 0, 0)
+                    setTextAppearance(R.style.TextAppearance_App_BodySmall)
+                    setTextColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnSurfaceVariant))
+                    maxLines = 2
+                    ellipsize = TextUtils.TruncateAt.MIDDLE
+                    setTextIsSelectable(true)
+                },
+            )
+        }
         content.addView(
             TextView(context).apply {
-                text = "${provider.behavior.replaceFirstChar { it.uppercaseChar() }} · ${provider.type.uppercase()} · ${provider.interval}"
-                setPadding(0, 10.dp(), 0, 0)
+                val behaviorLabel = provider.behavior.replaceFirstChar { it.uppercaseChar() }
+                val typeLabel = provider.type.uppercase()
+                val parts = mutableListOf(behaviorLabel, typeLabel)
+                providerEntryCounts[provider.name]?.let { count ->
+                    parts += context.getString(R.string.rule_provider_entries_fmt, count.toString())
+                }
+                text = parts.joinToString(" · ")
+                setPadding(0, 8.dp(), 0, 0)
                 setTextAppearance(R.style.TextAppearance_App_BodySmall)
                 setTextColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnSurfaceVariant))
                 maxLines = 1

--- a/design/src/main/res/layout/design_rule_snippet.xml
+++ b/design/src/main/res/layout/design_rule_snippet.xml
@@ -107,13 +107,29 @@
                             android:text="@string/rule_existing_provider_toggle_hint"
                             android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
 
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btn_update_all_rule_sets"
-                            style="@style/Widget.Material3.Button.OutlinedButton"
+                        <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:text="@string/rule_rule_sets_update_all" />
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btn_refresh_rule_providers"
+                                style="@style/Widget.Material3.Button"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="8dp"
+                                android:layout_weight="1"
+                                android:text="@string/rule_providers_refresh" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btn_update_all_rule_sets"
+                                style="@style/Widget.Material3.Button.OutlinedButton"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@string/rule_rule_sets_update_all" />
+                        </LinearLayout>
 
                         <LinearLayout
                             android:id="@+id/provider_items_container"

--- a/design/src/main/res/layout/design_rule_snippet.xml
+++ b/design/src/main/res/layout/design_rule_snippet.xml
@@ -107,29 +107,13 @@
                             android:text="@string/rule_existing_provider_toggle_hint"
                             android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
 
-                        <LinearLayout
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_update_all_rule_sets"
+                            style="@style/Widget.Material3.Button.OutlinedButton"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="12dp"
-                            android:orientation="horizontal">
-
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/btn_refresh_rule_providers"
-                                style="@style/Widget.Material3.Button"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_marginEnd="8dp"
-                                android:layout_weight="1"
-                                android:text="@string/rule_providers_refresh" />
-
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/btn_update_all_rule_sets"
-                                style="@style/Widget.Material3.Button.OutlinedButton"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:text="@string/rule_rule_sets_update_all" />
-                        </LinearLayout>
+                            android:text="@string/rule_rule_sets_update_all" />
 
                         <LinearLayout
                             android:id="@+id/provider_items_container"

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -688,8 +688,8 @@
 
     <string name="rule_manual_custom_kind">Тип правила Clash</string>
     <string name="rule_manual_content_payload_hint">Значение (домен, IP/CIDR, порт, …)</string>
-    <string name="rule_existing_provider_toggle_hint">Здесь можно обновить providers или открыть редактирование, чтобы посмотреть и изменить URL. Чтобы отключить ruleset, откройте «Rules -> Manual rules» и выключите соответствующую строку RULE-SET.</string>
-    <string name="rule_providers_refresh">Обновить список</string>
+    <string name="rule_existing_provider_toggle_hint">Иконка sync обновляет один provider, кнопка ниже — все сразу. Чтобы отключить ruleset, откройте «Rules -> Manual rules» и выключите соответствующую строку RULE-SET.</string>
+    <string name="rule_provider_entries_fmt">%1$s записей</string>
     <string name="rule_rule_sets_update_all">Обновить все rule-sets (ядро)</string>
     <string name="rule_rule_sets_need_vpn">Включите VPN, чтобы ядро обновило rule providers</string>
     <string name="rule_rule_sets_update_all_ok">Запущено обновление rule providers</string>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -688,7 +688,8 @@
 
     <string name="rule_manual_custom_kind">Тип правила Clash</string>
     <string name="rule_manual_content_payload_hint">Значение (домен, IP/CIDR, порт, …)</string>
-    <string name="rule_existing_provider_toggle_hint">Провайдеры здесь только для просмотра. Чтобы отключить ruleset, откройте «Rules -> Manual rules» и выключите соответствующую строку RULE-SET.</string>
+    <string name="rule_existing_provider_toggle_hint">Здесь можно обновить providers или открыть редактирование, чтобы посмотреть и изменить URL. Чтобы отключить ruleset, откройте «Rules -> Manual rules» и выключите соответствующую строку RULE-SET.</string>
+    <string name="rule_providers_refresh">Обновить список</string>
     <string name="rule_rule_sets_update_all">Обновить все rule-sets (ядро)</string>
     <string name="rule_rule_sets_need_vpn">Включите VPN, чтобы ядро обновило rule providers</string>
     <string name="rule_rule_sets_update_all_ok">Запущено обновление rule providers</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -310,7 +310,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="rule_provider_behavior">Behavior</string>
     <string name="rule_existing_providers">Existing Providers</string>
     <string name="rule_existing_providers_empty">No providers in active profile yet.</string>
-    <string name="rule_existing_provider_toggle_hint">Providers here are read-only. To disable a ruleset, open Rules -> Manual rules and turn off the matching RULE-SET line.</string>
+    <string name="rule_existing_provider_toggle_hint">Refresh providers here, or edit one to view and change its URL. To disable a ruleset, open Rules -> Manual rules and turn off the matching RULE-SET line.</string>
+    <string name="rule_providers_refresh">Refresh</string>
     <string name="rule_rule_sets_update_all">Update all rule-sets (core)</string>
     <string name="rule_rule_sets_need_vpn">Turn the VPN on so the core can refresh rule providers</string>
     <string name="rule_rule_sets_update_all_ok">Rule provider refresh started</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -310,8 +310,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="rule_provider_behavior">Behavior</string>
     <string name="rule_existing_providers">Existing Providers</string>
     <string name="rule_existing_providers_empty">No providers in active profile yet.</string>
-    <string name="rule_existing_provider_toggle_hint">Refresh providers here, or edit one to view and change its URL. To disable a ruleset, open Rules -> Manual rules and turn off the matching RULE-SET line.</string>
-    <string name="rule_providers_refresh">Refresh</string>
+    <string name="rule_existing_provider_toggle_hint">Use the sync icon to refresh a single provider, or update them all. To disable a ruleset, open Rules -> Manual rules and turn off the matching RULE-SET line.</string>
+    <string name="rule_provider_entries_fmt">%1$s entries</string>
     <string name="rule_rule_sets_update_all">Update all rule-sets (core)</string>
     <string name="rule_rule_sets_need_vpn">Turn the VPN on so the core can refresh rule providers</string>
     <string name="rule_rule_sets_update_all_ok">Rule provider refresh started</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -259,9 +259,12 @@ object ProfileProcessor {
                     configFile.writeText(merged)
                     Log.d("Subscription merge preserved local overlays: rules/rule-providers/proxy-providers reapplied for ${snapshot.uuid}")
 
+                    // Subscription providers are already on disk from the fetch above;
+                    // this second pass only downloads local-only providers reintroduced
+                    // by the merge step (force=false → skip files that already exist).
                     Clash.fetchProvidersAndValid(
                         context.processingDir,
-                        true,
+                        false,
                         SubscriptionRequestHeaders.toNativeFetchJson(context, effectiveUserAgentOverride),
                     ) {
                         try {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -214,6 +214,7 @@ object ProfileProcessor {
 
                 val userAgentOverride = SubscriptionOverrides.getUserAgent(context, snapshot.uuid)
                 val strictUserAgent = SubscriptionOverrides.isStrictUserAgent(context, snapshot.uuid)
+                var effectiveUserAgentOverride = userAgentOverride
                 try {
                     Clash.fetchAndValid(
                         context.processingDir,
@@ -246,6 +247,7 @@ object ProfileProcessor {
                             Log.w("Report fetch status callback failed", e2)
                         }
                     }.await()
+                    effectiveUserAgentOverride = null
                 }
 
                 if (!preserved.isEmpty() && configFile.isFile) {
@@ -256,6 +258,19 @@ object ProfileProcessor {
                     )
                     configFile.writeText(merged)
                     Log.d("Subscription merge preserved local overlays: rules/rule-providers/proxy-providers reapplied for ${snapshot.uuid}")
+
+                    Clash.fetchProvidersAndValid(
+                        context.processingDir,
+                        true,
+                        SubscriptionRequestHeaders.toNativeFetchJson(context, effectiveUserAgentOverride),
+                    ) {
+                        try {
+                            cb?.updateStatus(it)
+                        } catch (e: Exception) {
+                            cb = null
+                            Log.w("Report provider refresh status callback failed", e)
+                        }
+                    }.await()
                 }
 
                 GeoUrlSanitizer.sanitizeProfile(context.processingDir)


### PR DESCRIPTION
## Summary
- refresh preserved rule/proxy providers after subscription updates so local rule sets get downloaded after the merged config is written
- add JNI/core bridge support for provider-only fetch/validation
- improve Routing -> Rules provider cards with refresh/edit actions and a compact Material-style grid

## Testing
- `git diff --cached --check`
- `./gradlew.bat :app:assembleMetaDebug`