### PR TITLE
perf(connections): adapt snapshot poll interval to live connection count

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ConnectionsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ConnectionsActivity.kt
@@ -29,10 +29,17 @@ class ConnectionsActivity : BaseActivity<ConnectionsDesign>() {
 
         val refresh = launch {
             var lastRawSnapshot: String? = null
-            val activeDelayMs = 2000L
+            // Base interval for a quiet device with a handful of connections.
+            val baseDelayMs = 2000L
             // Bumped from 7s -> 30s. While the activity is in background or screen is off,
             // the live list is invisible; reduce wakeups and avoid pulling JSON snapshots.
             val idleDelayMs = 30_000L
+            // Last observed connection count — drives the adaptive throttle on the
+            // next iteration so a torrenting user (hundreds of live connections)
+            // doesn't burn CPU/GC reparsing a multi-MB JSON every 2s. Updated only
+            // when the snapshot actually decoded, so transient parse failures
+            // don't shrink the interval back to the base.
+            var lastConnectionCount = 0
             while (isActive) {
                 val interactive = getSystemService<PowerManager>()?.isInteractive ?: true
                 if (!activityStarted || !interactive) {
@@ -43,7 +50,7 @@ class ConnectionsActivity : BaseActivity<ConnectionsDesign>() {
                 try {
                     val raw = withClash { queryConnectionsSnapshot() }
                     if (raw == lastRawSnapshot) {
-                        delay(activeDelayMs)
+                        delay(scaledDelayFor(baseDelayMs, lastConnectionCount))
                         continue
                     }
                     lastRawSnapshot = raw
@@ -59,12 +66,13 @@ class ConnectionsActivity : BaseActivity<ConnectionsDesign>() {
                         if (snap.connections.isEmpty() && raw.length > 64) {
                             Log.w("Connections snapshot parsed but empty list; raw size=${raw.length}")
                         }
+                        lastConnectionCount = snap.connections.size
                         design.patchSnapshot(snap)
                     }
                 } catch (e: Exception) {
                     Log.w("Connections refresh query failed", e)
                 }
-                delay(activeDelayMs)
+                delay(scaledDelayFor(baseDelayMs, lastConnectionCount))
             }
         }
 
@@ -122,5 +130,20 @@ class ConnectionsActivity : BaseActivity<ConnectionsDesign>() {
         } finally {
             refresh.cancel()
         }
+    }
+
+    /**
+     * Adaptive snapshot interval. For a handful of connections we stay at
+     * the base 2s (the list stays "live"); above the user-visible noise
+     * floor we slow down so the JSON payload + parse stop being a hot
+     * loop on CPU/GC. Thresholds were picked empirically: torrenting
+     * sessions easily hit 200+ live connections, sustained P2P / scraping
+     * workloads cross 500. Snapshots above that no longer feel "live" to
+     * a human reader either way, so the slower cadence isn't a UX loss.
+     */
+    private fun scaledDelayFor(baseDelayMs: Long, connectionCount: Int): Long = when {
+        connectionCount > 500 -> baseDelayMs * 4
+        connectionCount > 200 -> baseDelayMs * 2
+        else -> baseDelayMs
     }
 }


### PR DESCRIPTION
ConnectionsActivity polled queryConnectionsSnapshot every 2s while interactive regardless of size. On a torrenting / scraping session with hundreds of live connections the raw JSON crosses megabytes and the decode (kotlinx.serialization on Dispatchers.Default) becomes a hot loop on CPU and GC. Past ~200 connections the list also stops feeling live to a human reader — frames change too fast to follow — so the extra cost has no UX upside (P2 from Jules' review).

Track the last successful snapshot size and scale the next poll interval off it: 2s up to 200 connections (unchanged for the typical case), 4s up to 500, 8s above. Falls back to the base interval when the core hasn't reported a size yet so a fresh activity always starts responsive. Transient parse failures keep the previous count instead of dropping the throttle back to base — flaky decodes don't widen the CPU window.

Idle path (screen off / activity not started) and the lastRawSnapshot skip are untouched. Event-driven reloads (close connection, etc.) stay immediate.