### PR TITLE
feat(design): unify screen headers to Material 3 large-header style

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/AccessControlDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AccessControlDesign.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.design
 
 import android.content.Context
 import android.view.View
+import android.widget.ArrayAdapter
 import androidx.core.view.updatePadding
 import androidx.core.widget.addTextChangedListener
 import com.github.kr328.clash.design.adapter.AppAdapter
@@ -138,6 +139,7 @@ class AccessControlDesign(
         binding.self = this
 
         binding.activityBarLayout.applyFrom(context)
+        binding.screenTitle.text = (context as? android.app.Activity)?.title?.toString().orEmpty()
 
         binding.mainList.recyclerList.also {
             it.bindAppBarElevation(binding.activityBarLayout)
@@ -164,14 +166,20 @@ class AccessControlDesign(
             launchApplyFilteredList()
         }
 
-        binding.namespaceFilterGroup.setOnCheckedStateChangeListener { _, checkedIds ->
-            namespaceFilter = when (checkedIds.firstOrNull()) {
-                binding.filterRuChip.id -> NamespaceFilter.Ru
-                binding.filterCnChip.id -> NamespaceFilter.Cn
-                binding.filterComChip.id -> NamespaceFilter.Com
-                binding.filterOtherChip.id -> NamespaceFilter.Other
-                else -> NamespaceFilter.All
-            }
+        val nsModes = NamespaceFilter.values().toList()
+        val nsLabels = listOf(
+            context.getString(R.string.filter),
+            context.getString(R.string.app_routing_filter_ru),
+            context.getString(R.string.app_routing_filter_cn),
+            context.getString(R.string.app_routing_filter_com),
+            context.getString(R.string.app_routing_filter_other),
+        )
+        binding.namespaceFilterDropdown.setAdapter(
+            ArrayAdapter(context, android.R.layout.simple_dropdown_item_1line, nsLabels),
+        )
+        binding.namespaceFilterDropdown.setText(nsLabels[nsModes.indexOf(namespaceFilter)], false)
+        binding.namespaceFilterDropdown.setOnItemClickListener { _, _, position, _ ->
+            namespaceFilter = nsModes.getOrElse(position) { NamespaceFilter.All }
             launchApplyFilteredList()
         }
 

--- a/design/src/main/java/com/github/kr328/clash/design/AnnouncementSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AnnouncementSettingsDesign.kt
@@ -37,10 +37,7 @@ class AnnouncementSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         // Bridge non-null UiStore strings to nullable properties expected by editableText.
         val supportUrlNullable = NullableStringProperty(uiStore::supportUrl)

--- a/design/src/main/java/com/github/kr328/clash/design/ApkBrokenDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ApkBrokenDesign.kt
@@ -23,10 +23,7 @@ class ApkBrokenDesign(context: Context) : Design<ApkBrokenDesign.Request>(contex
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         val screen = preferenceScreen(context) {
             tips(R.string.application_broken_tips)

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -34,10 +34,7 @@ class AppSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         val screen = preferenceScreen(context) {
             category(R.string.behavior)

--- a/design/src/main/java/com/github/kr328/clash/design/ConnectionsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ConnectionsDesign.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.design
 
 import android.content.Context
 import android.view.View
+import android.widget.ArrayAdapter
 import androidx.core.widget.addTextChangedListener
 import com.github.kr328.clash.core.model.ConnectionTracker
 import com.github.kr328.clash.core.model.ConnectionsSnapshot
@@ -48,6 +49,7 @@ class ConnectionsDesign(context: Context) : Design<ConnectionsDesign.Request>(co
 
     init {
         binding.self = this
+        binding.header.screenTitle.text = context.getString(R.string.connections_title)
         binding.connectionsList.adapter = adapter
         binding.btnConnectionsOpenLog.setOnClickListener {
             requests.trySend(Request.OpenLogcat)
@@ -68,15 +70,21 @@ class ConnectionsDesign(context: Context) : Design<ConnectionsDesign.Request>(co
             searchQuery = it?.toString().orEmpty()
             applyFilteredList()
         }
-        binding.connectionsFilterChips.setOnCheckedChangeListener { _, checkedId ->
-            filterMode = when (checkedId) {
-                R.id.filter_tcp -> FilterMode.TCP
-                R.id.filter_udp -> FilterMode.UDP
-                R.id.filter_direct -> FilterMode.DIRECT
-                R.id.filter_proxy -> FilterMode.PROXY
-                R.id.filter_reject -> FilterMode.REJECT
-                else -> FilterMode.ALL
-            }
+        val filterModes = FilterMode.values().toList()
+        val filterLabels = listOf(
+            context.getString(R.string.connections_filter_all),
+            context.getString(R.string.connections_filter_tcp),
+            context.getString(R.string.connections_filter_udp),
+            context.getString(R.string.connections_filter_direct),
+            context.getString(R.string.connections_filter_proxy),
+            context.getString(R.string.connections_filter_reject),
+        )
+        binding.connectionsFilterDropdown.setAdapter(
+            ArrayAdapter(context, android.R.layout.simple_dropdown_item_1line, filterLabels),
+        )
+        binding.connectionsFilterDropdown.setText(filterLabels[filterModes.indexOf(filterMode)], false)
+        binding.connectionsFilterDropdown.setOnItemClickListener { _, _, position, _ ->
+            filterMode = filterModes.getOrElse(position) { FilterMode.ALL }
             applyFilteredList()
         }
         renderSnapshot(ConnectionsSnapshot())

--- a/design/src/main/java/com/github/kr328/clash/design/EffectiveRulesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/EffectiveRulesDesign.kt
@@ -60,6 +60,7 @@ class EffectiveRulesDesign(context: Context) : Design<EffectiveRulesDesign.Reque
 
     init {
         binding.self = this
+        binding.header.screenTitle.text = context.getString(R.string.effective_rules_title)
         binding.ruleList.layoutManager = LinearLayoutManager(context)
         binding.ruleList.adapter = adapter
         binding.btnOpenLogcat.setOnClickListener {

--- a/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
@@ -53,10 +53,7 @@ class GeoDataSourceSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         val customDependencies: MutableList<Preference> = mutableListOf()
         var mirrorTips: TipsPreference? = null

--- a/design/src/main/java/com/github/kr328/clash/design/GeoSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/GeoSettingsDesign.kt
@@ -29,10 +29,7 @@ class GeoSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         val booleanValues: Array<Boolean?> = arrayOf(
             null,

--- a/design/src/main/java/com/github/kr328/clash/design/LanguageSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/LanguageSettingsDesign.kt
@@ -25,10 +25,7 @@ class LanguageSettingsDesign(
 
     init {
         binding.self = this
-        binding.toolbar.title = context.getString(R.string.app_language)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = context.getString(R.string.app_language)
         applyCheckedLanguage()
         binding.languageGroup.setOnCheckedChangeListener { _, checkedId ->
             val lang = when (checkedId) {

--- a/design/src/main/java/com/github/kr328/clash/design/LogcatDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/LogcatDesign.kt
@@ -56,11 +56,6 @@ class LogcatDesign(
         binding.self = this
         binding.streaming = streaming
 
-        binding.toolbar.title = context.getString(R.string.logcat)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
-
         binding.recyclerList.layoutManager = LinearLayoutManager(context).apply {
             if (streaming) {
                 reverseLayout = true

--- a/design/src/main/java/com/github/kr328/clash/design/LogsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/LogsDesign.kt
@@ -51,11 +51,6 @@ class LogsDesign(context: Context) : Design<LogsDesign.Request>(context) {
     init {
         binding.self = this
 
-        binding.toolbar.title = context.getString(R.string.logs)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
-
         binding.recyclerList.applyLinearAdapter(context, adapter)
     }
 }

--- a/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
@@ -48,10 +48,7 @@ class MetaFeatureSettingsDesign(
     init {
         binding.self = this
 
-        binding.toolbar.title = context.getString(R.string.meta_features)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = context.getString(R.string.meta_features)
 
         val booleanValues: Array<Boolean?> = arrayOf(
             null,

--- a/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
@@ -33,10 +33,7 @@ class NetworkSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = (context as? Activity)?.title?.toString().orEmpty()
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = (context as? Activity)?.title?.toString().orEmpty()
 
         val screen = preferenceScreen(context) {
             val vpnDependencies: MutableList<Preference> = mutableListOf()

--- a/design/src/main/java/com/github/kr328/clash/design/ProxyChainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ProxyChainDesign.kt
@@ -40,7 +40,6 @@ class ProxyChainDesign(
         false,
     )
 
-    private val toolbar: MaterialToolbar = rootView.findViewById(R.id.toolbar)
     private val scroll: NestedScrollView = rootView.findViewById(R.id.proxy_chain_scroll)
     private val diskChainsDetail: TextView = rootView.findViewById(R.id.disk_chains_detail)
     private val diskChainSpinner: AutoCompleteTextView = rootView.findViewById(R.id.disk_chain_spinner)
@@ -65,16 +64,11 @@ class ProxyChainDesign(
     init {
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            toolbar.setPadding(toolbar.paddingLeft, bars.top, toolbar.paddingRight, toolbar.paddingBottom)
             v.setPaddingRelative(bars.left, 0, bars.right, 0)
-            scroll.setPadding(scroll.paddingLeft, scroll.paddingTop, scroll.paddingRight, bars.bottom + 16)
+            scroll.setPadding(scroll.paddingLeft, bars.top, scroll.paddingRight, bars.bottom + 16)
             insets
         }
         rootView.post { ViewCompat.requestApplyInsets(rootView) }
-
-        toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
 
         btnConnect.setOnClickListener {
             requests.trySend(Request.Connect)

--- a/design/src/main/java/com/github/kr328/clash/design/ProxyProviderMergedGroupDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ProxyProviderMergedGroupDesign.kt
@@ -25,7 +25,6 @@ class ProxyProviderMergedGroupDesign(
         false,
     )
 
-    private val toolbar: MaterialToolbar = rootView.findViewById(R.id.toolbar)
     val summaryKeys: TextView = rootView.findViewById(R.id.provider_keys_summary)
     private val mergedExistingEmpty: TextView = rootView.findViewById(R.id.merged_existing_empty)
     private val mergedExistingList: LinearLayout = rootView.findViewById(R.id.merged_existing_list)
@@ -34,16 +33,13 @@ class ProxyProviderMergedGroupDesign(
         get() = rootView
 
     init {
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
             val top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
             v.setPadding(v.paddingLeft, top, v.paddingRight, v.paddingBottom)
             insets
         }
         rootView.post { ViewCompat.requestApplyInsets(rootView) }
 
-        toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
         rootView.findViewById<View>(R.id.btn_add_merged_select).setOnClickListener {
             requests.trySend(Request.AddMergedSelectGroup)
         }

--- a/design/src/main/java/com/github/kr328/clash/design/RoutingHubDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/RoutingHubDesign.kt
@@ -22,7 +22,7 @@ class RoutingHubDesign(context: Context) : Design<RoutingHubDesign.Request>(cont
 
     init {
         binding.self = this
-        binding.toolbar.title = context.getString(R.string.nav_routing)
+        binding.header.screenTitle.text = context.getString(R.string.nav_routing)
 
         binding.cardEffectiveRules.setOnClickListener { requests.trySend(Request.OpenEffectiveRules) }
         binding.cardRuleSnippets.setOnClickListener { requests.trySend(Request.OpenRules) }

--- a/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/RuleSnippetDesign.kt
@@ -34,7 +34,7 @@ class RuleSnippetDesign(context: Context) : Design<RuleSnippetDesign.Request>(co
 
     init {
         binding.self = this
-        binding.toolbar.title = context.getString(R.string.rule_snippet_title)
+        binding.header.screenTitle.text = context.getString(R.string.rule_snippet_title)
         binding.btnOpenCreateSheet.setOnClickListener { requests.trySend(Request.OpenCreateSheet) }
         binding.btnOpenManualRules.setOnClickListener { requests.trySend(Request.OpenManualRules) }
         binding.btnUpdateAllRuleSets.setOnClickListener { requests.trySend(Request.UpdateAllRuleSets) }

--- a/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
@@ -23,10 +23,7 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
 
     init {
         binding.self = this
-        binding.toolbar.title = context.getString(R.string.main_advanced_settings)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = context.getString(R.string.main_advanced_settings)
     }
 
     fun request(request: Request) {

--- a/design/src/main/java/com/github/kr328/clash/design/SubscriptionIdentityDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SubscriptionIdentityDesign.kt
@@ -42,10 +42,7 @@ class SubscriptionIdentityDesign(context: Context) : Design<SubscriptionIdentity
 
     init {
         binding.self = this
-        binding.toolbar.title = context.getString(R.string.subscription_identity)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = context.getString(R.string.subscription_identity)
         binding.textSupportedResponseHeaders.text = buildSupportedResponseHeadersText(context)
         renderDocsRows()
     }

--- a/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
@@ -53,10 +53,7 @@ class ThemeSettingsDesign(
 
     init {
         binding.surface = surface
-        binding.toolbar.title = context.getString(R.string.theme_settings)
-        binding.toolbar.setNavigationOnClickListener {
-            (context as? AppCompatActivity)?.onBackPressedDispatcher?.onBackPressed()
-        }
+        binding.header.screenTitle.text = context.getString(R.string.theme_settings)
 
         setupThemeMode()
         setupDynamicColors()

--- a/design/src/main/res/layout/design_access_control.xml
+++ b/design/src/main/res/layout/design_access_control.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable
             name="self"
@@ -36,11 +37,19 @@
                     android:gravity="center_vertical"
                     android:orientation="horizontal">
 
-                    <include
-                        layout="@layout/common_activity_bar"
+                    <TextView
+                        android:id="@+id/screen_title"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1" />
+                        android:layout_weight="1"
+                        android:paddingStart="16dp"
+                        android:paddingTop="4dp"
+                        android:paddingBottom="4dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.App.TitleLarge"
+                        android:textColor="?attr/colorOnSurface"
+                        android:textStyle="bold" />
 
                     <ImageView
                         android:id="@+id/menu_view"
@@ -107,69 +116,54 @@
                         android:text="@string/deny_selected_apps" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
-                <com.google.android.material.textfield.TextInputLayout
-                    style="@style/AppTextInputLayout"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/item_tailing_margin"
                     android:layout_marginTop="@dimen/item_text_margin"
-                    android:hint="@string/search"
-                    app:startIconDrawable="@drawable/ic_baseline_search">
+                    android:baselineAligned="false"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/search_input"
-                        android:layout_width="match_parent"
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/AppTextInputLayout"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:imeOptions="actionDone"
-                        android:inputType="text"
-                        android:maxLines="1" />
-                </com.google.android.material.textfield.TextInputLayout>
+                        android:layout_weight="1"
+                        android:hint="@string/search"
+                        app:startIconDrawable="@drawable/ic_baseline_search">
 
-                <com.google.android.material.chip.ChipGroup
-                    android:id="@+id/namespace_filter_group"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="@dimen/item_tailing_margin"
-                    android:layout_marginTop="@dimen/item_text_margin"
-                    app:singleSelection="true"
-                    app:selectionRequired="true">
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/search_input"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:imeOptions="actionDone"
+                            android:inputType="text"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/filter_all_chip"
-                        style="@style/AppChip.Filter"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/namespace_filter_layout"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:checked="true"
-                        android:text="@string/filter" />
+                        android:layout_marginStart="8dp">
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/filter_ru_chip"
-                        style="@style/AppChip.Filter"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/app_routing_filter_ru" />
-
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/filter_cn_chip"
-                        style="@style/AppChip.Filter"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/app_routing_filter_cn" />
-
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/filter_com_chip"
-                        style="@style/AppChip.Filter"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/app_routing_filter_com" />
-
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/filter_other_chip"
-                        style="@style/AppChip.Filter"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/app_routing_filter_other" />
-                </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                            android:id="@+id/namespace_filter_dropdown"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:inputType="none"
+                            android:minWidth="100dp"
+                            tools:ignore="LabelFor" />
+                    </com.google.android.material.textfield.TextInputLayout>
+                </LinearLayout>
 
                 <TextView
                     android:id="@+id/counter_view"

--- a/design/src/main/res/layout/design_connections.xml
+++ b/design/src/main/res/layout/design_connections.xml
@@ -28,8 +28,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="16dp"
-                android:paddingTop="10dp"
+                android:paddingTop="12dp"
                 android:paddingBottom="10dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <com.google.android.material.card.MaterialCardView
                     style="@style/AppCard.Filled"
@@ -47,25 +51,11 @@
                         android:orientation="vertical"
                         android:padding="16dp">
 
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_title"
-                            android:textAppearance="@style/TextAppearance.App.TitleMedium"
-                            android:textColor="?attr/colorOnSurface"
-                            android:textStyle="bold" />
-
                         <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
                             android:gravity="center_vertical"
                             android:orientation="horizontal">
-
-                            <View
-                                android:layout_width="0dp"
-                                android:layout_height="1dp"
-                                android:layout_weight="1" />
 
                             <com.google.android.material.button.MaterialButton
                                 android:id="@+id/btn_connections_open_log"
@@ -202,82 +192,54 @@
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 
-                <com.google.android.material.textfield.TextInputLayout
-                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
-                    android:hint="@string/connections_search_hint"
-                    app:endIconMode="clear_text"
-                    app:startIconDrawable="@drawable/ic_baseline_search">
+                    android:baselineAligned="false"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/connections_search"
-                        android:layout_width="match_parent"
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:imeOptions="actionSearch"
-                        android:inputType="text"
-                        android:maxLines="1" />
-                </com.google.android.material.textfield.TextInputLayout>
+                        android:layout_weight="1"
+                        android:hint="@string/connections_search_hint"
+                        app:endIconMode="clear_text"
+                        app:startIconDrawable="@drawable/ic_baseline_search">
 
-                <HorizontalScrollView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:overScrollMode="never"
-                    android:scrollbars="none">
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/connections_search"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:imeOptions="actionSearch"
+                            android:inputType="text"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <com.google.android.material.chip.ChipGroup
-                        android:id="@+id/connections_filter_chips"
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/connections_filter_layout"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        app:singleLine="true"
-                        app:singleSelection="true">
+                        android:layout_marginStart="8dp">
 
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_all"
-                            style="@style/Widget.Material3.Chip.Filter"
+                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                            android:id="@+id/connections_filter_dropdown"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:checked="true"
-                            android:text="@string/connections_filter_all" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_tcp"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_filter_tcp" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_udp"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_filter_udp" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_direct"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_filter_direct" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_proxy"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_filter_proxy" />
-
-                        <com.google.android.material.chip.Chip
-                            android:id="@+id/filter_reject"
-                            style="@style/Widget.Material3.Chip.Filter"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connections_filter_reject" />
-                    </com.google.android.material.chip.ChipGroup>
-                </HorizontalScrollView>
+                            android:minHeight="0dp"
+                            android:paddingTop="9dp"
+                            android:paddingBottom="9dp"
+                            android:inputType="none"
+                            android:minWidth="112dp"
+                            tools:ignore="LabelFor" />
+                    </com.google.android.material.textfield.TextInputLayout>
+                </LinearLayout>
             </LinearLayout>
 
             <FrameLayout

--- a/design/src/main/res/layout/design_effective_rules.xml
+++ b/design/src/main/res/layout/design_effective_rules.xml
@@ -32,16 +32,9 @@
                 android:paddingTop="12dp"
                 android:paddingBottom="8dp">
 
-                <TextView
-                    android:id="@+id/screen_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingTop="4dp"
-                    android:paddingBottom="12dp"
-                    android:text="@string/effective_rules_title"
-                    android:textAppearance="@style/TextAppearance.App.TitleLarge"
-                    android:textColor="?attr/colorOnSurface"
-                    android:textStyle="bold" />
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/design/src/main/res/layout/design_language_settings.xml
+++ b/design/src/main/res/layout/design_language_settings.xml
@@ -15,17 +15,10 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:clipToPadding="false"
             android:paddingBottom="@{self.surface.insets.bottom}">
 
@@ -34,8 +27,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="@dimen/main_padding_horizontal"
-                android:paddingTop="18dp"
+                android:paddingTop="12dp"
                 android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <com.google.android.material.card.MaterialCardView
                     style="@style/AppCard.Filled"

--- a/design/src/main/res/layout/design_logcat.xml
+++ b/design/src/main/res/layout/design_logcat.xml
@@ -19,12 +19,17 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/screen_title"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
+            android:paddingStart="16dp"
+            android:paddingTop="@{self.surface.insets.top}"
+            android:paddingBottom="12dp"
+            android:text="@string/logcat"
+            android:textAppearance="@style/TextAppearance.App.TitleLarge"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold" />
 
         <com.github.kr328.clash.design.view.AppRecyclerView
             android:id="@+id/recycler_list"

--- a/design/src/main/res/layout/design_logs.xml
+++ b/design/src/main/res/layout/design_logs.xml
@@ -18,14 +18,20 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingTop="@{self.surface.insets.top}">
 
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                style="@style/AppToolbar"
+            <TextView
+                android:id="@+id/screen_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingTop="@{self.surface.insets.top}" />
+                android:paddingHorizontal="16dp"
+                android:paddingTop="18dp"
+                android:paddingBottom="12dp"
+                android:text="@string/logs"
+                android:textAppearance="@style/TextAppearance.App.TitleLarge"
+                android:textColor="?attr/colorOnSurface"
+                android:textStyle="bold" />
 
             <ImageView
                 android:id="@+id/delete_view"

--- a/design/src/main/res/layout/design_main.xml
+++ b/design/src/main/res/layout/design_main.xml
@@ -831,7 +831,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="20dp"
-                android:paddingTop="8dp"
+                android:paddingTop="18dp"
                 android:paddingBottom="24dp">
 
                 <TextView

--- a/design/src/main/res/layout/design_proxy_chain.xml
+++ b/design/src/main/res/layout/design_proxy_chain.xml
@@ -6,13 +6,6 @@
     android:background="?attr/colorSurface"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
-        style="@style/AppToolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:title="" />
-
     <androidx.core.widget.NestedScrollView
         android:id="@+id/proxy_chain_scroll"
         android:layout_width="match_parent"
@@ -26,6 +19,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/screen_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="18dp"
+                android:paddingBottom="12dp"
+                android:text="@string/proxy_chain_title"
+                android:textAppearance="@style/TextAppearance.App.TitleLarge"
+                android:textColor="?attr/colorOnSurface"
+                android:textStyle="bold" />
 
             <com.google.android.material.card.MaterialCardView
                 style="@style/AppCard.Filled"

--- a/design/src/main/res/layout/design_proxy_provider_merged_group.xml
+++ b/design/src/main/res/layout/design_proxy_provider_merged_group.xml
@@ -5,12 +5,17 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <TextView
+        android:id="@+id/screen_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        app:title="@string/proxy_providers_merged_screen_title" />
+        android:paddingHorizontal="@dimen/main_padding_horizontal"
+        android:paddingTop="18dp"
+        android:paddingBottom="12dp"
+        android:text="@string/proxy_providers_merged_screen_title"
+        android:textAppearance="@style/TextAppearance.App.TitleLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"

--- a/design/src/main/res/layout/design_proxy_providers_editor.xml
+++ b/design/src/main/res/layout/design_proxy_providers_editor.xml
@@ -11,8 +11,19 @@
         style="@style/AppToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        app:title="@string/proxy_providers_editor_title" />
+        android:minHeight="?attr/actionBarSize" />
+
+    <TextView
+        android:id="@+id/screen_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="12dp"
+        android:text="@string/proxy_providers_editor_title"
+        android:textAppearance="@style/TextAppearance.App.TitleLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold" />
 
     <com.google.android.material.card.MaterialCardView
         style="@style/AppCard.Filled"

--- a/design/src/main/res/layout/design_routing_hub.xml
+++ b/design/src/main/res/layout/design_routing_hub.xml
@@ -17,19 +17,12 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <com.github.kr328.clash.design.view.ObservableScrollView
             android:id="@+id/scroll_root"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:paddingBottom="@{self.surface.insets.bottom}">
 
             <LinearLayout
@@ -39,6 +32,10 @@
                 android:paddingHorizontal="16dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <TextView
                     android:layout_width="match_parent"

--- a/design/src/main/res/layout/design_rule_snippet.xml
+++ b/design/src/main/res/layout/design_rule_snippet.xml
@@ -15,18 +15,11 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:paddingBottom="@{self.surface.insets.bottom}">
 
             <LinearLayout
@@ -34,8 +27,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="@dimen/main_padding_horizontal"
-                android:paddingTop="10dp"
+                android:paddingTop="12dp"
                 android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <com.google.android.material.card.MaterialCardView
                     style="@style/AppCard.Filled"

--- a/design/src/main/res/layout/design_settings.xml
+++ b/design/src/main/res/layout/design_settings.xml
@@ -17,19 +17,12 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <com.github.kr328.clash.design.view.ObservableScrollView
             android:id="@+id/scroll_root"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:paddingBottom="@{self.surface.insets.bottom}"
             android:scrollbars="none">
 
@@ -40,6 +33,10 @@
                 android:paddingHorizontal="16dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <TextView
                     android:layout_width="match_parent"

--- a/design/src/main/res/layout/design_settings_common.xml
+++ b/design/src/main/res/layout/design_settings_common.xml
@@ -15,29 +15,32 @@
         android:paddingStart="@{surface.insets.start}"
         android:paddingEnd="@{surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{surface.insets.top}" />
-
         <com.github.kr328.clash.design.view.ObservableScrollView
             android:id="@+id/scroll_root"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, surface.insets.top)}"
+            app:marginTopPx="@{surface.insets.top}"
             android:paddingBottom="@{surface.insets.bottom}"
             android:scrollbars="none">
 
-            <FrameLayout
-                android:id="@+id/content"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingHorizontal="16dp"
                 android:paddingTop="12dp"
-                android:paddingBottom="24dp" />
+                android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
+
+                <FrameLayout
+                    android:id="@+id/content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
         </com.github.kr328.clash.design.view.ObservableScrollView>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/design/src/main/res/layout/design_settings_meta_feature.xml
+++ b/design/src/main/res/layout/design_settings_meta_feature.xml
@@ -15,28 +15,31 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <com.github.kr328.clash.design.view.ObservableScrollView
             android:id="@+id/scroll_root"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:scrollbars="none">
 
-            <FrameLayout
-                android:id="@+id/content"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingHorizontal="16dp"
                 android:paddingTop="12dp"
-                android:paddingBottom="@{self.surface.insets.bottom}" />
+                android:paddingBottom="@{self.surface.insets.bottom}">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
+
+                <FrameLayout
+                    android:id="@+id/content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
         </com.github.kr328.clash.design.view.ObservableScrollView>
 
         <FrameLayout

--- a/design/src/main/res/layout/design_subscription_identity.xml
+++ b/design/src/main/res/layout/design_subscription_identity.xml
@@ -15,17 +15,10 @@
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{self.surface.insets.top}" />
-
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, self.surface.insets.top)}"
+            app:marginTopPx="@{self.surface.insets.top}"
             android:clipToPadding="false"
             android:paddingBottom="@{self.surface.insets.bottom}">
 
@@ -34,8 +27,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="@dimen/main_padding_horizontal"
-                android:paddingTop="8dp"
+                android:paddingTop="12dp"
                 android:paddingBottom="24dp">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <!-- ===== Device ===== -->
                 <TextView

--- a/design/src/main/res/layout/design_theme_settings.xml
+++ b/design/src/main/res/layout/design_theme_settings.xml
@@ -16,19 +16,12 @@
         android:paddingStart="@{surface.insets.start}"
         android:paddingEnd="@{surface.insets.end}">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            style="@style/AppToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@{surface.insets.top}" />
-
         <com.github.kr328.clash.design.view.ObservableScrollView
             android:id="@+id/scroll_root"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            app:marginTopPx="@{BindingExpressions.marginBelowToolbarPx(context, surface.insets.top)}"
+            app:marginTopPx="@{surface.insets.top}"
             android:scrollbars="none">
 
             <LinearLayout
@@ -36,8 +29,12 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="16dp"
-                android:paddingTop="@dimen/theme_screen_top_extra"
+                android:paddingTop="12dp"
                 android:paddingBottom="@{surface.insets.bottom + context.resources.getDimensionPixelSize(com.github.kr328.clash.design.R.dimen.theme_screen_bottom_extra)}">
+
+                <include
+                    android:id="@+id/header"
+                    layout="@layout/include_screen_header" />
 
                 <com.google.android.material.button.MaterialButtonToggleGroup
                     android:id="@+id/theme_mode_group"

--- a/design/src/main/res/layout/include_screen_header.xml
+++ b/design/src/main/res/layout/include_screen_header.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data />
+
+    <TextView
+        android:id="@+id/screen_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="6dp"
+        android:paddingBottom="12dp"
+        android:textAppearance="@style/TextAppearance.App.TitleLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold"
+        tools:text="Routing" />
+</layout>


### PR DESCRIPTION
Replace MaterialToolbar titles with a large TextView header across ~20 screens via a shared include_screen_header. Drop the toolbar on back-only and hub screens (system back); keep a slim toolbar only where there are menu actions (Profiles, ProxyProvidersEditor). Convert App routing and Live Connections to the header style with compact search + a filter exposed-dropdown instead of chip rows. Align every header to inset+18, including the main tab pages (Routing page in design_main.xml). Root cause of the clipped 'g': MaterialToolbar clips its title descenders.