### PR TITLE
chore(core): recover() at the JNI boundary so a bridge panic can't SIGABRT (BUG-2)

### DIFF
--- a/core/src/main/golang/native/app.go
+++ b/core/src/main/golang/native/app.go
@@ -31,6 +31,7 @@ func openRemoteContent(url string) (int, error) {
 
 //export notifyDnsChanged
 func notifyDnsChanged(dnsList C.c_string) {
+	defer guard("notifyDnsChanged")()
 	d := C.GoString(dnsList)
 
 	app.NotifyDnsChanged(d)
@@ -38,6 +39,7 @@ func notifyDnsChanged(dnsList C.c_string) {
 
 //export notifyInstalledAppsChanged
 func notifyInstalledAppsChanged(uids C.c_string) {
+	defer guard("notifyInstalledAppsChanged")()
 	u := C.GoString(uids)
 
 	app.NotifyInstallAppsChanged(u)
@@ -45,12 +47,14 @@ func notifyInstalledAppsChanged(uids C.c_string) {
 
 //export notifyTimeZoneChanged
 func notifyTimeZoneChanged(name C.c_string, offset C.int) {
+	defer guard("notifyTimeZoneChanged")()
 	app.NotifyTimeZoneChanged(C.GoString(name), int(offset))
 }
 
 
 //export queryConfiguration
 func queryConfiguration() *C.char {
+	defer guard("queryConfiguration")()
 	response := &struct{}{}
 
 	return marshalJson(&response)

--- a/core/src/main/golang/native/config.go
+++ b/core/src/main/golang/native/config.go
@@ -4,6 +4,7 @@ package main
 import "C"
 
 import (
+	"fmt"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -29,6 +30,17 @@ func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, h
 		subscriptionFetchSessionMu.Lock()
 		defer subscriptionFetchSessionMu.Unlock()
 
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("fetchAndValid", r)
+				if !completed {
+					C.fetch_complete(callback, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(callback)
+				}
+			}
+		}()
+
 		app.SetSubscriptionFetchHeadersJSON(headers)
 		defer app.ClearSubscriptionFetchHeaders()
 
@@ -39,6 +51,7 @@ func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, h
 		C.fetch_complete(callback, marshalString(err))
 
 		C.release_object(callback)
+		completed = true
 
 		runtime.GC()
 	}(C.GoString(path), C.GoString(url), C.GoString(headersJson), callback)
@@ -50,6 +63,17 @@ func fetchProvidersAndValid(callback unsafe.Pointer, path C.c_string, force C.in
 		subscriptionFetchSessionMu.Lock()
 		defer subscriptionFetchSessionMu.Unlock()
 
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("fetchProvidersAndValid", r)
+				if !completed {
+					C.fetch_complete(callback, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(callback)
+				}
+			}
+		}()
+
 		app.SetSubscriptionFetchHeadersJSON(headers)
 		defer app.ClearSubscriptionFetchHeaders()
 
@@ -60,6 +84,7 @@ func fetchProvidersAndValid(callback unsafe.Pointer, path C.c_string, force C.in
 		C.fetch_complete(callback, marshalString(err))
 
 		C.release_object(callback)
+		completed = true
 
 		runtime.GC()
 	}(C.GoString(path), C.GoString(headersJson), callback)
@@ -68,9 +93,21 @@ func fetchProvidersAndValid(callback unsafe.Pointer, path C.c_string, force C.in
 //export load
 func load(completable unsafe.Pointer, path C.c_string) {
 	go func(path string) {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("load", r)
+				if !completed {
+					C.complete(completable, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(completable)
+				}
+			}
+		}()
+
 		C.complete(completable, marshalString(config.Load(path)))
 
 		C.release_object(completable)
+		completed = true
 
 		runtime.GC()
 	}(C.GoString(path))
@@ -79,9 +116,21 @@ func load(completable unsafe.Pointer, path C.c_string) {
 //export validateProfile
 func validateProfile(completable unsafe.Pointer, path C.c_string) {
 	go func(path string) {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("validateProfile", r)
+				if !completed {
+					C.complete(completable, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(completable)
+				}
+			}
+		}()
+
 		C.complete(completable, marshalString(config.Validate(path)))
 
 		C.release_object(completable)
+		completed = true
 
 		runtime.GC()
 	}(C.GoString(path))
@@ -89,16 +138,19 @@ func validateProfile(completable unsafe.Pointer, path C.c_string) {
 
 //export parseProfileSnapshot
 func parseProfileSnapshot(path C.c_string) *C.char {
+	defer guard("parseProfileSnapshot")()
 	return C.CString(snapshot.MarshalJSON(C.GoString(path)))
 }
 
 //export parseProfileSnapshotFromBytes
 func parseProfileSnapshotFromBytes(yaml C.c_string) *C.char {
+	defer guard("parseProfileSnapshotFromBytes")()
 	return C.CString(snapshot.MarshalJSONFromBytes([]byte(C.GoString(yaml))))
 }
 
 //export validateProfileBytes
 func validateProfileBytes(yaml C.c_string) *C.char {
+	defer guard("validateProfileBytes")()
 	errMsg := snapshot.ValidateBytes([]byte(C.GoString(yaml)))
 	if errMsg == "" {
 		return nil
@@ -108,11 +160,13 @@ func validateProfileBytes(yaml C.c_string) *C.char {
 
 //export readOverride
 func readOverride(slot C.int) *C.char {
+	defer guard("readOverride")()
 	return C.CString(config.ReadOverride(config.OverrideSlot(slot)))
 }
 
 //export writeOverride
 func writeOverride(slot C.int, content C.c_string) {
+	defer guard("writeOverride")()
 	c := C.GoString(content)
 
 	config.WriteOverride(config.OverrideSlot(slot), c)
@@ -120,5 +174,6 @@ func writeOverride(slot C.int, content C.c_string) {
 
 //export clearOverride
 func clearOverride(slot C.int) {
+	defer guard("clearOverride")()
 	config.ClearOverride(config.OverrideSlot(slot))
 }

--- a/core/src/main/golang/native/log.go
+++ b/core/src/main/golang/native/log.go
@@ -44,6 +44,8 @@ func init() {
 //export subscribeLogcat
 func subscribeLogcat(remote unsafe.Pointer) {
 	go func(remote unsafe.Pointer) {
+		defer guard("subscribeLogcat")()
+
 		sub := log.Subscribe()
 		defer log.UnSubscribe(sub)
 

--- a/core/src/main/golang/native/main.go
+++ b/core/src/main/golang/native/main.go
@@ -24,6 +24,7 @@ func main() {
 
 //export coreInit
 func coreInit(home, versionName, gitVersion C.c_string, sdkVersion C.int) {
+	defer guard("coreInit")()
 	h := C.GoString(home)
 	v := C.GoString(versionName)
 	g := C.GoString(gitVersion)
@@ -36,6 +37,7 @@ func coreInit(home, versionName, gitVersion C.c_string, sdkVersion C.int) {
 
 //export reset
 func reset() {
+	defer guard("reset")()
 	config.LoadDefault()
 	tunnel.ResetStatistic()
 	tunnel.CloseAllConnections()
@@ -47,6 +49,8 @@ func reset() {
 //export forceGc
 func forceGc() {
 	go func() {
+		defer guard("forceGc")()
+
 		log.Infoln("[APP] request force GC")
 
 		runtime.GC()

--- a/core/src/main/golang/native/proxy.go
+++ b/core/src/main/golang/native/proxy.go
@@ -9,6 +9,7 @@ import (
 
 //export startHttp
 func startHttp(listenAt C.c_string) *C.char {
+	defer guard("startHttp")()
 	l := C.GoString(listenAt)
 
 	listen, err := proxy.Start(l)
@@ -21,5 +22,6 @@ func startHttp(listenAt C.c_string) *C.char {
 
 //export stopHttp
 func stopHttp() {
+	defer guard("stopHttp")()
 	proxy.Stop()
 }

--- a/core/src/main/golang/native/tun.go
+++ b/core/src/main/golang/native/tun.go
@@ -64,7 +64,14 @@ func (t *remoteTun) close() {
 }
 
 //export startTun
-func startTun(fd C.int, stack, gateway, portal, dns C.c_string, callback unsafe.Pointer) C.int {
+func startTun(fd C.int, stack, gateway, portal, dns C.c_string, callback unsafe.Pointer) (result C.int) {
+	// On panic return a failure code (1), not the success value (0).
+	defer func() {
+		if r := recover(); r != nil {
+			logRecover("startTun", r)
+			result = 1
+		}
+	}()
 	rTunLock.Lock()
 	defer rTunLock.Unlock()
 
@@ -99,6 +106,7 @@ func startTun(fd C.int, stack, gateway, portal, dns C.c_string, callback unsafe.
 
 //export stopTun
 func stopTun() {
+	defer guard("stopTun")()
 	rTunLock.Lock()
 	defer rTunLock.Unlock()
 

--- a/core/src/main/golang/native/tunnel.go
+++ b/core/src/main/golang/native/tunnel.go
@@ -4,6 +4,7 @@ package main
 import "C"
 
 import (
+	"fmt"
 	"unsafe"
 
 	"cfa/native/app"
@@ -12,6 +13,7 @@ import (
 
 //export queryTunnelState
 func queryTunnelState() *C.char {
+	defer guard("queryTunnelState")()
 	mode := tunnel.QueryMode()
 
 	response := &struct {
@@ -23,6 +25,7 @@ func queryTunnelState() *C.char {
 
 //export queryNow
 func queryNow(upload, download *C.uint64_t) {
+	defer guard("queryNow")()
 	up, down := tunnel.Now()
 
 	*upload = C.uint64_t(up)
@@ -31,6 +34,7 @@ func queryNow(upload, download *C.uint64_t) {
 
 //export queryTotal
 func queryTotal(upload, download *C.uint64_t) {
+	defer guard("queryTotal")()
 	up, down := tunnel.Total()
 
 	*upload = C.uint64_t(up)
@@ -39,16 +43,19 @@ func queryTotal(upload, download *C.uint64_t) {
 
 //export queryGroupNames
 func queryGroupNames(excludeNotSelectable C.int) *C.char {
+	defer guard("queryGroupNames")()
 	return marshalJson(tunnel.QueryProxyGroupNames(excludeNotSelectable != 0))
 }
 
 //export queryAllGroupNamesIncludingHidden
 func queryAllGroupNamesIncludingHidden() *C.char {
+	defer guard("queryAllGroupNamesIncludingHidden")()
 	return marshalJson(tunnel.QueryAllProxyGroupNamesIncludingHidden())
 }
 
 //export queryGroup
 func queryGroup(name C.c_string, sortMode C.c_string) *C.char {
+	defer guard("queryGroup")()
 	n := C.GoString(name)
 	s := C.GoString(sortMode)
 
@@ -73,15 +80,37 @@ func queryGroup(name C.c_string, sortMode C.c_string) *C.char {
 //export healthCheck
 func healthCheck(completable unsafe.Pointer, name C.c_string) {
 	go func(name string) {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("healthCheck", r)
+				if !completed {
+					C.complete(completable, marshalString(fmt.Sprintf("native panic: %v", r)))
+				}
+			}
+		}()
+
 		tunnel.HealthCheck(name)
 
 		C.complete(completable, nil)
+		completed = true
 	}(C.GoString(name))
 }
 
 //export healthCheckWithCallback
 func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
 	go func(name string, callback unsafe.Pointer) {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("healthCheckWithCallback", r)
+				if !completed {
+					C.proxy_delay_complete(callback, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(callback)
+				}
+			}
+		}()
+
 		earlyErr := tunnel.HealthCheckWithCallback(name, func(proxyName string, delayMs int, errMsg string) {
 			var errCStr *C.char
 			if errMsg != "" {
@@ -97,16 +126,19 @@ func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
 		C.proxy_delay_complete(callback, earlyErrCStr)
 
 		C.release_object(callback)
+		completed = true
 	}(C.GoString(name), callback)
 }
 
 //export healthCheckAll
 func healthCheckAll() {
+	defer guard("healthCheckAll")()
 	tunnel.HealthCheckAll()
 }
 
 //export patchSelector
 func patchSelector(selector, name C.c_string) C.int {
+	defer guard("patchSelector")()
 	s := C.GoString(selector)
 	n := C.GoString(name)
 
@@ -119,16 +151,19 @@ func patchSelector(selector, name C.c_string) C.int {
 
 //export queryProviders
 func queryProviders() *C.char {
+	defer guard("queryProviders")()
 	return marshalJson(tunnel.QueryProviders())
 }
 
 //export queryConnectionsSnapshot
 func queryConnectionsSnapshot() *C.char {
+	defer guard("queryConnectionsSnapshot")()
 	return marshalJson(tunnel.QueryConnectionsSnapshot())
 }
 
 //export closeConnection
 func closeConnection(id C.c_string) C.int {
+	defer guard("closeConnection")()
 	if tunnel.CloseConnection(C.GoString(id)) {
 		return 1
 	}
@@ -137,19 +172,33 @@ func closeConnection(id C.c_string) C.int {
 
 //export closeAllConnections
 func closeAllConnections() C.int {
+	defer guard("closeAllConnections")()
 	return C.int(tunnel.CloseAllConnections())
 }
 
 //export updateProvider
 func updateProvider(completable unsafe.Pointer, pType C.c_string, name C.c_string) {
 	go func(pType, name string) {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("updateProvider", r)
+				if !completed {
+					C.complete(completable, marshalString(fmt.Sprintf("native panic: %v", r)))
+					C.release_object(completable)
+				}
+			}
+		}()
+
 		C.complete(completable, marshalString(tunnel.UpdateProvider(pType, name)))
 
 		C.release_object(completable)
+		completed = true
 	}(C.GoString(pType), C.GoString(name))
 }
 
 //export suspend
 func suspend(suspended C.int) {
+	defer guard("suspend")()
 	tunnel.Suspend(suspended != 0)
 }

--- a/core/src/main/golang/native/utils.go
+++ b/core/src/main/golang/native/utils.go
@@ -5,7 +5,27 @@ import "C"
 import (
 	"encoding/json"
 	"reflect"
+	"runtime/debug"
+
+	"github.com/metacubex/mihomo/log"
 )
+
+// logRecover reports a recovered panic from a native export with its stack.
+func logRecover(name string, r any) {
+	log.Errorln("[NATIVE] %s panicked: %v\n%s", name, r, string(debug.Stack()))
+}
+
+// guard returns a deferred recover for a synchronous //export function.
+// Usage: `defer guard("funcName")()`. On panic it logs and lets the function
+// return its zero value (nil for *C.char, 0 for C.int) — so a bridge panic
+// never crosses the cgo boundary and aborts the process (BUG-2).
+func guard(name string) func() {
+	return func() {
+		if r := recover(); r != nil {
+			logRecover(name, r)
+		}
+	}
+}
 
 func marshalJson(obj any) *C.char {
 	res, err := json.Marshal(obj)


### PR DESCRIPTION
Guard every //export: synchronous functions recover and return a safe zero value (startTun returns failure=1); goroutine/callback functions recover inside the worker and complete the callback with the error (completed flag prevents double-complete/double-release) so Kotlin gets a ClashException instead of a hang. A panic in the bridge no longer aborts the process.