### PR TITLE
fix(import): host-based fallback name + transient-error retry on commit

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -888,7 +888,7 @@ class MainActivity : BaseActivity<MainDesign>() {
      */
     private suspend fun importSubscriptionFromUrl(design: MainDesign, url: String) {
         design.showToast(R.string.import_resolving, ToastDuration.Short)
-        val name = withTimeoutOrNull(4500L) {
+        val name = withTimeoutOrNull(8000L) {
             SubscriptionNameGuesser.guess(this@MainActivity, url)
         } ?: SubscriptionNameGuesser.guessFast(url)
         val uuid = withProfile {
@@ -919,11 +919,13 @@ class MainActivity : BaseActivity<MainDesign>() {
             }
 
             coroutineScope {
-                withProfile {
-                    commit(uuid) { status ->
-                        launch {
-                            configure {
-                                applyFetchStatus(this@MainActivity, status)
+                com.github.kr328.clash.util.ImportRetry.withTransientRetry {
+                    withProfile {
+                        commit(uuid) { status ->
+                            launch {
+                                configure {
+                                    applyFetchStatus(this@MainActivity, status)
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
@@ -202,7 +202,9 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
             create(Profile.Type.Url, name, trimmed)
         }
         try {
-            withProfile { commit(uuid) }
+            com.github.kr328.clash.util.ImportRetry.withTransientRetry {
+                withProfile { commit(uuid) }
+            }
         } catch (e: Exception) {
             showImportCommitFailureDialog(uuid, e)
             return

--- a/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
@@ -163,14 +163,19 @@ class ProfilesActivity : BaseActivity<ProfilesDesign>() {
             return
         }
         design.showToast(DesignR.string.import_resolving, ToastDuration.Short)
-        val name = withTimeoutOrNull(4500L) {
+        // 8s gives Cloudflare-fronted panels (Marzban / Pasarguard) time to
+        // actually answer with Profile-Title; 4.5s was tripping on cold CDNs
+        // and we'd fall back to the path-token name (e.g. "asdkjzx1238s").
+        val name = withTimeoutOrNull(8000L) {
             SubscriptionNameGuesser.guess(this@ProfilesActivity, trimmed)
         } ?: SubscriptionNameGuesser.guessFast(trimmed)
         val uuid = withProfile {
             create(Profile.Type.Url, name, trimmed)
         }
         try {
-            withProfile { commit(uuid) }
+            com.github.kr328.clash.util.ImportRetry.withTransientRetry {
+                withProfile { commit(uuid) }
+            }
         } catch (e: Exception) {
             showImportCommitFailureDialog(uuid, e)
             return
@@ -217,13 +222,15 @@ class ProfilesActivity : BaseActivity<ProfilesDesign>() {
         }
 
         d.showToast(DesignR.string.import_resolving, ToastDuration.Short)
-        val name = withTimeoutOrNull(4500L) {
+        val name = withTimeoutOrNull(8000L) {
             SubscriptionNameGuesser.guess(this@ProfilesActivity, text)
         } ?: SubscriptionNameGuesser.guessFast(text)
 
         val uuid = withProfile { create(Profile.Type.Url, name, text) }
         try {
-            withProfile { commit(uuid) }
+            com.github.kr328.clash.util.ImportRetry.withTransientRetry {
+                withProfile { commit(uuid) }
+            }
         } catch (e: Exception) {
             d.showExceptionToast(e)
             return

--- a/app/src/main/java/com/github/kr328/clash/util/ImportRetry.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/ImportRetry.kt
@@ -1,0 +1,84 @@
+package com.github.kr328.clash.util
+
+import com.github.kr328.clash.common.log.Log
+import kotlinx.coroutines.delay
+import java.io.EOFException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Retry policy for subscription commit / fetch on transient network errors.
+ *
+ * Mobile networks intermittently fail subscription fetches in three ways:
+ *  - Android DNS resolver gives up after 3 internal tries and throws
+ *    [UnknownHostException] ("No address associated with hostname"). On the
+ *    next attempt the DNS cache (router / SIM) is hot and the lookup succeeds.
+ *  - Mihomo's rule-provider HTTP/2 streams get reset mid-body → [EOFException]
+ *    or [IOException] with "unexpected end of stream".
+ *  - First TCP handshake on a cold CDN edge eats the connect timeout →
+ *    [SocketTimeoutException]; second attempt reuses the warm pool.
+ *
+ * One retry after ~1.5s recovers from the vast majority of these without
+ * making the user re-tap import. We do **not** retry programmer errors,
+ * parse failures, or HTTP 4xx responses — only transient I/O.
+ */
+object ImportRetry {
+
+    suspend fun <T> withTransientRetry(
+        maxAttempts: Int = 2,
+        delayMs: Long = 1500L,
+        block: suspend () -> T,
+    ): T {
+        var lastError: Throwable? = null
+        repeat(maxAttempts) { attempt ->
+            try {
+                return block()
+            } catch (e: Throwable) {
+                if (!isTransient(e)) throw e
+                lastError = e
+                Log.w(
+                    "ImportRetry: transient error on attempt ${attempt + 1}/$maxAttempts " +
+                        "— ${e.javaClass.simpleName}: ${e.message}",
+                )
+                if (attempt < maxAttempts - 1) {
+                    // Linear backoff: 1.5s, 3s, 4.5s. Linear (not exponential)
+                    // keeps the worst case bounded for the user — we never
+                    // want import to silently grind for >10s.
+                    delay(delayMs * (attempt + 1))
+                }
+            }
+        }
+        throw lastError ?: IllegalStateException("ImportRetry exhausted with no exception captured")
+    }
+
+    /**
+     * Walks the cause chain — Mihomo wraps the underlying I/O error in higher-
+     * level subscription / parser exceptions, so the top-level type alone
+     * isn't enough to classify.
+     */
+    private fun isTransient(e: Throwable): Boolean {
+        var cur: Throwable? = e
+        while (cur != null) {
+            when (cur) {
+                is UnknownHostException -> return true
+                is EOFException -> return true
+                is SocketTimeoutException -> return true
+                is IOException -> {
+                    val msg = cur.message?.lowercase().orEmpty()
+                    if (
+                        "eof" in msg ||
+                        "unexpected end" in msg ||
+                        "connection reset" in msg ||
+                        "no address associated" in msg ||
+                        "failed to connect" in msg ||
+                        "stream reset" in msg ||
+                        "broken pipe" in msg
+                    ) return true
+                }
+            }
+            cur = cur.cause
+        }
+        return false
+    }
+}

--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
@@ -298,20 +298,73 @@ object SubscriptionNameGuesser {
     private fun sanitizeName(s: String): String =
         s.replace(Regex("[\r\n\t]"), " ").trim().take(64)
 
+    /**
+     * Best-effort name when no server-supplied title is available.
+     *
+     * Used to favour the last URL path segment, but for nearly every modern
+     * panel (Marzban / Pasarguard / Marzneshin / 3X-UI / ...) that segment is a
+     * subscription token like `asdkjzx1238sZasd` — looks awful as a profile
+     * label. We now derive a brand name from the host:
+     *
+     *   sub.cubereon.io/abcdef…    → "cubereon"
+     *   m.example.co.uk/abc        → "example"
+     *   marzban.host.ru            → "marzban" (after dropping "host" as a
+     *                                noisy infrastructure subdomain… no, kept;
+     *                                we drop only generic prefixes like
+     *                                sub/www/api/panel/subscription)
+     *
+     * The path segment is used *only* when it looks human (short or contains
+     * obvious word separators), never for long alphanum tokens.
+     */
     private fun fallbackName(urlString: String): String =
         try {
             val uri = URL(urlString)
-            val path = uri.path?.trim('/')?.split('/')?.filter { it.isNotBlank() }?.lastOrNull()
-            val safePath = path?.takeIf { it.length <= 48 }?.let { p ->
-                p.replace(Regex("[^a-zA-Z0-9._-]"), "_")
-            }
-            when {
-                !safePath.isNullOrBlank() -> safePath
-                !uri.host.isNullOrBlank() -> uri.host.substringBefore('.')
-                    .replace(Regex("[^a-zA-Z0-9._-]"), "_")
-                else -> "Subscription"
-            }
+            val pathSeg = uri.path?.trim('/')?.split('/')?.filter { it.isNotBlank() }?.lastOrNull()
+            val humanPath = pathSeg?.let { trimFileExtension(it) }?.takeIf(::looksHumanReadable)
+            val byHost = uri.host?.let(::brandFromHost)
+            val pick = humanPath ?: byHost
+            pick?.replace(Regex("[^a-zA-Z0-9._-]"), "_")?.takeIf { it.isNotBlank() }
+                ?: "Subscription"
         } catch (_: Exception) {
             "Subscription"
         }
+
+    private fun trimFileExtension(segment: String): String =
+        when {
+            segment.endsWith(".yaml", ignoreCase = true) ||
+                segment.endsWith(".yml", ignoreCase = true) ||
+                segment.endsWith(".txt", ignoreCase = true) ||
+                segment.endsWith(".json", ignoreCase = true) ->
+                segment.substringBeforeLast('.')
+            else -> segment
+        }
+
+    /**
+     * True when a path segment plausibly carries a user-meaningful label
+     * rather than a random subscription token: short (≤16), or contains word
+     * separators with reasonable length.
+     */
+    private fun looksHumanReadable(segment: String): Boolean {
+        if (segment.length <= 16) return true
+        if (segment.length > 32) return false
+        return segment.contains('-') || segment.contains('_')
+    }
+
+    /**
+     * Derive a brand-ish name from a host:
+     *   - drop generic infra subdomain prefixes (sub, www, api, panel, m, …)
+     *   - take the first remaining label (typically the operator brand)
+     *   - fall back to the raw first label if everything was noisy
+     */
+    private fun brandFromHost(host: String): String? {
+        val parts = host.lowercase().split('.').filter { it.isNotBlank() }
+        if (parts.isEmpty()) return null
+        val noisy = setOf(
+            "sub", "subs", "subscription", "subscriptions",
+            "www", "api", "panel", "app",
+            "m", "s", "v1", "v2",
+        )
+        val significant = parts.dropWhile { it in noisy }
+        return significant.firstOrNull()?.takeIf { it.length >= 2 } ?: parts.firstOrNull()
+    }
 }


### PR DESCRIPTION
## Summary

- **Naming**: `fallbackName` now derives a brand-ish name from the host (drops noisy infra subdomains like `sub`/`www`/`api`, picks the first significant label) instead of the last URL path segment. Path segments are used only when they look human (≤16 chars or contain word separators) — long alphanum tokens like `asdkjzx1238sZasd` are no longer mistaken for subscription names. Name-guess timeout raised from 4.5s to 8s so Cloudflare-fronted panels (Marzban, Pasarguard, Marzneshin) actually get a chance to return `Profile-Title`.
- **Reliability**: new `ImportRetry` helper retries `commit()` once with a 1.5s linear backoff on transient I/O — `UnknownHostException`, `EOFException`, `SocketTimeoutException`, and `IOException` with EOF / connection-reset / no-address / stream-reset / broken-pipe markers in any layer of the cause chain. Applied at all four subscription import entry points: home FAB, profiles manual input, profiles clipboard, intent-based import.
- Force-update (`update(uuid)`) is intentionally left without retry — user can re-trigger manually; silent background retries there are not worth the complexity.

## Test plan

- [ ] Import a Clash subscription with many `rule-providers` on a flaky mobile network → goes through even if the first attempt hits a DNS error
- [ ] Toggle wifi off/on mid-import → retry catches the transient failure
- [ ] Import a Marzban / Pasarguard URL behind Cloudflare → profile name comes from `Profile-Title` header, not from the path token
- [ ] Import a URL without title headers (e.g. `https://sub.cubereon.io/abc123def456789xyz`) → name resolves to `cubereon`, not the token
- [ ] Import a non-existent host → fails cleanly with the error dialog after 2 attempts, no infinite hang
- [ ] Import an xray subscription → no regression
- [ ] Import via all 4 entry points: home FAB / profiles manual / profiles clipboard / intent → retry is active in each
