### PR TITLE
fix(update): stability + toast polish

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -29,6 +29,7 @@ import com.github.kr328.clash.common.util.ShareImportSupport
 import com.github.kr328.clash.util.SubscriptionMetaCache
 import com.github.kr328.clash.util.commitProfileWithProgress
 import com.github.kr328.clash.util.createEmptyUrlProfileAndOpenEditor
+import com.github.kr328.clash.util.updateProfileWithProgress
 import com.github.kr328.clash.common.util.StandalonePing
 import com.github.kr328.clash.common.util.SubscriptionNameGuesser
 import com.github.kr328.clash.common.util.SubscriptionOverrides
@@ -691,7 +692,11 @@ class MainActivity : BaseActivity<MainDesign>() {
 
                 design.profileForceUpdateRequests.onReceive { profile ->
                     launch {
-                        withProfile { update(profile.uuid) }
+                        // Success / failure toast comes from the broadcast
+                        // observer (onProfileUpdateCompleted / Failed). Don't
+                        // toast "started" here — the user sees that *after*
+                        // the modal closes, by which point the work is done.
+                        runCatching { updateProfileWithProgress(profile.uuid) }
                         // Run metadata sync in the background so the UI tap returns
                         // immediately. The earlier race (announcement-card hiding the
                         // active-card support button for a tick) was structural — we
@@ -702,7 +707,6 @@ class MainActivity : BaseActivity<MainDesign>() {
                             runCatching { syncSubscriptionMetadata() }
                             withContext(Dispatchers.Main) { refreshAnnouncement(design) }
                         }
-                        design.showToast(R.string.profile_update_scheduled, ToastDuration.Long)
                         scheduleDashboardRefresh()
                     }
                 }
@@ -811,8 +815,12 @@ class MainActivity : BaseActivity<MainDesign>() {
                 }
                 R.id.profile_menu_update -> {
                     launch {
-                        withProfile { update(profile.uuid) }
-                        design.showToast(R.string.profile_update_scheduled, ToastDuration.Long)
+                        // Success / failure toast is driven by the
+                        // Profile-Update-Completed / Failed broadcast in
+                        // onProfileUpdateCompleted / onProfileUpdateFailed —
+                        // no manual toast here, otherwise the user gets a
+                        // stale "started" message *after* the actual result.
+                        runCatching { updateProfileWithProgress(profile.uuid) }
                         design.fetch()
                     }
                     true

--- a/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ProfilesActivity.kt
@@ -21,6 +21,7 @@ import com.github.kr328.clash.design.util.showExceptionToast
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.util.commitProfileWithProgress
 import com.github.kr328.clash.util.createEmptyUrlProfileAndOpenEditor
+import com.github.kr328.clash.util.updateProfileWithProgress
 import com.github.kr328.clash.util.withClash
 import com.github.kr328.clash.util.withProfile
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -79,7 +80,7 @@ class ProfilesActivity : BaseActivity<ProfilesDesign>() {
                                 }
                             }
                         is ProfilesDesign.Request.Update ->
-                            withProfile { update(it.profile.uuid) }
+                            updateProfileWithProgress(it.profile.uuid)
                         is ProfilesDesign.Request.Delete ->
                             withProfile { delete(it.profile.uuid) }
                         is ProfilesDesign.Request.Edit ->

--- a/app/src/main/java/com/github/kr328/clash/util/ImportProgress.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/ImportProgress.kt
@@ -46,3 +46,41 @@ suspend fun Context.commitProfileWithProgress(uuid: UUID) {
         }
     }
 }
+
+/**
+ * Modal progress dialog + transient-error retry around `update(uuid)`.
+ *
+ * Sibling of [commitProfileWithProgress] for the force-refresh path. While
+ * the dialog is open the user physically cannot tap the refresh button again,
+ * which is the primary defence against the "io read/write on closed pipe"
+ * race that fires when two `update()` calls arrive in flight simultaneously.
+ * (ProfileManager.update also has a per-uuid dedupe set as a second line of
+ * defence — see its docstring.)
+ *
+ * The retry wrapper catches transient EOF / DNS / socket-timeout errors that
+ * mostly happen when refreshing a subscription while the VPN tunnel is active
+ * — the underlying connection sometimes gets reset mid-stream and a second
+ * attempt almost always succeeds.
+ */
+suspend fun Context.updateProfileWithProgress(uuid: UUID) {
+    val ctx = this
+    withModelProgressBar {
+        configure {
+            isIndeterminate = true
+            text = ctx.getString(R.string.initializing)
+        }
+        coroutineScope {
+            ImportRetry.withTransientRetry {
+                withProfile {
+                    update(uuid) { status ->
+                        launch {
+                            configure {
+                                applyFetchStatus(ctx, status)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/Design.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/Design.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.github.kr328.clash.design.ui.Surface
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.currentWindowInsetsSnapshot
+import com.github.kr328.clash.design.util.resolveThemedColor
 import com.github.kr328.clash.design.util.setOnInsertsChangedListener
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
@@ -41,9 +42,51 @@ abstract class Design<R>(val context: Context) :
             }
             Snackbar.make(root, message, len).apply {
                 root.findViewById<View>(R.id.main_bottom_nav_card)?.let { anchorView = it }
+                styleAsMaterial3()
                 configure()
             }.show()
         }
+    }
+
+    /**
+     * Material 3 styling for the Snackbar: rounded inverse-surface card
+     * (high-contrast against the page on both light and dark themes) with
+     * inverse-on-surface text and inverse-primary action button. Keeps the
+     * spec-correct inverse pairing — just gives it our 20dp corner radius
+     * via [R.drawable.bg_snackbar_m3] instead of the framework square edges.
+     */
+    private fun Snackbar.styleAsMaterial3() {
+        val ctx = view.context
+        // M3 inverse palette (the spec name is `colorSurfaceInverse`, NOT
+        // the legacy MaterialComponents `colorInverseSurface` — the latter
+        // doesn't exist in Material 1.12+). Material's Theme.Material3.* and
+        // .DayNight.* provide light + dark variants automatically, so we get
+        // the right contrast on either theme without managing two palettes.
+        val bgColor = ctx.resolveThemedColor(
+            com.google.android.material.R.attr.colorSurfaceInverse
+        )
+        val textColor = ctx.resolveThemedColor(
+            com.google.android.material.R.attr.colorOnSurfaceInverse
+        )
+        val actionColor = ctx.resolveThemedColor(
+            com.google.android.material.R.attr.colorPrimaryInverse
+        )
+
+        // Rounded shape comes from the drawable (which already uses
+        // ?attr/colorSurfaceInverse internally); setBackgroundTint asserts
+        // the same colour at the Snackbar layer to override the framework
+        // backgroundTint that would otherwise repaint over our drawable.
+        view.background = androidx.appcompat.content.res.AppCompatResources
+            .getDrawable(ctx, R.drawable.bg_snackbar_m3)
+        setBackgroundTint(bgColor)
+        view.elevation = 6f * ctx.resources.displayMetrics.density
+
+        // Snackbar.setTextColor / setActionTextColor push a ColorStateList
+        // through ViewCompat that survives view re-measures — these are the
+        // documented Snackbar styling hooks, safer than touching the
+        // internal snackbar_text / snackbar_action TextView directly.
+        setTextColor(textColor)
+        setActionTextColor(actionColor)
     }
 
     init {

--- a/design/src/main/res/drawable/bg_snackbar_m3.xml
+++ b/design/src/main/res/drawable/bg_snackbar_m3.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Snackbar background per the Material 3 spec: inverse-surface fill (the bar
+  reads as deliberately "other" against the page surface), with our rounded
+  20dp corners on top. Pairs with ?attr/colorOnSurfaceInverse text and
+  ?attr/colorPrimaryInverse action — both set in Design.styleAsMaterial3.
+
+  Note the M3 attr name is `colorSurfaceInverse`, NOT the legacy
+  MaterialComponents `colorInverseSurface` (AAPT will fail to resolve the
+  latter in Material 1.12+).
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceInverse" />
+    <corners android:radius="20dp" />
+</shape>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -26,6 +26,8 @@ import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.directoryLastModified
 import com.github.kr328.clash.service.util.generateProfileUUID
 import com.github.kr328.clash.service.util.importedDir
+import com.github.kr328.clash.service.util.sendProfileUpdateCompleted
+import com.github.kr328.clash.service.util.sendProfileUpdateFailed
 import com.github.kr328.clash.service.util.ProxyGroupsYamlPreview
 import com.github.kr328.clash.service.util.ProxyTransportYamlPreview
 import com.github.kr328.clash.service.util.ProxyYamlPreview
@@ -61,6 +63,16 @@ class ProfileManager(private val context: Context) : IProfileManager,
     // imports (e.g. auto-update + manual click) can both read the same MAX(profileOrder)
     // and produce duplicate ordering values that compare non-deterministically.
     private val profileOrderLock = Mutex()
+
+    /**
+     * UUIDs that currently have a manual [update] in flight. The second click
+     * on the "refresh" button arrives while the first is still running and
+     * would otherwise start a parallel fetch — that's what produced the
+     * "io read/write on closed pipe" errors in the wild. Set membership is
+     * the only signal; entries are removed in a `finally` so a crash or
+     * coroutine cancellation can't strand a profile in "updating forever".
+     */
+    private val updatingUuids = java.util.Collections.synchronizedSet(mutableSetOf<UUID>())
 
     private data class CachedFile(
         val relativePath: String,
@@ -228,12 +240,57 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
-    override suspend fun update(uuid: UUID) {
-        scheduleUpdate(uuid, true)
-        ImportedDao().queryByUUID(uuid)?.let {
-            if (it.type == Profile.Type.Url && it.source.startsWith("https://",true)) {
-                updateFlow(it)
+    override suspend fun update(uuid: UUID, callback: IFetchObserver?) {
+        // Per-uuid dedupe: drop the call if an update for this profile is
+        // already in flight. The UI also blocks rapid taps via a modal
+        // progress dialog, but this is the belt-and-suspenders guarantee:
+        // any caller (auto-update WorkManager, notification action, AIDL
+        // client) gets the same protection.
+        if (!updatingUuids.add(uuid)) {
+            Log.d("update($uuid) skipped — already in flight")
+            return
+        }
+        try {
+            val imported = ImportedDao().queryByUUID(uuid) ?: return
+            if (imported.type != Profile.Type.Url) return
+
+            // Direct invocation so the suspend point holds the lock for the
+            // FULL fetch+verify duration. The previous implementation called
+            // scheduleUpdate(true) which dispatched the work to ProfileWorker
+            // (foreground service) and returned immediately — the lock would
+            // have released after ~50ms while the real work ran in the
+            // background, defeating the dedupe and letting a second tap kick
+            // off a parallel fetch that fought the first one for the YAML
+            // pipe. ProfileProcessor.update already holds its own
+            // processLock so reentrancy from auto-update is safe.
+            //
+            // Side effect of bypassing ProfileWorker: the worker is what used
+            // to broadcast Profile-Update-Completed / Failed (so observers
+            // could surface a toast). We now emit those broadcasts here so
+            // the UI keeps getting the same lifecycle events on every path.
+            try {
+                ProfileProcessor.update(context, uuid, callback)
+
+                if (imported.source.startsWith("https://", true)) {
+                    updateFlow(imported)
+                }
+
+                // Re-arm the timer-based auto-update from the new mtime so the
+                // next automatic refresh fires at the correct interval — we no
+                // longer go through scheduleUpdate() which used to do this for us.
+                ImportedDao().queryByUUID(uuid)?.let {
+                    ProfileReceiver.scheduleNext(context, it)
+                }
+                context.sendProfileUpdateCompleted(uuid)
+            } catch (e: Exception) {
+                if (e !is kotlinx.coroutines.CancellationException) {
+                    val reason = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
+                    context.sendProfileUpdateFailed(uuid, reason)
+                }
+                throw e
             }
+        } finally {
+            updatingUuids.remove(uuid)
         }
     }
 

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -32,7 +32,18 @@ interface IProfileManager {
      * No-op if the profile is missing or not a URL subscription.
      */
     suspend fun applySubscriptionUpdateInterval(uuid: UUID, intervalMillis: Long)
-    suspend fun update(uuid: UUID)
+    /**
+     * Force-refresh the subscription identified by [uuid]. Suspends until the
+     * fetch + verify pipeline finishes (or fails). [callback] receives the
+     * usual `FetchStatus` updates so the UI can drive a progress dialog.
+     *
+     * Calls are deduplicated by UUID — if an `update()` is already in flight
+     * for the same profile, the second invocation returns immediately without
+     * starting a second concurrent fetch. This prevents the "io read/write on
+     * closed pipe" race that happened when the user rage-tapped the update
+     * button while a previous request was still running.
+     */
+    suspend fun update(uuid: UUID, callback: IFetchObserver? = null)
     suspend fun queryByUUID(uuid: UUID): Profile?
     suspend fun queryAll(): List<Profile>
     suspend fun reorder(uuids: List<String>)


### PR DESCRIPTION
## Summary

**Update stability**
- Per-uuid dedupe in `ProfileManager.update` — a second tap on "refresh" while the first is still running is dropped silently, killing the "io read/write on closed pipe" race that fired when two parallel fetches fought for the YAML stream.
- Manual update now calls `ProfileProcessor.update` directly instead of dispatching through `scheduleUpdate(true)` → ProfileWorker. The suspend point holds the dedupe lock for the full fetch+verify duration (previously released after ~50ms while real work ran in the background, defeating the dedupe).
- `IProfileManager.update(uuid, callback)` gains an optional `IFetchObserver` callback for progress reporting; new `updateProfileWithProgress` helper wraps the call in a modal progress dialog + `ImportRetry.withTransientRetry` (catches transient EOF / DNS / socket-timeout that hit when refreshing with the VPN tunnel active).
- Broadcasts `Profile-Update-Completed/Failed` are now emitted from `ProfileManager.update` directly (they used to come from ProfileWorker, which we now bypass on the manual path), so observer-driven toasts keep working.
- Removed the stale "Subscription update started" toast that fired *after* the modal closed, by which point the update was already done — success/failure result toast comes from the broadcast observer.
- Applied at 3 user-triggered call sites: home active-profile force-update, profile menu "Update", Profiles → Manage profiles. Auto-refresh-before-VPN-start kept on the direct path (no modal needed for an automatic pre-start check).