### PR TITLE
fix(design): rework Routing Rules screen header, compact controls, AND-rule rendering

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/EffectiveRulesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/EffectiveRulesDesign.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.widget.PopupMenu
@@ -59,7 +60,6 @@ class EffectiveRulesDesign(context: Context) : Design<EffectiveRulesDesign.Reque
 
     init {
         binding.self = this
-        binding.toolbar.title = ""
         binding.ruleList.layoutManager = LinearLayoutManager(context)
         binding.ruleList.adapter = adapter
         binding.btnOpenLogcat.setOnClickListener {
@@ -69,13 +69,24 @@ class EffectiveRulesDesign(context: Context) : Design<EffectiveRulesDesign.Reque
             searchQuery = it?.toString().orEmpty()
             renderRules()
         }
-        binding.ruleFilterChips.setOnCheckedChangeListener { _, checkedId ->
-            filterMode = when (checkedId) {
-                R.id.filter_active -> FilterMode.ACTIVE
-                R.id.filter_disabled -> FilterMode.DISABLED
-                R.id.filter_deleted -> FilterMode.DELETED
-                else -> FilterMode.ALL
-            }
+        val filterModes = listOf(
+            FilterMode.ALL,
+            FilterMode.ACTIVE,
+            FilterMode.DISABLED,
+            FilterMode.DELETED,
+        )
+        val filterLabels = listOf(
+            context.getString(R.string.effective_rules_filter_all),
+            context.getString(R.string.effective_rules_filter_active),
+            context.getString(R.string.effective_rules_filter_disabled),
+            context.getString(R.string.effective_rules_filter_deleted),
+        )
+        binding.ruleFilterDropdown.setAdapter(
+            ArrayAdapter(context, android.R.layout.simple_dropdown_item_1line, filterLabels),
+        )
+        binding.ruleFilterDropdown.setText(filterLabels[filterModes.indexOf(filterMode)], false)
+        binding.ruleFilterDropdown.setOnItemClickListener { _, _, position, _ ->
+            filterMode = filterModes.getOrElse(position) { FilterMode.ALL }
             renderRules()
         }
     }
@@ -220,6 +231,12 @@ class EffectiveRulesDesign(context: Context) : Design<EffectiveRulesDesign.Reque
         override fun getItemCount(): Int = rules.size
 
         private fun buildRuleLine(item: RuleItem): String {
+            // Logical/opaque rules (AND/OR/NOT/SUB-RULE/SCRIPT) keep the whole
+            // line in `raw` with empty value/policy — reconstructing them from
+            // fields yields "AND,,". Show the raw line verbatim instead.
+            if (item.value.isBlank() && item.policy.isBlank() && item.raw.isNotBlank()) {
+                return item.raw
+            }
             return if (item.type.equals("MATCH", true)) {
                 "MATCH,${item.policy}"
             } else if (item.type == "LEGACY") {

--- a/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
@@ -34,7 +34,7 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
 
     init {
         binding.self = this
-        binding.toolbar.title = ""
+        binding.toolbar.title = context.getString(R.string.rule_snippet_title)
         binding.btnOpenCreateSheet.setOnClickListener { requests.trySend(Request.OpenCreateSheet) }
         binding.btnOpenManualRules.setOnClickListener { requests.trySend(Request.OpenManualRules) }
         binding.btnUpdateAllRuleSets.setOnClickListener { requests.trySend(Request.UpdateAllRuleSets) }

--- a/design/src/main/res/layout/design_effective_rules.xml
+++ b/design/src/main/res/layout/design_effective_rules.xml
@@ -17,18 +17,11 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:paddingBottom="@{self.surface.insets.bottom}">
 
             <LinearLayout
@@ -36,125 +29,97 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="16dp"
-                android:paddingTop="10dp"
-                android:paddingBottom="10dp">
+                android:paddingTop="12dp"
+                android:paddingBottom="8dp">
 
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/AppCard.Filled"
+                <TextView
+                    android:id="@+id/screen_title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    app:cardBackgroundColor="?attr/colorSurfaceContainer"
-                    app:cardCornerRadius="24dp"
-                    app:cardElevation="0dp"
-                    app:strokeWidth="0dp">
+                    android:paddingTop="4dp"
+                    android:paddingBottom="12dp"
+                    android:text="@string/effective_rules_title"
+                    android:textAppearance="@style/TextAppearance.App.TitleLarge"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textStyle="bold" />
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:baselineAligned="false"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/effective_rules_summary"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="16dp">
+                        android:layout_weight="1"
+                        android:textAppearance="@style/TextAppearance.App.BodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        tools:text="128 shown · 120 active · 8 disabled · 0 deleted" />
 
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal">
-
-                            <TextView
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:text="@string/effective_rules_title"
-                                android:textAppearance="@style/TextAppearance.App.TitleMedium"
-                                android:textColor="?attr/colorOnSurface"
-                                android:textStyle="bold" />
-
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/btn_open_logcat"
-                                style="@style/Widget.Material3.Button.TextButton"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:minWidth="0dp"
-                                android:text="@string/effective_rules_open_logcat"
-                                app:icon="@drawable/ic_outline_article"
-                                app:iconGravity="textStart" />
-                        </LinearLayout>
-
-                        <TextView
-                            android:id="@+id/effective_rules_summary"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="6dp"
-                            android:textAppearance="@style/TextAppearance.App.BodySmall"
-                            android:textColor="?attr/colorOnSurfaceVariant"
-                            tools:text="128 shown · 120 active · 8 disabled · 0 deleted" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/rule_search_layout"
-                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:hint="@string/effective_rules_search_hint"
-                    app:endIconMode="clear_text"
-                    app:startIconDrawable="@drawable/ic_baseline_search">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/rule_search"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:imeOptions="actionSearch"
-                        android:inputType="text"
-                        android:maxLines="1" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <HorizontalScrollView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:overScrollMode="never"
-                    android:scrollbars="none">
-
-                    <com.google.android.material.chip.ChipGroup
-                        android:id="@+id/rule_filter_chips"
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btn_open_logcat"
+                        style="@style/Widget.Material3.Button.TextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        app:singleLine="true"
-                        app:singleSelection="true">
+                        android:layout_marginStart="8dp"
+                        android:minWidth="0dp"
+                        android:text="@string/effective_rules_open_logcat"
+                        app:icon="@drawable/ic_outline_article"
+                        app:iconGravity="textStart" />
+                </LinearLayout>
 
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_all"
-                            style="@style/Widget.Material3.Chip.Filter"
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:baselineAligned="false"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/rule_search_layout"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/effective_rules_search_hint"
+                        app:endIconMode="clear_text"
+                        app:startIconDrawable="@drawable/ic_baseline_search">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/rule_search"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:imeOptions="actionSearch"
+                            android:inputType="text"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/rule_filter_layout"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp">
+
+                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                            android:id="@+id/rule_filter_dropdown"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:checked="true"
-                            android:text="@string/effective_rules_filter_all" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_active"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/effective_rules_filter_active" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_disabled"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/effective_rules_filter_disabled" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_deleted"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/effective_rules_filter_deleted" />
-                    </com.google.android.material.chip.ChipGroup>
-                </HorizontalScrollView>
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:inputType="none"
+                            android:minWidth="128dp"
+                            tools:ignore="LabelFor" />
+                    </com.google.android.material.textfield.TextInputLayout>
+                </LinearLayout>
             </LinearLayout>
 
             <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION

EffectiveRules: title as plain TextView header (MaterialToolbar clipped the 'g' descender); stats as a thin row with Open core log; compact search + filter dropdown in one row (chips removed). RuleSnippet: set toolbar title from rule_snippet_title. Rule list: show raw line for logical rules (AND/OR/NOT/SUB-RULE/SCRIPT) instead of 'AND,,'.