### PR TITLE
fix(app): harden external VPN control + fix hidden-icon startup crash (SEC-3, BUG-3/4/5)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,15 +85,15 @@
                 <data android:host="installconfig"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="com.github.metacubex.clash.meta.action.START_CLASH" />
+                <action android:name="${applicationId}.action.START_CLASH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
-                <action android:name="com.github.metacubex.clash.meta.action.STOP_CLASH" />
+                <action android:name="${applicationId}.action.STOP_CLASH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
-                <action android:name="com.github.metacubex.clash.meta.action.TOGGLE_CLASH" />
+                <action android:name="${applicationId}.action.TOGGLE_CLASH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -5,12 +5,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.github.kr328.clash.common.constants.Intents
+import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.common.util.intent
 import com.github.kr328.clash.common.util.setUUID
 import com.github.kr328.clash.design.MainDesign
 import com.github.kr328.clash.design.ui.ToastDuration
-import com.github.kr328.clash.remote.Remote
 import com.github.kr328.clash.remote.StatusClient
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.util.startClashService
@@ -53,25 +56,28 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
                 }
             }
 
-            Intents.ACTION_TOGGLE_CLASH -> if(Remote.broadcasts.clashRunning) {
-                stopClash()
-            }
-            else {
-                startClash()
-            }
-
-            Intents.ACTION_START_CLASH -> if(!Remote.broadcasts.clashRunning) {
-                startClash()
-            }
-            else {
-                Toast.makeText(this, R.string.external_control_started, Toast.LENGTH_LONG).show()
+            Intents.ACTION_TOGGLE_CLASH -> if (externalControlAllowed()) {
+                if (isServiceRunning()) {
+                    stopClash()
+                } else {
+                    startClash()
+                }
             }
 
-            Intents.ACTION_STOP_CLASH -> if(Remote.broadcasts.clashRunning) {
-                stopClash()
+            Intents.ACTION_START_CLASH -> if (externalControlAllowed()) {
+                if (!isServiceRunning()) {
+                    startClash()
+                } else {
+                    Toast.makeText(this, R.string.external_control_started, Toast.LENGTH_LONG).show()
+                }
             }
-            else {
-                Toast.makeText(this, R.string.external_control_stopped, Toast.LENGTH_LONG).show()
+
+            Intents.ACTION_STOP_CLASH -> if (externalControlAllowed()) {
+                if (isServiceRunning()) {
+                    stopClash()
+                } else {
+                    Toast.makeText(this, R.string.external_control_stopped, Toast.LENGTH_LONG).show()
+                }
             }
         }
         return finish()
@@ -93,6 +99,57 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
     private fun stopClash() {
         stopClashService()
         Toast.makeText(this, R.string.external_control_stopped, Toast.LENGTH_LONG).show()
+        // SEC-3: an external stop must never be silent — let the user know the
+        // VPN was stopped by something other than their own action.
+        notifyExternalStop()
+    }
+
+    /**
+     * Fresh, authoritative running state via the status ContentProvider —
+     * unlike Remote.broadcasts.clashRunning, this is never stale when the
+     * activity is (cold-)started by an external intent, so external
+     * START/STOP/TOGGLE act on the real VPN state.
+     */
+    private fun isServiceRunning(): Boolean =
+        StatusClient(this).statusSnapshot().serviceRunning
+
+    /**
+     * SEC-3 gate. External control actions are honored only when the user has
+     * not disabled them. When disabled, give brief feedback and do nothing.
+     */
+    private fun externalControlAllowed(): Boolean {
+        if (ServiceStore(this).allowExternalControl) return true
+        Toast.makeText(this, R.string.external_control_disabled, Toast.LENGTH_LONG).show()
+        return false
+    }
+
+    private fun notifyExternalStop() {
+        val manager = NotificationManagerCompat.from(this)
+        // Best-effort: on Android 13+ without POST_NOTIFICATIONS this is a no-op;
+        // the allow-external-control setting is the guaranteed control.
+        if (!manager.areNotificationsEnabled()) return
+
+        manager.createNotificationChannel(
+            NotificationChannelCompat.Builder(
+                EXTERNAL_STOP_CHANNEL_ID,
+                NotificationManagerCompat.IMPORTANCE_DEFAULT,
+            ).setName(getString(R.string.external_stop_channel)).build()
+        )
+
+        val notification = NotificationCompat.Builder(this, EXTERNAL_STOP_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_warning)
+            .setContentTitle(getString(R.string.external_stop_title))
+            .setContentText(getString(R.string.external_stop_text))
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .build()
+
+        manager.notify(EXTERNAL_STOP_NOTIFICATION_ID, notification)
+    }
+
+    private companion object {
+        const val EXTERNAL_STOP_CHANNEL_ID = "external_control_channel"
+        const val EXTERNAL_STOP_NOTIFICATION_ID = 0x4543 // 'EC'
     }
 
     override fun finish() {

--- a/app/src/main/java/com/github/kr328/clash/MainApplication.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainApplication.kt
@@ -100,7 +100,15 @@ class MainApplication : Application() {
             .setRank(2)
             .build()
 
-        ShortcutManagerCompat.setDynamicShortcuts(this, listOf(toggle, start, stop))
+        // Dynamic shortcuts are a convenience and MUST NOT crash app startup.
+        // When the launcher icon is hidden (MainActivityAlias disabled) the
+        // package has no launcher activity and setDynamicShortcuts throws
+        // IllegalStateException("Launcher activity not found") — swallow it.
+        runCatching {
+            ShortcutManagerCompat.setDynamicShortcuts(this, listOf(toggle, start, stop))
+        }.onFailure {
+            Log.w("setupShortcuts: skipped dynamic shortcuts (no launcher activity?)", it)
+        }
     }
 
 }

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -100,6 +100,13 @@ class AppSettingsDesign(
             ) {
                 enabled = !running
             }
+
+            switch(
+                value = srvStore::allowExternalControl,
+                icon = R.drawable.ic_baseline_stack,
+                title = R.string.allow_external_control_title,
+                summary = R.string.allow_external_control_summary,
+            )
         }
 
         binding.content.addView(screen.root)

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -782,6 +782,12 @@
     <string name="external_control_activity">External Control</string>
     <string name="external_control_started">Clash.Meta service started</string>
     <string name="external_control_stopped">Clash.Meta service stopped</string>
+    <string name="allow_external_control_title">Разрешить внешнее управление</string>
+    <string name="allow_external_control_summary">Позволяет другим приложениям запускать, останавливать и переключать VPN (например, Tasker, ярлыки). Когда выключено — внешние запросы игнорируются.</string>
+    <string name="external_control_disabled">Внешнее управление отключено</string>
+    <string name="external_stop_channel">Внешнее управление</string>
+    <string name="external_stop_title">VPN остановлен</string>
+    <string name="external_stop_text">VPN был остановлен внешним запросом</string>
     <string name="force_dns_mapping">Force DNS Mapping</string>
     <string name="parse_pure_ip">Parse Pure IP</string>
     <string name="override_destination">Override Destination</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -328,6 +328,12 @@
     <string name="external_control_activity">外部控制</string>
     <string name="external_control_started">Clash.Meta 服务已启动</string>
     <string name="external_control_stopped">Clash.Meta 服务已停止</string>
+    <string name="allow_external_control_title">允许外部控制</string>
+    <string name="allow_external_control_summary">允许其他应用启动、停止或切换 VPN（如 Tasker、快捷方式）。关闭后将忽略外部请求。</string>
+    <string name="external_control_disabled">外部控制已禁用</string>
+    <string name="external_stop_channel">外部控制</string>
+    <string name="external_stop_title">VPN 已停止</string>
+    <string name="external_stop_text">VPN 被外部请求停止</string>
     <string name="import_from_qr_no_permission">相机权限受限，请前往设置开启。</string>
     <string name="import_from_qr_exception">发生系统未知异常，操作失败。</string>
 

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -934,6 +934,12 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="external_control_activity">External Control</string>
     <string name="external_control_started">Clash.Meta service started</string>
     <string name="external_control_stopped">Clash.Meta service stopped</string>
+    <string name="allow_external_control_title">Allow external control</string>
+    <string name="allow_external_control_summary">Let other apps start, stop or toggle the VPN (e.g. Tasker, shortcuts). When off, external requests are ignored.</string>
+    <string name="external_control_disabled">External control is disabled</string>
+    <string name="external_stop_channel">External control</string>
+    <string name="external_stop_title">VPN stopped</string>
+    <string name="external_stop_text">The VPN was stopped by an external request</string>
 
     <string name="hide_app_icon_title">Hide App Icon</string>
     <string name="hide_app_icon_desc">You can dial *#*#252746382#*#* to open this App</string>

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -82,6 +82,19 @@ class ServiceStore(context: Context) {
     )
 
     /**
+     * When true, externally-originated control intents (START/STOP/TOGGLE_CLASH
+     * via the exported ExternalControlActivity) are honored. Default true so
+     * existing automation (Tasker, launcher shortcuts) keeps working; when the
+     * user turns it off, external apps cannot drive the VPN at all. An external
+     * stop is always surfaced via a notification regardless of this flag (see
+     * SEC-3 / external-control-policy).
+     */
+    var allowExternalControl by store.boolean(
+        key = "allow_external_control",
+        defaultValue = true
+    )
+
+    /**
      * Hardening level applied at runtime against SOCKS5/HTTP/Mixed listener
      * leaks and direct access to the TUN interface from other apps. See
      * [ProxyHardeningMode]. Default is [ProxyHardeningMode.Strict] on Android


### PR DESCRIPTION
## Summary

Lands the app-side audit findings from `app-audit`. Four fixes, all in `app/` + `service`/`design`, no core changes.

- **SEC-3 (P2)** — exported `START/STOP/TOGGLE_CLASH` had no user gate, so any app could silently stop the VPN (denial-of-protection). Adds an **`allowExternalControl`** setting (default **on**, so existing automation keeps working) and posts a **notification** whenever the VPN is stopped by an external request — it is never silent. Off → external control is ignored.
- **BUG-4 (P2)** — external control read the stale `Remote.broadcasts.clashRunning` flag, which is `false` when the activity is cold-started by an external intent, so STOP frequently did nothing. Now reads a fresh `StatusClient.statusSnapshot()`.
- **BUG-5 (P2)** — rebrand mismatch: the manifest advertised `com.github.metacubex.clash.meta.action.*` while the code checks `${applicationId}.action.*`, so implicit external control was dead. Manifest now uses `${applicationId}.action.*` to match the handler per flavor (collision-free with other Clash apps).
- **BUG-3 (P1)** — hiding the app icon disabled `MainActivityAlias` (the only launcher activity), making `setupShortcuts` → `setDynamicShortcuts` throw `IllegalStateException: Launcher activity not found` and crash app startup. Guarded with `runCatching`; shortcuts are non-essential.

## Behavior change (heads-up)

External control actions are now scoped to the app's own id. Use `<applicationId>.action.{START,STOP,TOGGLE}_CLASH` (e.g. `com.nemu.clashfest.clash.alpha.action.STOP_CLASH`) — the old `com.github.metacubex.clash.meta.action.*` actions are no longer handled. In-app launcher shortcuts are unaffected.

## Testing

- `:service` + `:app` build green (`assembleAlphaDebug`, JDK 21); merged manifest confirmed `${applicationId}` substitution.
- On device (Pixel 7 Pro): control OFF → STOP ignored + toast; control ON → STOP stops the VPN + notification; in-app stop posts no external notification; hidden icon no longer crashes startup; implicit `am start -a <applicationId>.action.STOP_CLASH` works.

## Strings

`allow_external_control_*`, `external_control_disabled`, `external_stop_*` added in EN / RU / zh.