### PR TITLE
Feat/snapshot cache

### DIFF
--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/mihomo/tunnel"
+	"golang.org/x/sync/errgroup"
 )
 
 // defaultHealthCheckURL is mihomo's stock generate_204 endpoint. Used as a
@@ -23,6 +24,14 @@ const defaultHealthCheckURL = "http://www.gstatic.com/generate_204"
 // mihomo default so behaviour matches a vanilla provider.HealthCheck()
 // for subscriptions that don't override `health-check.timeout`.
 const perProxyHealthCheckTimeout = 5 * time.Second
+
+// perGroupConcurrencyLimit mirrors the cap mihomo's provider.HealthCheck
+// imposes via errgroup.SetLimit(10) in adapter/provider/healthcheck.go.
+// Without it, a group with 100+ proxies fires 100+ simultaneous URLTest
+// goroutines — TLS handshake storming + local socket pressure inflates
+// every reported delay 2-3x compared to the vanilla path. Matching the
+// engine's own cap keeps per-proxy push results comparable.
+const perGroupConcurrencyLimit = 10
 
 // extractHealthCheckSettings pulls the configured health-check timeout and
 // expected-status range out of a ProxyProvider so per-proxy URLTest can
@@ -135,7 +144,11 @@ func HealthCheckWithCallback(
 		return "invalid group type"
 	}
 
-	var wg sync.WaitGroup
+	// Bound concurrent URLTests across the whole group, not per provider —
+	// a kaso-style config can stack several providers behind one group and
+	// each one's leaf count adds to the outgoing socket pressure.
+	eg := new(errgroup.Group)
+	eg.SetLimit(perGroupConcurrencyLimit)
 	for _, prov := range g.Providers() {
 		url := prov.HealthCheckURL()
 		if url == "" {
@@ -149,20 +162,22 @@ func HealthCheckWithCallback(
 		timeout, expectedStatus := extractHealthCheckSettings(prov)
 		for _, target := range prov.Proxies() {
 			target := target
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			url := url
+			timeout := timeout
+			expectedStatus := expectedStatus
+			eg.Go(func() error {
 				ctx, cancel := context.WithTimeout(context.Background(), timeout)
 				defer cancel()
 				delay, err := target.URLTest(ctx, url, expectedStatus)
 				if err != nil {
 					onDelay(target.Name(), 0, err.Error())
-					return
+					return nil
 				}
 				onDelay(target.Name(), int(delay), "")
-			}()
+				return nil
+			})
 		}
 	}
-	wg.Wait()
+	_ = eg.Wait()
 	return ""
 }

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -7,6 +7,7 @@ import com.github.kr328.clash.common.util.SubscriptionOverrides
 import com.github.kr328.clash.common.util.SubscriptionRequestHeaders
 import com.github.kr328.clash.common.util.SubscriptionUsage
 import com.github.kr328.clash.core.Clash
+import com.github.kr328.clash.core.model.ProfileSnapshot
 import com.github.kr328.clash.service.data.Database
 import com.github.kr328.clash.service.data.Imported
 import com.github.kr328.clash.service.data.ImportedDao
@@ -60,6 +61,30 @@ class ProfileManager(private val context: Context) : IProfileManager,
     private val ruleApplyService = RuleApplyService(context)
     private val previewJson = Json { ignoreUnknownKeys = true }
     private val previewCache = LinkedHashMap<String, CachedPreview>()
+
+    /**
+     * In-memory cache of parsed [ProfileSnapshot] keyed by profile UUID.
+     * The dashboard ticker re-queries readProxyGroupsPreview /
+     * readProxyTransports / readProxyEntryYaml on every tick — without
+     * caching, each tick re-runs mihomo's full ParseRawConfig pipeline
+     * over a multi-MB config.yaml, which is the dominant cost on the
+     * service IPC path for users with heavy subscriptions.
+     *
+     * Invalidation is automatic via the config.yaml lastModified
+     * timestamp — subscription updates / re-imports rewrite the file,
+     * the next reader sees a fresh mtime and re-parses. The entry
+     * itself only needs explicit removal on profile delete (memory
+     * hygiene; nothing else reads it after deletion).
+     *
+     * Access guarded by [snapshotCacheLock]. Parse runs *outside* the
+     * lock so concurrent readers of different profiles never block on
+     * each other — a race between two readers of the same profile
+     * just causes a redundant parse (parse is idempotent, last writer
+     * to the map wins).
+     */
+    private data class CachedSnapshot(val lastModified: Long, val snapshot: ProfileSnapshot)
+    private val snapshotCache = LinkedHashMap<UUID, CachedSnapshot>()
+    private val snapshotCacheLock = Any()
     // Serializes nextProfileOrder() + Pending insert pairs. Without it, two concurrent
     // imports (e.g. auto-update + manual click) can both read the same MAX(profileOrder)
     // and produce duplicate ordering values that compare non-deterministically.
@@ -93,6 +118,48 @@ class ProfileManager(private val context: Context) : IProfileManager,
 
             ProfileReceiver.rescheduleAll(context)
         }
+    }
+
+    /**
+     * Return a parsed ProfileSnapshot for [configFile], reusing the cached
+     * one when the file's lastModified hasn't advanced. Callers can hand
+     * this to YAML preview helpers (ProxyGroupsYamlPreview /
+     * ProxyTransportYamlPreview / ProxyYamlPreview) without re-running
+     * mihomo's parser on every dashboard tick.
+     */
+    private fun getOrParseSnapshot(uuid: UUID, configFile: File): ProfileSnapshot {
+        val lastMod = configFile.lastModified()
+        synchronized(snapshotCacheLock) {
+            val cached = snapshotCache[uuid]
+            if (cached != null && cached.lastModified == lastMod) {
+                // LRU touch — promote to most-recently-used.
+                snapshotCache.remove(uuid)
+                snapshotCache[uuid] = cached
+                return cached.snapshot
+            }
+        }
+        val parsed = Clash.parseProfileSnapshot(configFile.parentFile!!)
+        synchronized(snapshotCacheLock) {
+            snapshotCache[uuid] = CachedSnapshot(lastMod, parsed)
+            while (snapshotCache.size > SNAPSHOT_CACHE_MAX) {
+                snapshotCache.remove(snapshotCache.keys.first())
+            }
+        }
+        return parsed
+    }
+
+    private fun invalidateSnapshotCache(uuid: UUID) {
+        synchronized(snapshotCacheLock) {
+            snapshotCache.remove(uuid)
+        }
+    }
+
+    companion object {
+        // Power users may juggle a handful of subscriptions; keep enough
+        // headroom that switching between them stays hot, but bound the
+        // total memory cost — parsed snapshots can reach a few hundred KB
+        // on heavy configs.
+        private const val SNAPSHOT_CACHE_MAX = 4
     }
 
     override suspend fun create(type: Profile.Type, name: String, source: String): UUID {
@@ -406,6 +473,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
         ProfileProcessor.delete(context, uuid)
         BrandRefresh.onProfileDeleted(context, uuid)
         store.clearSubscriptionShareLinksLockedFor(uuid)
+        invalidateSnapshotCache(uuid)
     }
 
     override suspend fun queryByUUID(uuid: UUID): Profile? {
@@ -475,7 +543,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 return@withContext emptyMap()
             }
             try {
-                val snapshot = Clash.parseProfileSnapshot(file.parentFile!!)
+                val snapshot = getOrParseSnapshot(uuid, file)
                 // includeHidden = true: when the live engine path serves the
                 // UI, the picker pills walk every group (visible + hidden) via
                 // Clash.queryAllProxyGroupNamesIncludingHidden, so the offline
@@ -504,7 +572,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 return@withContext emptyMap()
             }
             try {
-                val snapshot = Clash.parseProfileSnapshot(file.parentFile!!)
+                val snapshot = getOrParseSnapshot(uuid, file)
                 ProxyTransportYamlPreview.parse(snapshot, file.parentFile)
             } catch (_: Exception) {
                 emptyMap()
@@ -895,7 +963,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 return@withContext null
             }
             try {
-                val snapshot = Clash.parseProfileSnapshot(file.parentFile!!)
+                val snapshot = getOrParseSnapshot(uuid, file)
                 ProxyYamlPreview.extractProxyEntry(snapshot, proxyName)
             } catch (_: Exception) {
                 null


### PR DESCRIPTION
HealthCheckWithCallback was firing one goroutine per leaf proxy with no
upper bound — on a group with 100+ nodes that's 100+ simultaneous
URLTest calls (TLS handshakes, sockets, DNS lookups). The resulting
local pressure inflated reported delays 2-3x compared to a vanilla
provider.HealthCheck on the same group: a node that legitimately
answers in ~50ms came back as ~150ms because every URLTest was
fighting the others for the local stack.

Match what the engine itself does in adapter/provider/healthcheck.go:
errgroup.Group with SetLimit(10). The cap is group-wide rather than
per-provider because kaso-style configs stack several providers behind
one visible select root, and per-provider limits would still leave the
group as a whole storming the network.

Captured url/timeout/expectedStatus locally per iteration to avoid Go
1.20 loop-variable capture sharing.