### PR TITLE
feat(security): sanitize imported YAML listeners + allow-lan + external-controller

### DIFF
--- a/docs/security-smoke-checklist.md
+++ b/docs/security-smoke-checklist.md
@@ -9,6 +9,36 @@ Run this checklist before cutting a release tag.
 - Verify local listeners remain loopback-only under session overrides.
 - Verify no static auth/secret values are written to profile files after restart.
 
+## Imported YAML hardening (`YamlHardener`)
+
+Import a profile whose `config.yaml` contains a hostile-looking surface — e.g.:
+
+```yaml
+allow-lan: true
+external-controller: 0.0.0.0:9090
+bind-address: '*'
+listeners:
+  - name: leaky-socks
+    type: socks
+    listen: 0.0.0.0
+    port: 1080
+```
+
+After the import completes, open the on-disk `config.yaml` under
+`<filesDir>/clash/profiles/<uuid>/config.yaml` and confirm:
+
+- `listeners:` block is **absent** when hardening mode is `Strict` (default on Android 10+).
+- `listeners:` block keeps every entry with `listen: 127.0.0.1` when hardening mode is `Compat`.
+- `allow-lan` is `false` regardless of mode (when mode != `Off`).
+- `bind-address` is `127.0.0.1`.
+- `external-controller` host is `127.0.0.1` (port preserved).
+- A `config.original.yaml` sibling file exists with the **unmodified** subscription YAML.
+
+Trigger a subscription refresh and re-check: hardening must be re-applied (idempotent),
+and the user's original snapshot in `config.original.yaml` must remain untouched
+from the first import. A custom user-edited listener bound to `127.0.0.1` with
+auth must survive the refresh (see `SubscriptionUpdateMerge.listeners` preservation).
+
 ## Functional regression
 
 - Start/stop VPN five times in a row (no crash, no stuck "starting" state).

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -30,6 +30,16 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
+android {
+    // Stub Android APIs (android.util.Log etc.) called from production code
+    // return default values inside JVM unit tests instead of throwing
+    // "Method X not mocked". Lets YamlHardener / SubscriptionUpdateMerge
+    // tests cover the real production code path including its log lines.
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
 afterEvaluate {
     android {
         libraryVariants.forEach {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -15,6 +15,7 @@ import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.GeoUrlSanitizer
 import com.github.kr328.clash.service.util.RuleApplyService
 import com.github.kr328.clash.service.util.SubscriptionUpdateMerge
+import com.github.kr328.clash.service.util.YamlHardener
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.pendingDir
 import com.github.kr328.clash.service.util.processingDir
@@ -95,6 +96,10 @@ object ProfileProcessor {
                 }
 
                 GeoUrlSanitizer.sanitizeProfile(context.processingDir)
+                YamlHardener.hardenProfile(
+                    context.processingDir,
+                    ServiceStore(context).proxyHardeningMode,
+                )
 
                 withContext(NonCancellable) {
                     profileLock.withLock {
@@ -304,6 +309,10 @@ object ProfileProcessor {
                 }
 
                 GeoUrlSanitizer.sanitizeProfile(context.processingDir)
+                YamlHardener.hardenProfile(
+                    context.processingDir,
+                    ServiceStore(context).proxyHardeningMode,
+                )
 
                 withContext(NonCancellable) {
                     profileLock.withLock {

--- a/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
@@ -32,6 +32,22 @@ class MihomoConfigDocument private constructor(
         return rendered
     }
 
+    /**
+     * Strip the named top-level blocks from the rendered output. Used by
+     * sanitisers that need to *delete* a section (e.g. dropping `listeners:`
+     * outright in security hardening) rather than rewrite it — [renderReplacing]
+     * intentionally short-circuits when the root key is absent, so a plain
+     * `root.remove(key)` followed by replacement render leaves the block
+     * untouched in the source text.
+     */
+    fun renderRemoving(vararg keys: String): String {
+        var rendered = source
+        for (key in keys) {
+            rendered = TopLevelYamlBlockPatcher.remove(text = rendered, key = key)
+        }
+        return rendered
+    }
+
     fun requireSupportedShape() {
         root["rule-providers"]?.let {
             require(it is Map<*, *>) { "Generated rule-providers must be a map" }
@@ -122,6 +138,22 @@ private object TopLevelYamlBlockPatcher {
             }
         }
         return if (lineSeparator == "\r\n") patched.replace("\n", "\r\n") else patched
+    }
+
+    /** Drop the named top-level block from [text] entirely. No-op if absent. */
+    fun remove(text: String, key: String): String {
+        val lineSeparator = if (text.contains("\r\n")) "\r\n" else "\n"
+        val normalized = text.replace("\r\n", "\n")
+        val lines = normalized.split('\n')
+        val range = findBlockRange(lines, key) ?: return text
+        val before = lines.take(range.first).joinToString("\n")
+        val after = lines.drop(range.lastExclusive).joinToString("\n")
+        val joined = when {
+            before.isEmpty() -> after
+            after.isEmpty() -> before
+            else -> "$before\n$after"
+        }
+        return if (lineSeparator == "\r\n") joined.replace("\n", "\r\n") else joined
     }
 
     private fun appendBlock(text: String, replacement: String): String {

--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -15,6 +15,15 @@ object SubscriptionUpdateMerge {
         val rules: Any?,
         val proxyProviders: Any?,
         val proxyGroups: Any?,
+        /**
+         * User-authored entries from the top-level `listeners:` block.
+         * Carried across subscription refreshes so an advanced user who
+         * configured e.g. an authenticated local SOCKS doesn't lose it on
+         * every fetch. YamlHardener still runs afterwards, so the
+         * loopback-only invariants stay enforced even if the preserved
+         * entries originally bound to a remote interface.
+         */
+        val listeners: Any? = null,
     ) {
         fun isEmpty(): Boolean {
             val rpEmpty =
@@ -24,11 +33,12 @@ object SubscriptionUpdateMerge {
                 proxyProviders == null || (proxyProviders is Map<*, *> && proxyProviders.isEmpty())
             val pgEmpty =
                 proxyGroups == null || (proxyGroups is List<*> && proxyGroups.isEmpty())
-            return rpEmpty && rEmpty && ppEmpty && pgEmpty
+            val lEmpty = listeners == null || (listeners is List<*> && listeners.isEmpty())
+            return rpEmpty && rEmpty && ppEmpty && pgEmpty && lEmpty
         }
 
         companion object {
-            val EMPTY = PreservedOverlay(null, null, null, null)
+            val EMPTY = PreservedOverlay(null, null, null, null, null)
         }
     }
 
@@ -48,8 +58,12 @@ object SubscriptionUpdateMerge {
             ?.let { JsonElementToYaml.convertObjectMap(it) }
         val pg = snapshot.proxyGroups.takeIf { it.isNotEmpty() }
             ?.let { JsonElementToYaml.convertObjectList(it) }
-        if (rp == null && rules == null && pp == null && pg == null) return PreservedOverlay.EMPTY
-        return PreservedOverlay(rp, rules, pp, pg)
+        val listeners = snapshot.listeners.takeIf { it.isNotEmpty() }
+            ?.let { JsonElementToYaml.convertObjectList(it) }
+        if (rp == null && rules == null && pp == null && pg == null && listeners == null) {
+            return PreservedOverlay.EMPTY
+        }
+        return PreservedOverlay(rp, rules, pp, pg, listeners)
     }
 
     /**
@@ -73,6 +87,9 @@ object SubscriptionUpdateMerge {
         if (preserved.proxyGroups != null) {
             root["proxy-groups"] = mergeProxyGroupsLists(root, preserved, profileDir)
         }
+        if (preserved.listeners != null) {
+            root["listeners"] = mergeListenersLists(root["listeners"], preserved.listeners)
+        }
         // Garbage-collect providers nothing references. After overlaying the
         // pre-fetch state on top of the fresh subscription, a rule-provider
         // may exist that no `RULE-SET,name,...` rule mentions, or a
@@ -83,7 +100,35 @@ object SubscriptionUpdateMerge {
         // must be re-added too.
         gcUnusedRuleProviders(root)
         gcUnusedProxyProviders(root)
-        return document.renderReplacing("rule-providers", "rules", "proxy-providers", "proxy-groups")
+        return document.renderReplacing(
+            "rule-providers",
+            "rules",
+            "proxy-providers",
+            "proxy-groups",
+            "listeners",
+        )
+    }
+
+    /**
+     * Union fetched + preserved listener entries on `name` (mihomo's
+     * identity key for listeners). Preserved entries override fetched
+     * ones — local edits win — but unknown listeners shipped with the
+     * subscription are still kept. YamlHardener.hardenProfile runs after
+     * the merge so any non-loopback bind ultimately gets sanitised.
+     */
+    private fun mergeListenersLists(fetched: Any?, preserved: Any?): Any? {
+        val fetchedList = fetched as? List<*> ?: emptyList<Any?>()
+        val preservedList = preserved as? List<*> ?: emptyList<Any?>()
+        if (preservedList.isEmpty()) return fetched
+        val byName = LinkedHashMap<String, Any?>()
+        val anonymous = mutableListOf<Any?>()
+        fun add(entry: Any?) {
+            val name = (entry as? Map<*, *>)?.get("name")?.toString()
+            if (name.isNullOrBlank()) anonymous.add(entry) else byName[name] = entry
+        }
+        fetchedList.forEach(::add)
+        preservedList.forEach(::add)
+        return byName.values.toMutableList<Any?>().apply { addAll(anonymous) }
     }
 
     /**

--- a/service/src/main/java/com/github/kr328/clash/service/util/YamlHardener.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/YamlHardener.kt
@@ -1,0 +1,235 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.common.log.Log
+import com.github.kr328.clash.service.model.ProxyHardeningMode
+import java.io.File
+
+/**
+ * Sanitises an imported / refreshed `config.yaml` at the filesystem level
+ * before mihomo loads it. Closes the leak window left by [ProxyHardener]:
+ * that one only rewrites global ports via [ConfigurationOverride], so a
+ * subscription can still expose an unauthenticated SOCKS5/HTTP listener
+ * to the LAN through the YAML `listeners:` block — bypassing Strict mode
+ * entirely. This file-level pass covers the same surface the engine
+ * actually reads.
+ *
+ * Targets (per [ProxyHardeningMode.Strict]):
+ *  - `listeners:` — dropped wholesale. Custom listener configs are an
+ *    advanced power-user feature; ClashFest's contract is TUN-only.
+ *  - `allow-lan: true` — forced to `false`. LAN exposure is never the
+ *    default for a security-first client.
+ *  - `bind-address: <non-loopback>` — rewritten to `127.0.0.1`.
+ *  - `external-controller: <non-loopback>:port` — host rewritten to
+ *    `127.0.0.1`, port preserved.
+ *
+ * [ProxyHardeningMode.Compat] keeps `listeners:` but force-binds each
+ * entry to `127.0.0.1` so it never advertises to the network even if the
+ * subscription set `listen: 0.0.0.0`. allow-lan and external-controller
+ * follow the same loopback rules as Strict.
+ *
+ * [ProxyHardeningMode.Off] is a true no-op — used only by users who
+ * explicitly opt out via the UI.
+ *
+ * AGENTS.md requires that hardening changes preserve the user's original
+ * YAML at `config.original.yaml`; this writer creates that copy on the
+ * first transformation only (subsequent runs find it already there and
+ * leave it untouched). Re-running the hardener on already-clean YAML is
+ * a no-op, both on disk and in the returned text.
+ */
+object YamlHardener {
+    private const val ORIGINAL_FILENAME = "config.original.yaml"
+
+    /**
+     * Apply the requested [mode] to `config.yaml` inside [profileDir].
+     *
+     * @return true if the file was rewritten (and `config.original.yaml`
+     *         was created if it didn't exist yet).
+     */
+    fun hardenProfile(profileDir: File, mode: ProxyHardeningMode): Boolean {
+        if (mode == ProxyHardeningMode.Off) return false
+        val configFile = File(profileDir, "config.yaml")
+        if (!configFile.isFile) return false
+
+        val original = try {
+            configFile.readText()
+        } catch (e: Exception) {
+            Log.w("YamlHardener: failed to read ${configFile.absolutePath}: ${e.message}", e)
+            return false
+        }
+        val hardened = hardenYaml(original, mode) ?: return false
+        if (hardened == original) return false
+
+        // Preserve the user's YAML on the first hardening run only — later
+        // runs (e.g. subscription refresh) must not overwrite the snapshot
+        // we made of the unmodified subscription.
+        val originalFile = File(profileDir, ORIGINAL_FILENAME)
+        if (!originalFile.isFile) {
+            try {
+                originalFile.writeText(original)
+            } catch (e: Exception) {
+                Log.w("YamlHardener: failed to save ${originalFile.absolutePath}: ${e.message}", e)
+                // Continue — the original is recoverable via the subscription
+                // URL even if we couldn't snapshot it locally.
+            }
+        }
+
+        return try {
+            configFile.writeText(hardened)
+            Log.i("YamlHardener: applied $mode hardening to ${configFile.absolutePath}")
+            true
+        } catch (e: Exception) {
+            Log.w("YamlHardener: failed to write ${configFile.absolutePath}: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * Returns hardened YAML for [text]. `null` if [text] doesn't parse as
+     * a top-level map; identical-to-input string if the document was
+     * already clean.
+     *
+     * Exposed for unit tests and for callers that operate on in-memory
+     * YAML (e.g. subscription merge before write).
+     */
+    fun hardenYaml(text: String, mode: ProxyHardeningMode): String? {
+        if (mode == ProxyHardeningMode.Off) return text
+        val document = MihomoConfigDocument.parse(text) ?: return null
+        val root = document.root
+        var changed = false
+        // listeners hardening is a *removal* in Strict — the model mutation
+        // does root.remove("listeners"), which renderReplacing intentionally
+        // skips. Track it separately so the renderer can strip the block
+        // from the source text via renderRemoving.
+        var dropListenersFromSource = false
+
+        when (val listenersChange = hardenListeners(root, mode)) {
+            ListenersChange.None -> Unit
+            ListenersChange.Rewritten -> changed = true
+            ListenersChange.Dropped -> {
+                changed = true
+                dropListenersFromSource = true
+            }
+        }
+        changed = forceFalse(root, "allow-lan") || changed
+        changed = forceLoopbackHost(root, "bind-address") || changed
+        changed = forceLoopbackHostPort(root, "external-controller") || changed
+
+        if (!changed) return text
+
+        var rendered = document.renderReplacing(
+            "listeners",
+            "allow-lan",
+            "bind-address",
+            "external-controller",
+        )
+        if (dropListenersFromSource) {
+            rendered = MihomoConfigDocument.parseOrEmpty(rendered).let {
+                // Re-render through the cleaner so the second pass produces
+                // a document with the listeners block actually stripped.
+                it.renderRemoving("listeners")
+            }
+        }
+        return rendered
+    }
+
+    private enum class ListenersChange { None, Rewritten, Dropped }
+
+    /**
+     * Strict drops the whole `listeners:` block. Compat rewrites every
+     * entry's `listen:` to a loopback bind. Off never runs.
+     */
+    private fun hardenListeners(root: MutableMap<String, Any?>, mode: ProxyHardeningMode): ListenersChange {
+        val listeners = root["listeners"] as? List<*> ?: return ListenersChange.None
+        if (listeners.isEmpty()) {
+            // Empty `listeners: []` block is harmless; leave it untouched
+            // rather than churning the YAML signature.
+            return ListenersChange.None
+        }
+        return when (mode) {
+            ProxyHardeningMode.Off -> ListenersChange.None
+            ProxyHardeningMode.Strict -> {
+                root.remove("listeners")
+                Log.i("YamlHardener: dropped ${listeners.size} listener entries (Strict)")
+                ListenersChange.Dropped
+            }
+            ProxyHardeningMode.Compat -> {
+                val rewritten = listeners.map { sanitizeListenerEntry(it) }
+                if (rewritten == listeners) return ListenersChange.None
+                root["listeners"] = rewritten
+                Log.i("YamlHardener: rebound ${listeners.size} listener entries to loopback (Compat)")
+                ListenersChange.Rewritten
+            }
+        }
+    }
+
+    /** Force a listener entry's `listen:` to a loopback bind. Other keys untouched. */
+    private fun sanitizeListenerEntry(entry: Any?): Any? {
+        val map = entry as? Map<*, *> ?: return entry
+        val current = map["listen"]?.toString()
+        if (current != null && isLoopbackBind(current)) return entry
+        val mutable = LinkedHashMap<String, Any?>(map.size)
+        for ((k, v) in map) mutable[k.toString()] = v
+        mutable["listen"] = rewriteListenToLoopback(current)
+        return mutable
+    }
+
+    private fun forceFalse(root: MutableMap<String, Any?>, key: String): Boolean {
+        val current = root[key]
+        if (current == false) return false
+        // Absent allow-lan defaults to false in mihomo, so don't write it
+        // unless the file explicitly opted in.
+        if (current == null) return false
+        root[key] = false
+        return true
+    }
+
+    private fun forceLoopbackHost(root: MutableMap<String, Any?>, key: String): Boolean {
+        val raw = root[key]?.toString()?.trim() ?: return false
+        if (raw.isEmpty()) return false
+        if (isLoopbackHost(raw)) return false
+        root[key] = "127.0.0.1"
+        return true
+    }
+
+    /**
+     * Rewrites a `host:port` entry so the host portion is loopback. Used
+     * for `external-controller` which would otherwise expose the RESTful
+     * API + dashboard to the LAN.
+     */
+    private fun forceLoopbackHostPort(root: MutableMap<String, Any?>, key: String): Boolean {
+        val raw = root[key]?.toString()?.trim() ?: return false
+        if (raw.isEmpty()) return false
+        val rewritten = rewriteListenToLoopback(raw)
+        if (rewritten == raw) return false
+        root[key] = rewritten
+        return true
+    }
+
+    /**
+     * Accepts both `host:port` and bare `:port`. Returns input untouched
+     * when host is already loopback; otherwise replaces the host token.
+     */
+    private fun rewriteListenToLoopback(value: String?): String {
+        val raw = value?.trim().orEmpty()
+        if (raw.isEmpty()) return "127.0.0.1"
+        if (raw.startsWith(":")) return "127.0.0.1$raw"
+        val colon = raw.lastIndexOf(':')
+        val (host, port) = if (colon < 0) raw to "" else raw.substring(0, colon) to raw.substring(colon)
+        if (isLoopbackHost(host)) return raw
+        return "127.0.0.1$port"
+    }
+
+    private fun isLoopbackBind(value: String): Boolean {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) return false
+        if (trimmed.startsWith(":")) return false
+        val colon = trimmed.lastIndexOf(':')
+        val host = if (colon < 0) trimmed else trimmed.substring(0, colon)
+        return isLoopbackHost(host)
+    }
+
+    private fun isLoopbackHost(host: String): Boolean {
+        val h = host.trim().trim('[', ']').lowercase()
+        return h == "127.0.0.1" || h == "::1" || h == "localhost"
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
@@ -18,11 +18,13 @@ class SubscriptionUpdateMergeTest {
         ruleProviders: Map<String, JsonObject> = emptyMap(),
         proxyProviders: Map<String, JsonObject> = emptyMap(),
         proxyGroups: List<JsonObject> = emptyList(),
+        listeners: List<JsonObject> = emptyList(),
     ) = ProfileSnapshot(
         rules = rules,
         ruleProviders = ruleProviders,
         proxyProviders = proxyProviders,
         proxyGroups = proxyGroups,
+        listeners = listeners,
     )
 
     private fun jsonObj(vararg pairs: Pair<String, JsonElement>): JsonObject =
@@ -336,5 +338,66 @@ class SubscriptionUpdateMergeTest {
             "logical AND should be dropped during subscription merge per policy",
             merged.contains("AND,((NETWORK,UDP),(DST-PORT,53)),DIRECT"),
         )
+    }
+
+    @Test
+    fun extractPreserved_carriesListenersFromSnapshot() {
+        val preserved = SubscriptionUpdateMerge.extractPreserved(
+            snapshot(listeners = listOf(
+                jsonObj(
+                    "name" to JsonPrimitive("local-socks"),
+                    "type" to JsonPrimitive("socks"),
+                    "listen" to JsonPrimitive("127.0.0.1"),
+                    "port" to JsonPrimitive(1080),
+                ),
+            )),
+        )
+        assertNotNull(preserved.listeners)
+        @Suppress("UNCHECKED_CAST")
+        val list = preserved.listeners as List<Any?>
+        assertEquals(1, list.size)
+        @Suppress("UNCHECKED_CAST")
+        val entry = list[0] as Map<String, Any?>
+        assertEquals("local-socks", entry["name"])
+        assertEquals(1080L, entry["port"])
+    }
+
+    @Test
+    fun mergeAfterFetch_preservesLocalListenersAcrossRefresh() {
+        // User added a custom listener with auth — subscription refresh ships a
+        // YAML without listeners. The pre-fetch snapshot must carry it over so
+        // the user's edit isn't silently wiped. YamlHardener runs after this
+        // merge and would force any non-loopback bind to 127.0.0.1, so it's
+        // safe to merge first and harden later.
+        val preserved = SubscriptionUpdateMerge.extractPreserved(
+            snapshot(listeners = listOf(
+                jsonObj(
+                    "name" to JsonPrimitive("user-mixed"),
+                    "type" to JsonPrimitive("mixed"),
+                    "listen" to JsonPrimitive("127.0.0.1"),
+                    "port" to JsonPrimitive(7890),
+                    "users" to JsonPrimitive("redacted"),
+                ),
+            )),
+        )
+
+        val fetched = """
+            mixed-port: 0
+            proxies:
+              - name: node-a
+                type: ss
+                server: 1.2.3.4
+                port: 8388
+                cipher: aes-256-gcm
+                password: x
+        """.trimIndent()
+
+        val merged = SubscriptionUpdateMerge.mergeAfterFetch(fetched, preserved)
+        assertTrue(
+            "merged config must keep user's listener entry, was:\n$merged",
+            merged.contains("user-mixed"),
+        )
+        assertTrue(merged.contains("listen: 127.0.0.1"))
+        assertTrue(merged.contains("port: 7890"))
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
@@ -1,0 +1,230 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.service.model.ProxyHardeningMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class YamlHardenerTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private fun parse(yaml: String): Map<String, Any?> {
+        return YamlFormatting.parseRootMap(yaml) ?: error("not a YAML map")
+    }
+
+    // -- in-memory hardenYaml ---------------------------------------------
+
+    @Test
+    fun strict_dropsListenersBlock() {
+        val input = """
+            listeners:
+              - name: leaky
+                type: socks
+                listen: 0.0.0.0
+                port: 1080
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        val root = parse(hardened!!)
+        assertNull("Strict must remove the entire listeners block", root["listeners"])
+    }
+
+    @Test
+    fun compat_rebindsListenersToLoopback() {
+        val input = """
+            listeners:
+              - name: lan-socks
+                type: socks
+                listen: 0.0.0.0
+                port: 1080
+              - name: ipv6-any
+                type: http
+                listen: '[::]:8080'
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Compat)
+        assertNotNull(hardened)
+        val root = parse(hardened!!)
+        val listeners = root["listeners"] as? List<*> ?: error("listeners must survive Compat")
+        assertEquals("Compat keeps every listener, just rewrites listen", 2, listeners.size)
+        val first = listeners[0] as Map<*, *>
+        assertEquals("127.0.0.1", first["listen"])
+        // Port and other fields untouched.
+        assertEquals(1080, first["port"])
+        assertEquals("lan-socks", first["name"])
+    }
+
+    @Test
+    fun off_isFullNoop() {
+        val input = """
+            listeners:
+              - name: leaky
+                type: socks
+                listen: 0.0.0.0
+            allow-lan: true
+            external-controller: 0.0.0.0:9090
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Off)
+        // Off must return the original text, no parse, no transform.
+        assertEquals(input, hardened)
+    }
+
+    @Test
+    fun strict_forcesAllowLanFalseWhenExplicitlyTrue() {
+        val input = """
+            allow-lan: true
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        assertEquals(false, parse(hardened!!)["allow-lan"])
+    }
+
+    @Test
+    fun strict_leavesAbsentAllowLanAlone() {
+        // mihomo defaults allow-lan to false when absent. Touching the file
+        // just to write the same default would churn the signature cache
+        // and produce a misleading "modified" event for the user.
+        val input = """
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertEquals(input, hardened)
+    }
+
+    @Test
+    fun strict_rewritesExternalControllerHostToLoopback() {
+        val input = """
+            external-controller: 0.0.0.0:9090
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        assertEquals("127.0.0.1:9090", parse(hardened!!)["external-controller"])
+    }
+
+    @Test
+    fun strict_rewritesExternalControllerBarePort() {
+        val input = """
+            external-controller: ':9090'
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        assertEquals("127.0.0.1:9090", parse(hardened!!)["external-controller"])
+    }
+
+    @Test
+    fun strict_keepsLoopbackExternalControllerUntouched() {
+        val input = """
+            external-controller: 127.0.0.1:9090
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertEquals(input, hardened)
+    }
+
+    @Test
+    fun strict_rewritesBindAddressToLoopback() {
+        val input = """
+            bind-address: '*'
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        assertEquals("127.0.0.1", parse(hardened!!)["bind-address"])
+    }
+
+    @Test
+    fun isIdempotent_secondPassNoChange() {
+        val dirty = """
+            listeners:
+              - name: leaky
+                type: socks
+                listen: 0.0.0.0
+                port: 1080
+            allow-lan: true
+            external-controller: 0.0.0.0:9090
+        """.trimIndent()
+        val first = YamlHardener.hardenYaml(dirty, ProxyHardeningMode.Strict)
+        assertNotNull(first)
+        val second = YamlHardener.hardenYaml(first!!, ProxyHardeningMode.Strict)
+        assertEquals("re-running hardener on clean YAML must be a no-op", first, second)
+    }
+
+    @Test
+    fun returnsNullOnUnparseableInput() {
+        assertNull(YamlHardener.hardenYaml("not a map - just a string", ProxyHardeningMode.Strict))
+    }
+
+    // -- on-disk hardenProfile + config.original.yaml ---------------------
+
+    @Test
+    fun hardenProfile_savesOriginalOnceAndRewritesConfig() {
+        val profile = tmp.newFolder("profile-1")
+        val original = """
+            listeners:
+              - name: leaky
+                type: socks
+                listen: 0.0.0.0
+            proxies: []
+        """.trimIndent()
+        File(profile, "config.yaml").writeText(original)
+
+        val changed = YamlHardener.hardenProfile(profile, ProxyHardeningMode.Strict)
+        assertTrue("first run must report a change", changed)
+
+        val originalFile = File(profile, "config.original.yaml")
+        assertTrue("config.original.yaml must be created", originalFile.isFile)
+        assertEquals(original, originalFile.readText())
+
+        val cfgText = File(profile, "config.yaml").readText()
+        assertFalse("listeners must be stripped on disk", cfgText.contains("listen: 0.0.0.0"))
+    }
+
+    @Test
+    fun hardenProfile_keepsOriginalAcrossSubsequentRuns() {
+        // First import saves original. A later subscription update writes a
+        // fresh subscription YAML; YamlHardener must not overwrite the
+        // pre-existing original.yaml — the user's first snapshot of the
+        // subscription is the audit trail we never want to clobber.
+        val profile = tmp.newFolder("profile-2")
+        val firstImport = "listeners:\n  - name: a\n    listen: 0.0.0.0\n"
+        File(profile, "config.yaml").writeText(firstImport)
+        YamlHardener.hardenProfile(profile, ProxyHardeningMode.Strict)
+        val originalAfterFirst = File(profile, "config.original.yaml").readText()
+        assertEquals(firstImport, originalAfterFirst)
+
+        // Simulate refresh: fresh subscription replaces config.yaml.
+        val secondImport = "listeners:\n  - name: b\n    listen: 0.0.0.0\n"
+        File(profile, "config.yaml").writeText(secondImport)
+        YamlHardener.hardenProfile(profile, ProxyHardeningMode.Strict)
+        assertEquals(
+            "original.yaml must reflect the very first import, not later refreshes",
+            firstImport,
+            File(profile, "config.original.yaml").readText(),
+        )
+    }
+
+    @Test
+    fun hardenProfile_offModeIsNoOp() {
+        val profile = tmp.newFolder("profile-off")
+        val original = "listeners:\n  - name: leaky\n    listen: 0.0.0.0\n"
+        File(profile, "config.yaml").writeText(original)
+
+        val changed = YamlHardener.hardenProfile(profile, ProxyHardeningMode.Off)
+        assertFalse("Off must not rewrite the file", changed)
+        assertFalse(
+            "Off must not create the original snapshot — there's nothing to back up",
+            File(profile, "config.original.yaml").isFile,
+        )
+        assertEquals(original, File(profile, "config.yaml").readText())
+    }
+}


### PR DESCRIPTION


ProxyHardener only rewrites global ports via ConfigurationOverride — the YAML `listeners:` block, `allow-lan: true`, and a non-loopback `external-controller` slip past it and let a hostile subscription expose an unauthenticated SOCKS5/HTTP listener on the LAN, bypassing Strict hardening entirely (P0 from Jules' review).

YamlHardener applies a file-level pass on `config.yaml` right after GeoUrlSanitizer in both the import and the subscription-update paths. Strict drops the listeners block wholesale; Compat keeps every entry but force-binds its listen to 127.0.0.1. allow-lan is forced false when the file explicitly opted in (absent default left alone), bind-address and external-controller are rewritten to loopback. config.original.yaml is snapshotted on the first hardening run only — per AGENTS.md the user's unmodified subscription stays recoverable. Idempotent: re-running on already-clean YAML is a no-op.

SubscriptionUpdateMerge.PreservedOverlay learns about listeners so a user-edited entry (e.g. an authenticated local SOCKS) survives a subscription refresh; YamlHardener still runs afterwards so any non-loopback bind a preserved entry happened to carry gets sanitised on the way out (P2 of the same review).