### PR TITLE
fix(app): deeplink url-only + scope cleanup + redact brand-logo URL logs [DL-1, Q-1, LOG-1]

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -21,6 +21,7 @@ import com.github.kr328.clash.util.stopClashService
 import com.github.kr328.clash.util.withProfile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.util.*
 import com.github.kr328.clash.design.R
@@ -39,21 +40,23 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
 
                 launch {
                     val uuid = withProfile {
-                        val type = when (uri.getQueryParameter("type")?.lowercase(Locale.getDefault())) {
-                            "url" -> Profile.Type.Url
-                            "file" -> Profile.Type.File
-                            else -> Profile.Type.Url
-                        }
+                        // DL-1: external deeplinks only create a URL-source profile.
+                        // File import must come from the in-app picker (which grants
+                        // a content-URI), never from an untrusted deeplink path.
                         val name = uri.getQueryParameter("name")
                             ?: getString(R.string.subscription_default_name)
 
-                        create(type, name).also {
+                        create(Profile.Type.Url, name).also {
                             patch(it, name, url, 0)
                         }
                     }
                     startActivity(PropertiesActivity::class.intent.setUUID(uuid))
                     finish()
                 }
+                // Don't fall through to the synchronous finish() below — the
+                // activity must stay alive until the coroutine completes (then
+                // it finishes itself; onDestroy cancels the scope).
+                return
             }
 
             Intents.ACTION_TOGGLE_CLASH -> if (externalControlAllowed()) {
@@ -84,10 +87,6 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
     }
 
     private fun startClash() {
-//        if (currentProfile == null) {
-//            Toast.makeText(this, R.string.no_profile_selected, Toast.LENGTH_LONG).show()
-//            return
-//        }
         val vpnRequest = startClashService()
         if (vpnRequest != null) {
             Toast.makeText(this, R.string.unable_to_start_vpn, Toast.LENGTH_LONG).show()
@@ -156,5 +155,12 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
         super.finish()
         @Suppress("DEPRECATION")
         overridePendingTransition(0, 0)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Q-1: the install-config branch launches on this MainScope; cancel it
+        // so the scope doesn't outlive the (immediately finishing) activity.
+        cancel()
     }
 }

--- a/service/src/main/java/com/github/kr328/clash/service/branding/BrandLogoFetcher.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/branding/BrandLogoFetcher.kt
@@ -3,6 +3,7 @@ package com.github.kr328.clash.service.branding
 import android.content.Context
 import android.graphics.BitmapFactory
 import com.github.kr328.clash.common.log.Log
+import com.github.kr328.clash.common.log.LogRedaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -40,18 +41,20 @@ object BrandLogoFetcher {
     )
 
     suspend fun fetch(context: Context, urlString: String): String? = withContext(Dispatchers.IO) {
+        // LOG-1: never log the full URL (may carry operator tokens / query
+        // params) — log only host/scheme, or redact when there's no host.
         val parsed = runCatching { URL(urlString) }.getOrNull()
         if (parsed == null) {
-            Log.w("BrandLogoFetcher: malformed URL: $urlString")
+            Log.w("BrandLogoFetcher: malformed URL: ${LogRedaction.redactSuspicious(urlString)}")
             return@withContext null
         }
         if (!parsed.protocol.equals("https", ignoreCase = true)) {
-            Log.w("BrandLogoFetcher: rejected non-https URL: $urlString")
+            Log.w("BrandLogoFetcher: rejected non-https URL (scheme=${parsed.protocol}, host=${parsed.host})")
             return@withContext null
         }
         if (!isPublicHost(parsed.host)) {
             Log.w(
-                "BrandLogoFetcher: SSRF guard rejected $urlString — host '${parsed.host}' " +
+                "BrandLogoFetcher: SSRF guard rejected host '${parsed.host}' — " +
                     "resolves to a private/loopback/link-local IP (this can happen when the " +
                     "VPN tunnel is active and DNS resolves through it)",
             )


### PR DESCRIPTION

DL-1: external install-config deeplink creates only a URL-source profile (file import stays in-app-picker only). 
Q-1: cancel the activity scope in onDestroy (ACTION_VIEW returns instead of finishing synchronously so the coroutine completes) and drop dead commented code. 
LOG-1: BrandLogoFetcher logs host/scheme or redacts via LogRedaction, never the full URL.