### PR TITLE
fix(import): optimistic async name resolution without unsaved state

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -887,28 +887,53 @@ class MainActivity : BaseActivity<MainDesign>() {
      * [commit]s the fetch, activates it — no Properties screen on success.
      */
     private suspend fun importSubscriptionFromUrl(design: MainDesign, url: String) {
-        design.showToast(R.string.import_resolving, ToastDuration.Short)
-        val name = withTimeoutOrNull(8000L) {
-            SubscriptionNameGuesser.guess(this@MainActivity, url)
-        } ?: SubscriptionNameGuesser.guessFast(url)
+        // Optimistic import: don't block the UI on Profile-Title lookup.
+        // Create with a host-based preliminary name (instant), kick off the
+        // network guess in the background, and rename after commit() if a
+        // better name arrives. Previous flow froze the UI for up to 8s before
+        // the progress bar even appeared.
+        val pending = com.github.kr328.clash.util.AsyncNameResolver.start(this, this@MainActivity, url)
         val uuid = withProfile {
-            create(Profile.Type.Url, name, url)
+            create(Profile.Type.Url, pending.preliminaryName, url)
         }
         try {
             commitProfileWithProgress(uuid)
         } catch (e: Exception) {
+            pending.betterName.cancel()
             showImportCommitFailureDialog(uuid, e)
             return
         }
+        val displayName = upgradeProfileNameIfBetter(uuid, pending, url)
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
             ensureGlobalSelectionSafeWithRetry()
-            design.showToast(getString(R.string.import_done_named, name), ToastDuration.Long)
+            design.showToast(getString(R.string.import_done_named, displayName), ToastDuration.Long)
         } else {
             launchProperties(uuid)
         }
         design.fetch()
+    }
+
+    /**
+     * Awaits the background [com.github.kr328.clash.util.AsyncNameResolver]
+     * result and renames the imported profile if a better name arrived.
+     * Uses [com.github.kr328.clash.service.remote.IProfileManager.renameImported]
+     * (direct ImportedDao update) — NOT [patch], which would put the profile
+     * back into a pending/draft state and surface as "unsaved" to the user.
+     * Returns the effective display name (better one if applied, preliminary
+     * otherwise).
+     */
+    @Suppress("UNUSED_PARAMETER")
+    private suspend fun upgradeProfileNameIfBetter(
+        uuid: java.util.UUID,
+        pending: com.github.kr328.clash.util.AsyncNameResolver.Pending,
+        url: String,
+    ): String {
+        val better = runCatching { pending.betterName.await() }.getOrNull()
+            ?: return pending.preliminaryName
+        runCatching { withProfile { renameImported(uuid, better) } }
+        return better
     }
 
     private suspend fun commitProfileWithProgress(uuid: UUID) {

--- a/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
@@ -196,27 +196,43 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
             return
         }
         val d = design ?: return
-        d.showToast(R.string.import_resolving, ToastDuration.Short)
-        val name = SubscriptionNameGuesser.guess(self, trimmed)
+        // Optimistic import: see [com.github.kr328.clash.util.AsyncNameResolver].
+        // Was a fully synchronous guess() with no timeout at all here — could
+        // block the QR-import flow up to 40s on stalled CDNs.
+        val pending = com.github.kr328.clash.util.AsyncNameResolver.start(this, self, trimmed)
         val uuid = withProfile {
-            create(Profile.Type.Url, name, trimmed)
+            create(Profile.Type.Url, pending.preliminaryName, trimmed)
         }
         try {
             com.github.kr328.clash.util.ImportRetry.withTransientRetry {
                 withProfile { commit(uuid) }
             }
         } catch (e: Exception) {
+            pending.betterName.cancel()
             showImportCommitFailureDialog(uuid, e)
             return
         }
+        val displayName = upgradeProfileNameIfBetter(uuid, pending, trimmed)
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
-            d.showToast(getString(R.string.import_done_named, name), ToastDuration.Long)
+            d.showToast(getString(R.string.import_done_named, displayName), ToastDuration.Long)
             finish()
         } else {
             launchProperties(uuid)
         }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private suspend fun upgradeProfileNameIfBetter(
+        uuid: UUID,
+        pending: com.github.kr328.clash.util.AsyncNameResolver.Pending,
+        url: String,
+    ): String {
+        val better = runCatching { pending.betterName.await() }.getOrNull()
+            ?: return pending.preliminaryName
+        runCatching { withProfile { renameImported(uuid, better) } }
+        return better
     }
 
     /** Commit failed after QR scan: show error in a dialog first; Properties only if user chooses. */

--- a/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
@@ -162,33 +162,52 @@ class ProfilesActivity : BaseActivity<ProfilesDesign>() {
             design.showToast(DesignR.string.invalid_url, ToastDuration.Long)
             return
         }
-        design.showToast(DesignR.string.import_resolving, ToastDuration.Short)
-        // 8s gives Cloudflare-fronted panels (Marzban / Pasarguard) time to
-        // actually answer with Profile-Title; 4.5s was tripping on cold CDNs
-        // and we'd fall back to the path-token name (e.g. "asdkjzx1238s").
-        val name = withTimeoutOrNull(8000L) {
-            SubscriptionNameGuesser.guess(this@ProfilesActivity, trimmed)
-        } ?: SubscriptionNameGuesser.guessFast(trimmed)
+        // Optimistic import: see [com.github.kr328.clash.util.AsyncNameResolver].
+        // Synchronously block here used to freeze the UI for up to 8s before
+        // commit() even started — and worse, on slow links the timeout fired
+        // before Profile-Title arrived, giving us the host name anyway.
+        val pending = com.github.kr328.clash.util.AsyncNameResolver
+            .start(this, this@ProfilesActivity, trimmed)
         val uuid = withProfile {
-            create(Profile.Type.Url, name, trimmed)
+            create(Profile.Type.Url, pending.preliminaryName, trimmed)
         }
         try {
             com.github.kr328.clash.util.ImportRetry.withTransientRetry {
                 withProfile { commit(uuid) }
             }
         } catch (e: Exception) {
+            pending.betterName.cancel()
             showImportCommitFailureDialog(uuid, e)
             return
         }
+        val displayName = upgradeProfileNameIfBetter(uuid, pending, trimmed)
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
             ensureGlobalSelectionSafeAfterImport()
-            design.showToast(getString(DesignR.string.import_done_named, name), ToastDuration.Long)
+            design.showToast(getString(DesignR.string.import_done_named, displayName), ToastDuration.Long)
             design.fetch()
         } else {
             startActivity(PropertiesActivity::class.intent.setUUID(uuid))
         }
+    }
+
+    /**
+     * Awaits the background [com.github.kr328.clash.util.AsyncNameResolver]
+     * result and renames the imported profile if a better name arrived.
+     * Uses [com.github.kr328.clash.service.remote.IProfileManager.renameImported]
+     * to avoid the draft/unsaved state that [patch] would create.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    private suspend fun upgradeProfileNameIfBetter(
+        uuid: UUID,
+        pending: com.github.kr328.clash.util.AsyncNameResolver.Pending,
+        url: String,
+    ): String {
+        val better = runCatching { pending.betterName.await() }.getOrNull()
+            ?: return pending.preliminaryName
+        runCatching { withProfile { renameImported(uuid, better) } }
+        return better
     }
 
     private suspend fun showImportCommitFailureDialog(uuid: UUID, e: Throwable) {
@@ -221,26 +240,25 @@ class ProfilesActivity : BaseActivity<ProfilesDesign>() {
             return
         }
 
-        d.showToast(DesignR.string.import_resolving, ToastDuration.Short)
-        val name = withTimeoutOrNull(8000L) {
-            SubscriptionNameGuesser.guess(this@ProfilesActivity, text)
-        } ?: SubscriptionNameGuesser.guessFast(text)
-
-        val uuid = withProfile { create(Profile.Type.Url, name, text) }
+        val pending = com.github.kr328.clash.util.AsyncNameResolver
+            .start(this, this@ProfilesActivity, text)
+        val uuid = withProfile { create(Profile.Type.Url, pending.preliminaryName, text) }
         try {
             com.github.kr328.clash.util.ImportRetry.withTransientRetry {
                 withProfile { commit(uuid) }
             }
         } catch (e: Exception) {
+            pending.betterName.cancel()
             d.showExceptionToast(e)
             return
         }
+        val displayName = upgradeProfileNameIfBetter(uuid, pending, text)
 
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
             ensureGlobalSelectionSafeAfterImport()
-            d.showToast(getString(DesignR.string.import_done_named, name), ToastDuration.Long)
+            d.showToast(getString(DesignR.string.import_done_named, displayName), ToastDuration.Long)
             d.fetch()
         } else {
             startActivity(PropertiesActivity::class.intent.setUUID(uuid))

--- a/app/src/main/java/com/github/kr328/clash/util/AsyncNameResolver.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/AsyncNameResolver.kt
@@ -1,0 +1,56 @@
+package com.github.kr328.clash.util
+
+import android.content.Context
+import com.github.kr328.clash.common.util.SubscriptionNameGuesser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Async name resolver for subscription imports.
+ *
+ * Old behaviour was synchronous: the UI froze for up to 8 seconds while we
+ * tried to read Profile-Title before even creating the profile or starting
+ * `commit()`. On slow networks that meant blocked UI **plus** frequent fallback
+ * to a host-based name (the timeout fired before Profile-Title arrived).
+ *
+ * This helper starts the network guess in the background, returns a fast
+ * synchronous host-based name for the placeholder, and exposes a [Deferred]
+ * the caller awaits **after** `commit()` to upgrade the profile name to the
+ * real Profile-Title — without blocking the user-visible progress bar.
+ *
+ * The background guess uses a 20s timeout: generous enough for Cloudflare-
+ * fronted panels on mobile, but bounded so we don't hold the rename forever
+ * if the panel never responds.
+ */
+object AsyncNameResolver {
+    /**
+     * @property preliminaryName host-based name available immediately; safe
+     *   to pass to `create(Profile.Type.Url, name, url)` without any wait.
+     * @property betterName resolves to a Profile-Title-derived name when the
+     *   background fetch finishes within 20s **and** it differs from
+     *   [preliminaryName]. Otherwise resolves to `null` — caller should
+     *   leave the profile name as-is.
+     */
+    data class Pending(
+        val preliminaryName: String,
+        val betterName: Deferred<String?>,
+    )
+
+    fun start(
+        scope: CoroutineScope,
+        context: Context,
+        url: String,
+    ): Pending {
+        val preliminary = SubscriptionNameGuesser.guessFast(url)
+        val better = scope.async {
+            withTimeoutOrNull(20_000L) {
+                runCatching {
+                    SubscriptionNameGuesser.guess(context, url)
+                }.getOrNull()
+            }?.takeIf { it.isNotBlank() && it != preliminary }
+        }
+        return Pending(preliminary, better)
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -190,6 +190,23 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
+    override suspend fun renameImported(uuid: UUID, name: String) {
+        withContext(Dispatchers.IO) {
+            val trimmed = name.trim()
+            if (trimmed.isBlank()) return@withContext
+            val imported = ImportedDao().queryByUUID(uuid) ?: return@withContext
+            if (imported.name == trimmed) return@withContext
+            ImportedDao().update(imported.copy(name = trimmed))
+            // Mirror to a pending draft if one happens to exist (full edit
+            // flow in progress) — otherwise we'd silently overwrite the
+            // user's in-progress edit on the next commit. No-op when no draft.
+            PendingDao().queryByUUID(uuid)?.let { pending ->
+                PendingDao().update(pending.copy(name = trimmed))
+            }
+            context.sendProfileChanged(uuid)
+        }
+    }
+
     override suspend fun applySubscriptionUpdateInterval(uuid: UUID, intervalMillis: Long) {
         withContext(Dispatchers.IO) {
             val min = java.util.concurrent.TimeUnit.MINUTES.toMillis(15)

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -14,6 +14,18 @@ interface IProfileManager {
     suspend fun release(uuid: UUID)
     suspend fun delete(uuid: UUID)
     suspend fun patch(uuid: UUID, name: String, source: String, interval: Long)
+
+    /**
+     * Direct rename of an **already imported** profile — only changes `name`
+     * in [ImportedDao], does not enter the pending/draft state that [patch]
+     * uses for the full "Edit profile" flow. Used by optimistic-import to
+     * upgrade the placeholder host-based name to the real Profile-Title once
+     * the background guess finishes, without making the profile look unsaved
+     * to the user. No-op if the profile is not in [ImportedDao] (pending /
+     * deleted).
+     */
+    suspend fun renameImported(uuid: UUID, name: String)
+
     /**
      * Persists subscription auto-update interval from operator headers (e.g. `Profile-Update-Interval`)
      * without re-fetching the subscription body. Coerces to at least 15 minutes (same as [ProfileReceiver]).


### PR DESCRIPTION
## Summary

- Resolve subscription name in the background instead of blocking the UI for up to 8s before `commit()`. New `AsyncNameResolver` returns an instant host-based preliminary name plus a `Deferred` that resolves to the real Profile-Title (20s timeout). Progress bar now appears immediately on every import path.
- After `commit()` finishes, the placeholder name is upgraded to the real one via a new direct AIDL method `renameImported(uuid, name)` that updates `ImportedDao` only. Previously used `patch()`, which by design enters the Pending/draft state and made every freshly imported profile look "unsaved" + show "not ready yet" on VPN start.
- Applied to all four import entry points: home FAB, profiles manual input, profiles clipboard, intent/QR.
