### PR TITLE
feat(home): per-proxy push for the post-connect warmup path

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -53,6 +53,7 @@ import com.github.kr328.clash.remote.StatusClient
 import com.github.kr328.clash.service.model.AccessControlMode
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.model.ProxyGroupPreviewRow
+import com.github.kr328.clash.service.remote.IProxyDelayObserver
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.util.RussianBypassDefaults
 import com.github.kr328.clash.util.GitHubReleaseUpdate
@@ -668,21 +669,56 @@ class MainActivity : BaseActivity<MainDesign>() {
                                 waitForProxyEngineReady()
                                 val groupsToRefresh = collectRuntimeGroupTree(group)
                                     .ifEmpty { linkedSetOf(group).filter { it.isNotBlank() }.toSet() }
+                                // Prime live engine state so per-proxy push has rows to land on.
+                                // healthCheckPerProxy only updates delays for proxies already
+                                // present in proxyDetails — without an initial query the very
+                                // first ping cycle would be a silent no-op until the closing
+                                // refresh below.
+                                val primed = refreshRuntimeGroupDetails(groupsToRefresh)
+                                if (primed.isNotEmpty()) {
+                                    design.patchProxyDetails(primed)
+                                }
                                 val jobs = groupsToRefresh.map { groupName ->
                                     launch {
                                         runCatching {
-                                            withClash { healthCheck(groupName) }
+                                            withClash {
+                                                healthCheckPerProxy(
+                                                    groupName,
+                                                    object : IProxyDelayObserver {
+                                                        override fun onDelay(
+                                                            group: String,
+                                                            proxy: String,
+                                                            delayMs: Int,
+                                                            errMsg: String,
+                                                        ) {
+                                                            // Failed URLTest carries errMsg + delayMs == 0.
+                                                            // Surfacing 0 would render as "0ms" in the
+                                                            // pill — engine convention is Int.MAX_VALUE
+                                                            // for unreachable, so coerce here.
+                                                            val effective = if (errMsg.isNotEmpty()) {
+                                                                Int.MAX_VALUE
+                                                            } else {
+                                                                delayMs
+                                                            }
+                                                            this@MainActivity.launch {
+                                                                design.patchSingleProxyDelay(group, proxy, effective)
+                                                            }
+                                                        }
+
+                                                        override fun onComplete(error: String?) {
+                                                            // Logged-only — the outer launch's join()
+                                                            // is what completes the suspend call.
+                                                        }
+                                                    },
+                                                )
+                                            }
                                         }
                                     }
                                 }
-                                while (isActive && jobs.any { !it.isCompleted }) {
-                                    delay(350L)
-                                    val partial = refreshRuntimeGroupDetails(groupsToRefresh)
-                                    if (partial.isNotEmpty()) {
-                                        design.patchProxyDetails(partial)
-                                    }
-                                }
                                 jobs.forEach { it.join() }
+                                // Closing refresh captures `now` / `alive` fields the per-proxy
+                                // push doesn't carry, plus any auto-group selection that the
+                                // engine's url-test logic flipped after the ping cycle.
                                 val refreshed = refreshRuntimeGroupDetails(groupsToRefresh)
                                 if (refreshed.isNotEmpty()) {
                                     design.patchProxyDetails(refreshed)

--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -296,6 +296,50 @@ class MainActivity : BaseActivity<MainDesign>() {
         return warmUpAutoProxyGroups()
     }
 
+    /**
+     * Run a per-proxy health check on [group] and stream each proxy's delay
+     * into the active card as soon as URLTest resolves. Suspends until every
+     * proxy has reported (or the call early-outed because the group is
+     * missing / wrong type).
+     *
+     * UI patches are dispatched on the activity's MainScope and target the
+     * design property — if the activity has already torn down the design by
+     * the time a result lands, the patch is silently dropped. Callers that
+     * need `now` / `alive` state should still issue a closing
+     * refreshRuntimeGroupDetails — per-proxy push only carries the delay
+     * measurement itself.
+     */
+    private suspend fun runPerProxyHealthCheck(group: String) {
+        runCatching {
+            withClash {
+                healthCheckPerProxy(
+                    group,
+                    object : IProxyDelayObserver {
+                        override fun onDelay(
+                            grp: String,
+                            proxy: String,
+                            delayMs: Int,
+                            errMsg: String,
+                        ) {
+                            // Failed URLTest carries errMsg + delayMs == 0. Showing 0 would
+                            // render as "0ms" — engine convention is Int.MAX_VALUE for
+                            // unreachable, so coerce before the patch.
+                            val effective = if (errMsg.isNotEmpty()) Int.MAX_VALUE else delayMs
+                            this@MainActivity.launch {
+                                this@MainActivity.design?.patchSingleProxyDelay(grp, proxy, effective)
+                            }
+                        }
+
+                        override fun onComplete(error: String?) {
+                            // No-op: the outer suspend returns via await() in
+                            // ClashManager.healthCheckPerProxy.
+                        }
+                    },
+                )
+            }
+        }
+    }
+
     private suspend fun warmUpAutoProxyGroups(): Set<String> = coroutineScope {
         waitForProxyEngineReady()
 
@@ -334,12 +378,16 @@ class MainActivity : BaseActivity<MainDesign>() {
         }
         if (autoGroups.isEmpty()) return@coroutineScope emptySet()
 
+        // Prime engine state so per-proxy push has rows to land on. Without
+        // this, the first warmup cycle on cold start would have nowhere to
+        // write — proxyDetails is empty until the user scrolls into a group.
+        val primed = refreshRuntimeGroupDetails(autoGroups)
+        if (primed.isNotEmpty()) {
+            design?.patchProxyDetails(primed)
+        }
+
         autoGroups.map { group ->
-            launch {
-                runCatching {
-                    withClash { healthCheck(group) }
-                }
-            }
+            launch { runPerProxyHealthCheck(group) }
         }.joinAll()
         autoGroups.toSet()
     }
@@ -679,41 +727,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                                     design.patchProxyDetails(primed)
                                 }
                                 val jobs = groupsToRefresh.map { groupName ->
-                                    launch {
-                                        runCatching {
-                                            withClash {
-                                                healthCheckPerProxy(
-                                                    groupName,
-                                                    object : IProxyDelayObserver {
-                                                        override fun onDelay(
-                                                            group: String,
-                                                            proxy: String,
-                                                            delayMs: Int,
-                                                            errMsg: String,
-                                                        ) {
-                                                            // Failed URLTest carries errMsg + delayMs == 0.
-                                                            // Surfacing 0 would render as "0ms" in the
-                                                            // pill — engine convention is Int.MAX_VALUE
-                                                            // for unreachable, so coerce here.
-                                                            val effective = if (errMsg.isNotEmpty()) {
-                                                                Int.MAX_VALUE
-                                                            } else {
-                                                                delayMs
-                                                            }
-                                                            this@MainActivity.launch {
-                                                                design.patchSingleProxyDelay(group, proxy, effective)
-                                                            }
-                                                        }
-
-                                                        override fun onComplete(error: String?) {
-                                                            // Logged-only — the outer launch's join()
-                                                            // is what completes the suspend call.
-                                                        }
-                                                    },
-                                                )
-                                            }
-                                        }
-                                    }
+                                    launch { runPerProxyHealthCheck(groupName) }
                                 }
                                 jobs.forEach { it.join() }
                                 // Closing refresh captures `now` / `alive` fields the per-proxy

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -206,6 +206,18 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheck(JNIEnv *env, jo
 }
 
 JNIEXPORT void JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheckWithCallback(JNIEnv *env, jobject thiz,
+                                                                              jobject callback,
+                                                                              jstring name) {
+    TRACE_METHOD();
+
+    jobject _callback = new_global(callback);
+    scoped_string _name = get_string(name);
+
+    healthCheckWithCallback(_callback, _name);
+}
+
+JNIEXPORT void JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheckAll(JNIEnv *env, jobject thiz) {
     TRACE_METHOD();
 
@@ -435,6 +447,8 @@ static jmethodID m_logcat_interface_received;
 static jmethodID m_clash_exception;
 static jmethodID m_fetch_callback_report;
 static jmethodID m_fetch_callback_complete;
+static jmethodID m_proxy_delay_callback_report;
+static jmethodID m_proxy_delay_callback_complete;
 static jmethodID m_open;
 static jmethodID m_get_message;
 static jclass c_clash_exception;
@@ -518,6 +532,38 @@ static void call_fetch_callback_complete_impl(void *fetch_callback, const char *
                            (jstring) _error);
 }
 
+static void call_proxy_delay_callback_report_impl(void *callback, const char *proxy_name, int delay_ms, const char *err_msg) {
+    TRACE_METHOD();
+
+    ATTACH_JNI();
+
+    jstring _proxy_name = new_string(proxy_name);
+    jstring _err_msg = err_msg != NULL ? new_string(err_msg) : new_string("");
+
+    (*env)->CallVoidMethod(env,
+                           (jobject) callback,
+                           (jmethodID) m_proxy_delay_callback_report,
+                           (jstring) _proxy_name,
+                           (jint) delay_ms,
+                           (jstring) _err_msg);
+}
+
+static void call_proxy_delay_callback_complete_impl(void *callback, const char *error) {
+    TRACE_METHOD();
+
+    ATTACH_JNI();
+
+    jstring _error = NULL;
+
+    if (error != NULL)
+        _error = new_string(error);
+
+    (*env)->CallVoidMethod(env,
+                           (jobject) callback,
+                           (jmethodID) m_proxy_delay_callback_complete,
+                           (jstring) _error);
+}
+
 static int call_logcat_interface_received_impl(void *callback, const char *payload) {
     TRACE_METHOD();
 
@@ -589,6 +635,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved) {
     jclass c_tun_interface = find_class("com/github/kr328/clash/core/bridge/TunInterface");
     jclass c_completable = find_class("kotlinx/coroutines/CompletableDeferred");
     jclass c_fetch_callback = find_class("com/github/kr328/clash/core/bridge/FetchCallback");
+    jclass c_proxy_delay_callback = find_class("com/github/kr328/clash/core/bridge/ProxyDelayCallback");
     jclass c_logcat_interface = find_class("com/github/kr328/clash/core/bridge/LogcatInterface");
     jclass _c_clash_exception = find_class("com/github/kr328/clash/core/bridge/ClashException");
     jclass _c_content = find_class("com/github/kr328/clash/core/bridge/Content");
@@ -605,6 +652,10 @@ JNI_OnLoad(JavaVM *vm, void *reserved) {
                                           "(Ljava/lang/String;)V");
     m_fetch_callback_complete = find_method(c_fetch_callback, "complete",
                                             "(Ljava/lang/String;)V");
+    m_proxy_delay_callback_report = find_method(c_proxy_delay_callback, "report",
+                                                "(Ljava/lang/String;ILjava/lang/String;)V");
+    m_proxy_delay_callback_complete = find_method(c_proxy_delay_callback, "complete",
+                                                  "(Ljava/lang/String;)V");
     m_completable_complete_exceptionally = find_method(c_completable, "completeExceptionally",
                                                        "(Ljava/lang/Throwable;)Z");
     m_logcat_interface_received = find_method(c_logcat_interface, "received",
@@ -629,6 +680,8 @@ JNI_OnLoad(JavaVM *vm, void *reserved) {
     complete_func = &call_completable_complete_impl;
     fetch_report_func = &call_fetch_callback_report_impl;
     fetch_complete_func = &call_fetch_callback_complete_impl;
+    proxy_delay_report_func = &call_proxy_delay_callback_report_impl;
+    proxy_delay_complete_func = &call_proxy_delay_callback_complete_impl;
     logcat_received_func = &call_logcat_interface_received_impl;
     open_content_func = &open_content_impl;
     release_object_func = &release_jni_object_impl;

--- a/core/src/main/golang/native/bridge.c
+++ b/core/src/main/golang/native/bridge.c
@@ -11,6 +11,10 @@ void (*fetch_report_func)(void *fetch_callback, const char *status_json);
 
 void (*fetch_complete_func)(void *fetch_callback, const char *error);
 
+void (*proxy_delay_report_func)(void *callback, const char *proxy_name, int delay_ms, const char *err_msg);
+
+void (*proxy_delay_complete_func)(void *callback, const char *error);
+
 int (*logcat_received_func)(void *logcat_interface, const char *payload);
 
 int (*open_content_func)(const char *url, char *error, int error_length);
@@ -56,6 +60,23 @@ void fetch_report(void *fetch_callback, char *json_status) {
     fetch_report_func(fetch_callback, json_status);
 
     free(json_status);
+}
+
+void proxy_delay_report(void *callback, char *proxy_name, int delay_ms, char *err_msg) {
+    TRACE_METHOD();
+
+    proxy_delay_report_func(callback, proxy_name, delay_ms, err_msg);
+
+    free(proxy_name);
+    free(err_msg);
+}
+
+void proxy_delay_complete(void *callback, char *error) {
+    TRACE_METHOD();
+
+    proxy_delay_complete_func(callback, error);
+
+    free(error);
 }
 
 int logcat_received(void *logcat_interface, char *payload) {

--- a/core/src/main/golang/native/bridge.h
+++ b/core/src/main/golang/native/bridge.h
@@ -19,6 +19,10 @@ extern void (*fetch_report_func)(void *fetch_callback, const char *status_json);
 
 extern void (*fetch_complete_func)(void *fetch_callback, const char *error);
 
+extern void (*proxy_delay_report_func)(void *callback, const char *proxy_name, int delay_ms, const char *err_msg);
+
+extern void (*proxy_delay_complete_func)(void *callback, const char *error);
+
 extern int (*logcat_received_func)(void *logcat_interface, const char *payload);
 
 extern void (*release_object_func)(void *obj);
@@ -35,6 +39,10 @@ extern void complete(void *obj, char *error);
 extern void fetch_complete(void *completable, char *exception);
 
 extern void fetch_report(void *fetch_callback, char *status_json);
+
+extern void proxy_delay_report(void *callback, char *proxy_name, int delay_ms, char *err_msg);
+
+extern void proxy_delay_complete(void *callback, char *error);
 
 extern int logcat_received(void *logcat_interface, char *payload);
 

--- a/core/src/main/golang/native/tunnel.go
+++ b/core/src/main/golang/native/tunnel.go
@@ -79,6 +79,27 @@ func healthCheck(completable unsafe.Pointer, name C.c_string) {
 	}(C.GoString(name))
 }
 
+//export healthCheckWithCallback
+func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
+	go func(name string, callback unsafe.Pointer) {
+		earlyErr := tunnel.HealthCheckWithCallback(name, func(proxyName string, delayMs int, errMsg string) {
+			var errCStr *C.char
+			if errMsg != "" {
+				errCStr = marshalString(errMsg)
+			}
+			C.proxy_delay_report(callback, marshalString(proxyName), C.int(delayMs), errCStr)
+		})
+
+		var earlyErrCStr *C.char
+		if earlyErr != "" {
+			earlyErrCStr = marshalString(earlyErr)
+		}
+		C.proxy_delay_complete(callback, earlyErrCStr)
+
+		C.release_object(callback)
+	}(C.GoString(name), callback)
+}
+
 //export healthCheckAll
 func healthCheckAll() {
 	tunnel.HealthCheckAll()

--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -1,13 +1,25 @@
 package tunnel
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
 	"github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/mihomo/tunnel"
 )
+
+// defaultHealthCheckURL is mihomo's stock generate_204 endpoint. Used as a
+// fallback when a provider has no configured health-check URL (typical for
+// compatible providers built from inline `proxies:` lists).
+const defaultHealthCheckURL = "http://www.gstatic.com/generate_204"
+
+// perProxyHealthCheckTimeout caps each individual proxy URLTest. Provider's
+// own health-check pipeline uses a similar 5s default — we follow it to
+// keep ping totals comparable between the batch and per-proxy paths.
+const perProxyHealthCheckTimeout = 5 * time.Second
 
 func HealthCheck(name string) {
 	p := tunnel.Proxies()[name]
@@ -46,4 +58,56 @@ func HealthCheckAll() {
 			HealthCheck(group)
 		}(g)
 	}
+}
+
+// HealthCheckWithCallback runs URLTest against every proxy of every provider
+// in the named group in parallel and pushes each result to onDelay the moment
+// that proxy's test resolves. Mirrors what provider.HealthCheck does
+// internally (URLTest with the provider's own health-check URL, no filter)
+// but reports per proxy instead of a single batch return — UI can patch a
+// row as soon as it has data instead of polling queryProxyGroup on a timer.
+//
+// Returns ("", nil) when every proxy reported; ("group not found" / "invalid
+// type", nil) on the obvious early-outs. onDelay is called from a goroutine,
+// so the caller is responsible for any cross-goroutine synchronisation.
+//
+// errMsg is empty on success, otherwise carries the proxy's URLTest error
+// reason; delayMs is meaningful only when errMsg == "".
+func HealthCheckWithCallback(
+	name string,
+	onDelay func(proxyName string, delayMs int, errMsg string),
+) string {
+	p := tunnel.Proxies()[name]
+	if p == nil {
+		return "group not found"
+	}
+	g, ok := p.Adapter().(outboundgroup.ProxyGroup)
+	if !ok {
+		return "invalid group type"
+	}
+
+	var wg sync.WaitGroup
+	for _, prov := range g.Providers() {
+		url := prov.HealthCheckURL()
+		if url == "" {
+			url = defaultHealthCheckURL
+		}
+		for _, target := range prov.Proxies() {
+			target := target
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ctx, cancel := context.WithTimeout(context.Background(), perProxyHealthCheckTimeout)
+				defer cancel()
+				delay, err := target.URLTest(ctx, url, nil)
+				if err != nil {
+					onDelay(target.Name(), 0, err.Error())
+					return
+				}
+				onDelay(target.Name(), int(delay), "")
+			}()
+		}
+	}
+	wg.Wait()
+	return ""
 }

--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -2,10 +2,12 @@ package tunnel
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
+	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/mihomo/tunnel"
@@ -16,10 +18,57 @@ import (
 // compatible providers built from inline `proxies:` lists).
 const defaultHealthCheckURL = "http://www.gstatic.com/generate_204"
 
-// perProxyHealthCheckTimeout caps each individual proxy URLTest. Provider's
-// own health-check pipeline uses a similar 5s default — we follow it to
-// keep ping totals comparable between the batch and per-proxy paths.
+// perProxyHealthCheckTimeout caps each individual proxy URLTest when the
+// provider's own health-check timeout cannot be extracted. Mirrors the
+// mihomo default so behaviour matches a vanilla provider.HealthCheck()
+// for subscriptions that don't override `health-check.timeout`.
 const perProxyHealthCheckTimeout = 5 * time.Second
+
+// extractHealthCheckSettings pulls the configured health-check timeout and
+// expected-status range out of a ProxyProvider so per-proxy URLTest can
+// honour the subscription's settings instead of hard-coding defaults.
+// mihomo only exposes HealthCheckURL() through the ProxyProvider interface
+// — timeout / expectedStatus live on the private baseProvider.healthCheck
+// field. Reflection is the least invasive workaround: a submodule patch
+// adding public getters would be cleaner but requires forking mihomo
+// (the current submodule points at upstream MetaCubeX/mihomo).
+//
+// If the field layout shifts in a future mihomo bump the function falls
+// back to mihomo's own defaults — timeout = perProxyHealthCheckTimeout,
+// expectedStatus = nil (match any 2xx) — keeping the call path safe.
+func extractHealthCheckSettings(prov provider.ProxyProvider) (time.Duration, utils.IntRanges[uint16]) {
+	timeout := perProxyHealthCheckTimeout
+	var expectedStatus utils.IntRanges[uint16]
+
+	pv := reflect.ValueOf(prov)
+	if pv.Kind() == reflect.Ptr {
+		pv = pv.Elem()
+	}
+	if !pv.IsValid() || pv.Kind() != reflect.Struct {
+		return timeout, expectedStatus
+	}
+
+	hcField := pv.FieldByName("healthCheck")
+	if !hcField.IsValid() || hcField.Kind() != reflect.Ptr || hcField.IsNil() {
+		return timeout, expectedStatus
+	}
+	hc := hcField.Elem()
+	if !hc.IsValid() || hc.Kind() != reflect.Struct {
+		return timeout, expectedStatus
+	}
+
+	if t := hc.FieldByName("timeout"); t.IsValid() && t.Kind() == reflect.Uint {
+		if tval := t.Uint(); tval > 0 {
+			timeout = time.Duration(tval) * time.Millisecond
+		}
+	}
+	if es := hc.FieldByName("expectedStatus"); es.IsValid() {
+		if v, ok := es.Interface().(utils.IntRanges[uint16]); ok {
+			expectedStatus = v
+		}
+	}
+	return timeout, expectedStatus
+}
 
 func HealthCheck(name string) {
 	p := tunnel.Proxies()[name]
@@ -92,14 +141,20 @@ func HealthCheckWithCallback(
 		if url == "" {
 			url = defaultHealthCheckURL
 		}
+		// Honour provider-level health-check.timeout / expected-status from
+		// the subscription. Without this a custom `health-check.timeout: 10`
+		// would still cap at 5s here, producing false timeout entries that
+		// disagree with what the engine's own provider.HealthCheck() would
+		// report. See extractHealthCheckSettings for the reflection caveat.
+		timeout, expectedStatus := extractHealthCheckSettings(prov)
 		for _, target := range prov.Proxies() {
 			target := target
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), perProxyHealthCheckTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
 				defer cancel()
-				delay, err := target.URLTest(ctx, url, nil)
+				delay, err := target.URLTest(ctx, url, expectedStatus)
 				if err != nil {
 					onDelay(target.Name(), 0, err.Error())
 					return

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -142,6 +142,42 @@ object Clash {
         }
     }
 
+    /**
+     * Per-proxy health check with push delivery. [onProxyDelay] is invoked
+     * from a JNI thread for each proxy in the group as soon as its URLTest
+     * resolves — call sites that touch UI state must marshal back to the
+     * main thread themselves. The returned deferred completes after every
+     * proxy has reported, or with a ClashException if the group lookup
+     * itself failed (group not found / invalid type).
+     *
+     * Unlike [healthCheck] this avoids a polling loop in the caller: a
+     * single UI patch fires per proxy at its natural resolution time
+     * instead of every poll tick.
+     */
+    fun healthCheckPerProxy(
+        name: String,
+        onProxyDelay: (proxyName: String, delayMs: Int, errMsg: String) -> Unit,
+    ): CompletableDeferred<Unit> {
+        val deferred = CompletableDeferred<Unit>()
+        Bridge.nativeHealthCheckWithCallback(
+            object : ProxyDelayCallback {
+                override fun report(proxyName: String, delayMs: Int, errMsg: String) {
+                    onProxyDelay(proxyName, delayMs, errMsg)
+                }
+
+                override fun complete(error: String?) {
+                    if (error != null) {
+                        deferred.completeExceptionally(ClashException(error))
+                    } else {
+                        deferred.complete(Unit)
+                    }
+                }
+            },
+            name,
+        )
+        return deferred
+    }
+
     fun healthCheckAll() {
         Bridge.nativeHealthCheckAll()
     }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -27,6 +27,7 @@ object Bridge {
     external fun nativeQueryAllGroupNamesIncludingHidden(): String
     external fun nativeQueryGroup(name: String, sort: String): String?
     external fun nativeHealthCheck(completable: CompletableDeferred<Unit>, name: String)
+    external fun nativeHealthCheckWithCallback(callback: ProxyDelayCallback, name: String)
     external fun nativeHealthCheckAll()
     external fun nativePatchSelector(selector: String, name: String): Boolean
     external fun nativeFetchAndValid(

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/ProxyDelayCallback.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/ProxyDelayCallback.kt
@@ -1,0 +1,21 @@
+package com.github.kr328.clash.core.bridge
+
+import androidx.annotation.Keep
+
+/**
+ * Per-proxy delay push for an in-flight health check. The native side fires
+ * [report] once per proxy as soon as the URLTest for that proxy resolves —
+ * UI can patch a single row immediately instead of polling queryProxyGroup.
+ * [complete] fires after every proxy in the group has reported (or the call
+ * was aborted). `error` is null on success, otherwise carries the engine's
+ * reason — e.g. "group not found" or "invalid group type".
+ *
+ * `delayMs` is 0 when [errMsg] is non-empty (the proxy timed out or failed
+ * to connect). Callers should treat (errMsg.isNotEmpty()) as "no signal"
+ * rather than "0ms latency".
+ */
+@Keep
+interface ProxyDelayCallback {
+    fun report(proxyName: String, delayMs: Int, errMsg: String)
+    fun complete(error: String?)
+}

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -986,6 +986,12 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         }
     }
 
+    suspend fun patchSingleProxyDelay(group: String, proxy: String, delayMs: Int) {
+        withContext(Dispatchers.Main) {
+            profileAdapter.patchSingleProxyDelay(group, proxy, delayMs)
+        }
+    }
+
     suspend fun clearProxyDetails() {
         withContext(Dispatchers.Main) {
             profileAdapter.clearProxyDetails()

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -377,6 +377,41 @@ class ProfileAdapter(
         }
     }
 
+    /**
+     * Update a single proxy's delay inside the active profile's live group
+     * map. Receives one push per proxy from the per-proxy health-check path
+     * — bypasses the full setProxyDetails merge so we don't trigger pending /
+     * disk-overlay reconciliation on every URLTest tick.
+     *
+     * No-ops if the proxy or group isn't tracked yet (the live engine map
+     * hasn't been populated for this group, or the active profile changed
+     * between the request and the callback). The caller is responsible for
+     * the eventual full refresh that fills in `now` / `alive` fields the
+     * per-proxy push doesn't carry.
+     */
+    fun patchSingleProxyDelay(groupName: String, proxyName: String, delayMs: Int) {
+        if (groupName.isBlank() || proxyName.isBlank()) return
+        val active = activeProfileUuid ?: return
+        val current = proxyDetails
+        val key = if (current.containsKey(groupName)) {
+            groupName
+        } else {
+            current.entries.firstOrNull { groupsMatchKey(groupName, it.key) }?.key ?: return
+        }
+        val existing = current[key] ?: return
+        val proxyIdx = existing.proxies.indexOfFirst { it.name == proxyName }
+        if (proxyIdx < 0) return
+        if (existing.proxies[proxyIdx].delay == delayMs) return
+        val updatedProxies = existing.proxies.toMutableList().also { list ->
+            list[proxyIdx] = list[proxyIdx].copy(delay = delayMs)
+        }
+        proxyDetails = current.toMutableMap().apply {
+            this[key] = existing.copy(proxies = updatedProxies)
+        }
+        val i = profiles.indexOfFirst { it.uuid == active }
+        if (i >= 0) notifyItemChanged(i)
+    }
+
     fun clearProxyDetails() {
         if (proxyDetails.isEmpty()) return
         proxyDetails = emptyMap()

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -10,6 +10,7 @@ import com.github.kr328.clash.service.model.RequestHistoryRepository
 import com.github.kr328.clash.service.model.RequestHistorySnapshot
 import com.github.kr328.clash.service.remote.IClashManager
 import com.github.kr328.clash.service.remote.ILogObserver
+import com.github.kr328.clash.service.remote.IProxyDelayObserver
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.ProxyHardener
 import com.github.kr328.clash.service.util.sendOverrideChanged
@@ -169,6 +170,23 @@ class ClashManager(private val context: Context) : IClashManager,
 
     override suspend fun healthCheck(group: String) {
         return Clash.healthCheck(group).await()
+    }
+
+    override suspend fun healthCheckPerProxy(group: String, observer: IProxyDelayObserver) {
+        // JNI fires onProxyDelay from arbitrary worker threads. AIDL stubs are
+        // not thread-safe across simultaneous calls, so the observer must
+        // tolerate concurrent onDelay() — IPC marshals them serially through
+        // the binder transaction queue, but a DeadObjectException from a
+        // crashed activity must not kill the whole health-check pipeline.
+        val finalErr: String? = runCatching {
+            Clash.healthCheckPerProxy(group) { name, ms, err ->
+                runCatching { observer.onDelay(group, name, ms, err) }
+            }.await()
+            null
+        }.getOrElse { e ->
+            e.message ?: e::class.simpleName ?: "unknown"
+        }
+        runCatching { observer.onComplete(finalErr) }
     }
 
     override fun healthCheckAll() {

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
@@ -26,6 +26,8 @@ interface IClashManager {
 
     suspend fun healthCheck(group: String)
 
+    suspend fun healthCheckPerProxy(group: String, observer: IProxyDelayObserver)
+
     fun healthCheckAll()
     suspend fun updateProvider(type: Provider.Type, name: String)
 

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProxyDelayObserver.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProxyDelayObserver.kt
@@ -1,0 +1,22 @@
+package com.github.kr328.clash.service.remote
+
+import com.github.kr328.kaidl.BinderInterface
+
+/**
+ * IPC bridge for per-proxy delay push during a health check. ClashService
+ * adapts the JNI [ProxyDelayCallback] into this AIDL observer so the
+ * activity-side coroutine can patch one row at a time without polling
+ * queryProxyGroup on a timer.
+ *
+ * [onDelay] fires once per proxy as soon as its URLTest resolves. When
+ * [errMsg] is empty the call is a success and [delayMs] carries the
+ * measured latency; otherwise the proxy timed out / failed and [delayMs]
+ * is meaningless. [onComplete] fires exactly once after the whole group
+ * has been measured, with [error] carrying the engine reason if the call
+ * couldn't even start (group missing / wrong type).
+ */
+@BinderInterface
+interface IProxyDelayObserver {
+    fun onDelay(group: String, proxy: String, delayMs: Int, errMsg: String)
+    fun onComplete(error: String?)
+}


### PR DESCRIPTION
Move warmUpAutoProxyGroups onto the same event-based delay subscription
the ping-all path already uses. Was: each auto-group fired healthCheck()
as a fire-and-forget batch whose results only reached the UI through the
caller's closing refreshRuntimeGroupDetails — a single staircase of
delays after every group finished. Now: each group's URLTest results
stream into the active card as proxies resolve, so the cold-start
sequence on connect (where users are most likely to watch the pills
populate) shows incremental progress instead of staying blank until the
whole sweep completes.

Extracts the observer-construction boilerplate from the ping-all
consumer into a private runPerProxyHealthCheck helper so warmup and
ping-all share one code path — kills ~40 lines of duplicated object
expression in MainActivity.

Closes the event-based delays epic. Health-check polling is now fully
removed from MainActivity for the engine-ready path.