### PR TITLE
feat(brand): X-Brand-Cabinet-URL — per-user account deep link on Operator tab

### DIFF
--- a/common/src/main/java/com/github/kr328/clash/common/branding/BrandHeaders.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/branding/BrandHeaders.kt
@@ -38,6 +38,16 @@ object BrandHeaders {
     const val STATUS_URL = "X-Brand-Status-URL"
     const val RENEW_URL = "X-Brand-Renew-URL"
 
+    /**
+     * Personal account / billing entry-point for the current user of this
+     * subscription. Built by the operator with a panel template variable
+     * (e.g. `https://t.me/<bot>?startapp={{SHORT_UUID}}` for a Telegram
+     * Mini App, or `https://billing.example.com/account?ref={{ID}}` for a
+     * web cabinet). ClashFest opens the URL via `ACTION_VIEW` — `tg://` and
+     * `https://t.me/...` route to Telegram, plain `https://` to a browser.
+     */
+    const val CABINET_URL = "X-Brand-Cabinet-URL"
+
     // --- Per-user context (v2 — meaningful only when the panel substitutes
     //                       variables like {{USERNAME}} into the header) ---
     const val USER_DISPLAY_NAME = "X-Brand-User-Display-Name"

--- a/common/src/main/java/com/github/kr328/clash/common/branding/BrandManifest.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/branding/BrandManifest.kt
@@ -36,6 +36,18 @@ data class BrandManifest(
     val renewUrl: String? = null,
 
     /**
+     * Personal account / billing URL for the *current user* of this
+     * subscription. The operator builds it by templating their panel's
+     * user identifier (e.g. `https://t.me/<bot>?startapp={{SHORT_UUID}}`
+     * for Telegram Mini App, or `https://billing.example.com/account?ref={{ID}}`
+     * for a web cabinet). We pass it through verbatim and open it via
+     * `ACTION_VIEW` — Android routes `tg://` / `https://t.me/...` to
+     * Telegram, `https://...` to a browser, etc. Per-subscription, validated
+     * the same way as other URL fields.
+     */
+    val cabinetUrl: String? = null,
+
+    /**
      * Per-user display name surfaced in About sheet. Operators wire this via
      * a panel template variable (e.g. `X-Brand-User-Display-Name: {{USERNAME}}`)
      * so the panel substitutes the actual username before the response leaves.
@@ -83,6 +95,7 @@ data class BrandManifest(
             helpUrl == null &&
             statusUrl == null &&
             renewUrl == null &&
+            cabinetUrl == null &&
             userDisplayName == null &&
             greeting == null &&
             hideStats == null &&

--- a/common/src/main/java/com/github/kr328/clash/common/branding/BrandManifestParser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/branding/BrandManifestParser.kt
@@ -93,6 +93,7 @@ object BrandManifestParser {
             helpUrl = BrandValidation.cleanBrandUrl(raw(BrandHeaders.HELP_URL)),
             statusUrl = BrandValidation.cleanBrandUrl(raw(BrandHeaders.STATUS_URL)),
             renewUrl = BrandValidation.cleanBrandUrl(raw(BrandHeaders.RENEW_URL)),
+            cabinetUrl = BrandValidation.cleanBrandUrl(raw(BrandHeaders.CABINET_URL)),
             userDisplayName = BrandValidation.cleanString(
                 raw(BrandHeaders.USER_DISPLAY_NAME),
                 BrandValidation.USER_DISPLAY_NAME_MAX_LENGTH,

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -406,6 +406,18 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
             binding.operatorRenewButton.visibility = View.GONE
         }
 
+        // Personal cabinet entry-point. Stays tonal-secondary even when Renew
+        // is absent — the visual difference between Renew (filled) and
+        // Cabinet (tonal) is a deliberate hierarchy cue: Renew converts the
+        // user into a paying / renewing customer, Cabinet only navigates.
+        val cabinet = brand.cabinetUrl?.takeIf { it.isNotBlank() }
+        if (cabinet != null) {
+            binding.operatorCabinetButton.visibility = View.VISIBLE
+            binding.operatorCabinetButton.setOnClickListener { onOpenBrandUrl?.invoke(cabinet) }
+        } else {
+            binding.operatorCabinetButton.visibility = View.GONE
+        }
+
         // Grouped link rows. Each row gets a leading icon and a trailing chevron;
         // groups are separated by small headers so the user can scan the page
         // by intent (talk to humans / read docs / check status).

--- a/design/src/main/java/com/github/kr328/clash/design/SubscriptionIdentityDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SubscriptionIdentityDesign.kt
@@ -77,6 +77,7 @@ class SubscriptionIdentityDesign(context: Context) : Design<SubscriptionIdentity
             "X-Brand-Help-URL" to context.getString(R.string.headers_desc_brand_help),
             "X-Brand-Status-URL" to context.getString(R.string.headers_desc_brand_status),
             "X-Brand-Renew-URL" to context.getString(R.string.headers_desc_brand_renew),
+            "X-Brand-Cabinet-URL" to context.getString(R.string.headers_desc_brand_cabinet),
             "X-Brand-User-Display-Name" to context.getString(R.string.headers_desc_brand_user_display_name),
             "X-Brand-Greeting" to context.getString(R.string.headers_desc_brand_greeting),
             "X-Brand-Show-Operator-Tab" to context.getString(R.string.headers_desc_brand_show_tab),

--- a/design/src/main/res/drawable/ic_baseline_account_circle.xml
+++ b/design/src/main/res/drawable/ic_baseline_account_circle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,5c1.66,0 3,1.34 3,3s-1.34,3 -3,3s-3,-1.34 -3,-3s1.34,-3 3,-3zM12,19.2c-2.5,0 -4.71,-1.28 -6,-3.22c0.03,-1.99 4,-3.08 6,-3.08c1.99,0 5.97,1.09 6,3.08c-1.29,1.94 -3.5,3.22 -6,3.22z" />
+</vector>

--- a/design/src/main/res/layout/design_main.xml
+++ b/design/src/main/res/layout/design_main.xml
@@ -1167,6 +1167,27 @@
                             android:textAllCaps="false"
                             android:visibility="gone" />
 
+                        <!--
+                          Personal cabinet entry-point. The operator builds the URL
+                          with a panel template variable that identifies the current
+                          user (e.g. `https://t.me/<bot>?startapp={{SHORT_UUID}}` for
+                          a Telegram Mini App, or `https://billing.example.com/account?ref={{ID}}`
+                          for a web cabinet). We open it via ACTION_VIEW — Android
+                          routes the appropriate handler.
+                        -->
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/operator_cabinet_button"
+                            style="@style/Widget.Material3.Button.TonalButton"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            android:text="@string/about_brand_cabinet"
+                            android:textAllCaps="false"
+                            android:visibility="gone"
+                            app:icon="@drawable/ic_baseline_account_circle"
+                            app:iconGravity="textStart"
+                            app:iconPadding="8dp" />
+
                         <LinearLayout
                             android:id="@+id/operator_links"
                             android:layout_width="match_parent"

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -406,6 +406,7 @@
     <string name="about_brand_terms">Условия</string>
     <string name="about_brand_status">Статус</string>
     <string name="about_brand_renew">Продлить подписку</string>
+    <string name="about_brand_cabinet">Личный кабинет</string>
     <string name="about_brand_reset">Сбросить брендинг</string>
     <string name="brand_reset_toast">Брендинг оператора сброшен</string>
     <string name="brand_renew_action">Продлить</string>
@@ -460,6 +461,7 @@
     <string name="headers_desc_brand_help">Ссылка на Help / FAQ.</string>
     <string name="headers_desc_brand_status">Страница статуса сервиса (показывается при проблемах с подключением).</string>
     <string name="headers_desc_brand_renew">Deep link на продление подписки. Открывается тапом по critical-expiry chip.</string>
+    <string name="headers_desc_brand_cabinet">Deep link на личный кабинет с template-переменной панели (например {{SHORT_UUID}} для Telegram Mini App). Отображается как кнопка «Личный кабинет» на вкладке Operator.</string>
     <string name="headers_desc_brand_user_display_name">Имя пользователя в About (заполняется через panel-переменные, например {{USERNAME}}).</string>
     <string name="headers_desc_brand_greeting">Приветствие на Operator-вкладке. Сочетайте panel-переменные для динамического контента.</string>
     <string name="headers_desc_brand_show_tab">Явный opt-in для появления отдельной Operator-вкладки.</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -603,6 +603,7 @@
     <string name="about_brand_terms">服务条款</string>
     <string name="about_brand_status">状态</string>
     <string name="about_brand_renew">续订订阅</string>
+    <string name="about_brand_cabinet">个人中心</string>
     <string name="about_brand_reset">重置品牌</string>
     <string name="brand_reset_toast">运营商品牌已重置</string>
     <string name="brand_renew_action">续订</string>
@@ -667,6 +668,7 @@
     <string name="headers_desc_brand_help">帮助/常见问题链接。</string>
     <string name="headers_desc_brand_status">服务状态页(连接问题时显示)。</string>
     <string name="headers_desc_brand_renew">订阅续订深度链接。点击临近到期标签会打开此链接。</string>
+    <string name="headers_desc_brand_cabinet">使用面板模板变量(如 {{SHORT_UUID}})构建的个人账户/计费深度链接。在运营商页显示为「个人中心」按钮。</string>
     <string name="headers_desc_brand_user_display_name">在“关于”中显示的用户名(通过面板模板变量填充,例如 {{USERNAME}})。</string>
     <string name="headers_desc_brand_greeting">运营商标签页的问候语。可结合模板变量实现动态内容。</string>
     <string name="headers_desc_brand_show_tab">显式启用专用的运营商底部导航标签。</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="about_brand_terms">Terms</string>
     <string name="about_brand_status">Status</string>
     <string name="about_brand_renew">Renew subscription</string>
+    <string name="about_brand_cabinet">My account</string>
     <string name="about_brand_reset">Reset branding</string>
     <string name="brand_reset_toast">Operator branding has been reset</string>
     <string name="brand_renew_action">Renew</string>
@@ -375,6 +376,7 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="headers_desc_brand_help">Help / FAQ link.</string>
     <string name="headers_desc_brand_status">Service status page (surfaces on connection issues).</string>
     <string name="headers_desc_brand_renew">Subscription renewal deep link. Tapping a critical-expiry chip opens it.</string>
+    <string name="headers_desc_brand_cabinet">Personal account / billing deep link with a panel template variable (e.g. {{SHORT_UUID}} for a Telegram Mini App). Surfaces as the \"My account\" button on the Operator tab.</string>
     <string name="headers_desc_brand_user_display_name">Per-user name shown in About (template-variable driven, e.g. {{USERNAME}}).</string>
     <string name="headers_desc_brand_greeting">Hero greeting on the Operator tab. Combine template variables for dynamic content.</string>
     <string name="headers_desc_brand_show_tab">Explicit opt-in to add the dedicated Operator bottom-nav tab.</string>

--- a/docs/operator-api/headers.md
+++ b/docs/operator-api/headers.md
@@ -208,6 +208,15 @@ is ignored.
 | Applied to | When subscription expiry is critical (<3 days or already expired):<br>• tap on the existing critical-expiry chip on the profile card<br>• "Renew" button in the profile bottom sheet near the expiry info<br>• "Renew subscription" entry in the profile overflow menu<br>About screen also gets a Renew button when this URL is set. |
 | Notes | All entry points appear only when this URL is provided. No URL → no Renew UI anywhere. |
 
+### `X-Brand-Cabinet-URL`
+
+| | |
+|---|---|
+| Type | URL (https / tg / mailto) — almost always built with a panel template variable |
+| Status | **v3** |
+| Applied to | "My account" button on the **Operator** tab, rendered as a tonal-secondary button under the Renew CTA (or alone if no Renew URL). |
+| Notes | The operator builds a **per-user** URL using their panel's identifier template — e.g. `{{SHORT_UUID}}`, `{{ID}}`, `{{USERNAME}}`. Examples:<br>• Telegram Mini App: `https://t.me/<bot>?startapp={{SHORT_UUID}}` (requires the bot to be registered as a Mini App in BotFather).<br>• Web cabinet: `https://billing.example.com/account?ref={{ID}}`<br>• Bot chat with start payload: `https://t.me/<bot>?start={{SHORT_UUID}}` (operator must handle the payload in `/start` and surface the cabinet button).<br>Client opens the URL via `ACTION_VIEW` — Android routes `tg://` / `https://t.me/...` to Telegram (Mini App or chat depending on the URL form), other `https://` to the browser. |
+
 ---
 
 ## 3. User context

--- a/docs/supported-headers.md
+++ b/docs/supported-headers.md
@@ -104,6 +104,7 @@ All URL fields accept `https://`, `tg://`, `mailto:`, `t.me/`
 | `X-Brand-Help-URL` | About → Help chip |
 | `X-Brand-Status-URL` | Service-status page link |
 | `X-Brand-Renew-URL` | Deep link for renewal. Critical-expiry chip becomes tappable when set; Renew CTA appears on the Operator tab. |
+| `X-Brand-Cabinet-URL` | Per-user personal account / billing deep link built with a panel template variable (e.g. `https://t.me/<bot>?startapp={{SHORT_UUID}}` for a Telegram Mini App, or `https://billing.example.com/account?ref={{ID}}`). Surfaces as the "My account" button on the Operator tab. |
 
 #### UX surfaces
 


### PR DESCRIPTION
## Summary

- New optional header `X-Brand-Cabinet-URL` lets the operator hand the client a per-user personal-account / billing deep link. The URL is built with a panel template variable identifying the current user (e.g. `https://t.me/<bot>?startapp={{SHORT_UUID}}` for a Telegram Mini App registered via BotFather, or `https://billing.example.com/account?ref={{ID}}` for a web cabinet).
- Surfaces as a new **"My account"** tonal-secondary button on the Operator tab, placed under the Renew CTA. Tap opens via `ACTION_VIEW` — Android routes `tg://` / `https://t.me/...` to Telegram (Mini App or chat depending on the URL form), other `https://` to a browser.
- No client-side identity logic: the operator already knows who the user is by the subscription token in their panel and is solely responsible for building the right URL per user. ClashFest just passes it through.
- Parsed with the same `cleanBrandUrl` validation as other brand URLs (https / tg / mailto / t.me/). Localised in EN / RU / ZH. Added to the Schemes & HWID in-app reference and to `docs/operator-api/headers.md` + `docs/supported-headers.md`.
