### PR TITLE
fix(security): strip global proxy ports in Strict to close cross-UID listener leak (SEC-1)

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/util/YamlHardener.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/YamlHardener.kt
@@ -39,6 +39,10 @@ import java.io.File
 object YamlHardener {
     private const val ORIGINAL_FILENAME = "config.original.yaml"
 
+    /** Global proxy listener ports; stripped at file level in Strict (SEC-1). */
+    private val GLOBAL_PORT_KEYS =
+        listOf("port", "socks-port", "mixed-port", "redir-port", "tproxy-port")
+
     /**
      * Apply the requested [mode] to `config.yaml` inside [profileDir].
      *
@@ -96,18 +100,34 @@ object YamlHardener {
         val document = MihomoConfigDocument.parse(text) ?: return null
         val root = document.root
         var changed = false
-        // listeners hardening is a *removal* in Strict — the model mutation
-        // does root.remove("listeners"), which renderReplacing intentionally
-        // skips. Track it separately so the renderer can strip the block
-        // from the source text via renderRemoving.
-        var dropListenersFromSource = false
+        // Removals in Strict (listeners block, global port keys) do
+        // root.remove(...), which renderReplacing intentionally skips. Collect
+        // such keys so the renderer can strip them from the source text via
+        // renderRemoving.
+        val removeFromSource = mutableListOf<String>()
 
-        when (val listenersChange = hardenListeners(root, mode)) {
+        when (hardenListeners(root, mode)) {
             ListenersChange.None -> Unit
             ListenersChange.Rewritten -> changed = true
             ListenersChange.Dropped -> {
                 changed = true
-                dropListenersFromSource = true
+                removeFromSource += "listeners"
+            }
+        }
+        // SEC-1: in Strict the global proxy ports must not survive into the
+        // config the engine loads. The runtime override (ports=0) is applied
+        // after Clash.load, never reloaded, and cleared on each runtime start,
+        // so a YAML-declared mixed-port/socks-port stays open (cross-UID
+        // reachable on loopback) on every connect. File-level removal is the
+        // only reliable close. Compat keeps them (loopback bind via
+        // bind-address + RuntimeSocksAuth credential).
+        if (mode == ProxyHardeningMode.Strict) {
+            for (key in GLOBAL_PORT_KEYS) {
+                if (root.containsKey(key)) {
+                    root.remove(key)
+                    changed = true
+                    removeFromSource += key
+                }
             }
         }
         changed = forceFalse(root, "allow-lan") || changed
@@ -122,12 +142,11 @@ object YamlHardener {
             "bind-address",
             "external-controller",
         )
-        if (dropListenersFromSource) {
-            rendered = MihomoConfigDocument.parseOrEmpty(rendered).let {
-                // Re-render through the cleaner so the second pass produces
-                // a document with the listeners block actually stripped.
-                it.renderRemoving("listeners")
-            }
+        if (removeFromSource.isNotEmpty()) {
+            // Re-render through the cleaner so this pass produces a document
+            // with the removed blocks/keys actually stripped from the source.
+            rendered = MihomoConfigDocument.parseOrEmpty(rendered)
+                .renderRemoving(*removeFromSource.toTypedArray())
         }
         return rendered
     }

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
@@ -142,6 +142,55 @@ class YamlHardenerTest {
         assertEquals("127.0.0.1", parse(hardened!!)["bind-address"])
     }
 
+    // -- SEC-1: global proxy ports stripped in Strict ---------------------
+
+    @Test
+    fun strict_stripsAllGlobalProxyPorts() {
+        val input = """
+            port: 7892
+            socks-port: 7891
+            mixed-port: 7890
+            redir-port: 7893
+            tproxy-port: 7894
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        val root = parse(hardened!!)
+        for (key in listOf("port", "socks-port", "mixed-port", "redir-port", "tproxy-port")) {
+            assertNull("Strict must strip $key from the model", root[key])
+            assertFalse("Strict must strip $key from the source text", hardened.contains(key))
+        }
+        // unrelated keys survive
+        assertTrue(root.containsKey("proxies"))
+    }
+
+    @Test
+    fun strict_portStripIsIdempotent() {
+        val input = "mixed-port: 7890\nproxies: []\n"
+        val first = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(first)
+        assertFalse(first!!.contains("mixed-port"))
+        val second = YamlHardener.hardenYaml(first, ProxyHardeningMode.Strict)
+        assertEquals("second pass on already-stripped YAML must be a no-op", first, second)
+    }
+
+    @Test
+    fun compat_keepsGlobalProxyPorts() {
+        val input = "mixed-port: 7890\nsocks-port: 7891\nproxies: []\n"
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Compat)
+        // Compat must not strip global ports (loopback bind + RuntimeSocksAuth).
+        assertEquals(7890, parse(hardened!!)["mixed-port"])
+        assertEquals(7891, parse(hardened)["socks-port"])
+    }
+
+    @Test
+    fun off_keepsGlobalProxyPorts() {
+        val input = "mixed-port: 7890\nproxies: []\n"
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Off)
+        assertEquals(input, hardened)
+    }
+
     @Test
     fun isIdempotent_secondPassNoChange() {
         val dirty = """


### PR DESCRIPTION
A profile-declared global port (mixed-port/socks-port/port/redir-port/tproxy-port) stayed open on 127.0.0.1 under Strict and was reachable cross-UID, because YamlHardener only stripped listeners and the runtime override (ports=0) is applied after Clash.load, never reloaded, and cleared each runtime start. YamlHardener now removes the global port keys at the file level in Strict (Compat keeps them loopback-bound + authed). Closes confirmed P0 SEC-1.