### PR TITLE
feat(profiles): read-only config.yaml viewer + trim profile menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -220,6 +220,11 @@
             android:exported="false"
             android:label="@string/rule_providers_editor_title" />
         <activity
+            android:name=".ProfileConfigActivity"
+            android:configChanges="uiMode"
+            android:exported="false"
+            android:label="@string/profile_menu_view_config" />
+        <activity
             android:name=".ProxyProvidersEditorActivity"
             android:configChanges="uiMode"
             android:exported="false"

--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -874,13 +874,8 @@ class MainActivity : BaseActivity<MainDesign>() {
         val m = popup.menu
         m.findItem(R.id.profile_menu_set_active).isVisible =
             profile.imported && !profile.active
-        m.findItem(R.id.profile_menu_update).isVisible =
-            profile.imported && profile.type != Profile.Type.File
         m.findItem(R.id.profile_menu_subscription_sources).isVisible = profile.imported
         m.findItem(R.id.profile_menu_duplicate).isVisible = profile.imported
-        val shareLocked = ServiceStore(this).subscriptionShareLinksLockedFor(profile.uuid)
-        m.findItem(R.id.profile_menu_share).isVisible =
-            profile.imported && profile.type == Profile.Type.Url && !shareLocked
         popup.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.profile_menu_set_active -> {
@@ -897,31 +892,6 @@ class MainActivity : BaseActivity<MainDesign>() {
                     }
                     true
                 }
-                R.id.profile_menu_update -> {
-                    launch {
-                        // Success / failure toast is driven by the
-                        // Profile-Update-Completed / Failed broadcast in
-                        // onProfileUpdateCompleted / onProfileUpdateFailed —
-                        // no manual toast here, otherwise the user gets a
-                        // stale "started" message *after* the actual result.
-                        runCatching { updateProfileWithProgress(profile.uuid) }
-                        design.fetch()
-                    }
-                    true
-                }
-                R.id.profile_menu_share -> {
-                    val text = profile.source.takeIf { it.isNotBlank() } ?: return@setOnMenuItemClickListener false
-                    startActivity(
-                        Intent.createChooser(
-                            Intent(Intent.ACTION_SEND).apply {
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, text)
-                            },
-                            getString(R.string.profile_menu_share),
-                        ),
-                    )
-                    true
-                }
                 R.id.profile_menu_edit -> {
                     showProfileQuickEditSheet(design, profile) { design.fetch() }
                     true
@@ -930,6 +900,10 @@ class MainActivity : BaseActivity<MainDesign>() {
                     if (profile.imported) {
                         startActivity(ProxyProvidersEditorActivity::class.intent.setUUID(profile.uuid))
                     }
+                    true
+                }
+                R.id.profile_menu_view_config -> {
+                    startActivity(ProfileConfigActivity::class.intent.setUUID(profile.uuid))
                     true
                 }
                 R.id.profile_menu_duplicate -> {

--- a/app/src/main/java/com/github/kr328/clash/ProfileConfigActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ProfileConfigActivity.kt
@@ -1,0 +1,72 @@
+package com.github.kr328.clash
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.getSystemService
+import com.github.kr328.clash.common.util.uuid
+import com.github.kr328.clash.design.ProfileConfigDesign
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.ui.ToastDuration
+import com.github.kr328.clash.design.util.showExceptionToast
+import com.github.kr328.clash.util.withProfile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
+
+class ProfileConfigActivity : BaseActivity<ProfileConfigDesign>() {
+    override suspend fun main() {
+        val uuid = intent.uuid ?: return finish()
+        val design = ProfileConfigDesign(this)
+        setContentDesign(design)
+
+        val profile = withProfile { queryByUUID(uuid) }
+        design.setTitle(
+            profile?.name?.takeIf { it.isNotBlank() }
+                ?: getString(R.string.profile_menu_view_config),
+        )
+
+        // Read-only snapshot of the on-disk config; never written back.
+        val config = withProfile { readConfigYaml(uuid) }.orEmpty()
+        design.setConfig(config)
+
+        while (isActive) {
+            select<Unit> {
+                design.requests.onReceive { req ->
+                    when (req) {
+                        ProfileConfigDesign.Request.Copy -> {
+                            if (config.isNotBlank()) {
+                                val clip = ClipData.newPlainText("config.yaml", config)
+                                getSystemService<ClipboardManager>()?.setPrimaryClip(clip)
+                                design.showToast(R.string.copied, ToastDuration.Short)
+                            }
+                        }
+                        ProfileConfigDesign.Request.Download -> {
+                            if (config.isNotBlank()) {
+                                val baseName = profile?.name?.takeIf { it.isNotBlank() } ?: "config"
+                                val fileName = baseName.replace(Regex("[^A-Za-z0-9._-]"), "_") + ".yaml"
+                                val output = startActivityForResult(
+                                    ActivityResultContracts.CreateDocument("text/yaml"),
+                                    fileName,
+                                )
+                                if (output != null) {
+                                    try {
+                                        withContext(Dispatchers.IO) {
+                                            contentResolver.openOutputStream(output)?.use {
+                                                it.write(config.toByteArray())
+                                            }
+                                        }
+                                        design.showToast(R.string.file_exported, ToastDuration.Long)
+                                    } catch (e: Exception) {
+                                        design.showExceptionToast(e)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/ProfileConfigDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ProfileConfigDesign.kt
@@ -1,0 +1,75 @@
+package com.github.kr328.clash.design
+
+import android.content.Context
+import android.view.View
+import com.github.kr328.clash.design.databinding.DesignProfileConfigBinding
+import com.github.kr328.clash.design.util.YamlHighlighter
+import com.github.kr328.clash.design.util.layoutInflater
+import com.github.kr328.clash.design.util.root
+import com.google.android.material.color.MaterialColors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Read-only viewer of a profile's processed `config.yaml`. Displays YAML with lightweight
+ * syntax highlighting in a monospace view; never writes the file. Copy/Share are routed to
+ * the host activity via [Request].
+ */
+class ProfileConfigDesign(context: Context) : Design<ProfileConfigDesign.Request>(context) {
+    enum class Request {
+        Copy, Download
+    }
+
+    private val binding = DesignProfileConfigBinding
+        .inflate(context.layoutInflater, context.root, false)
+
+    // Resolved from yaml* theme attrs so the palette follows the app's in-app day/night
+    // (the app applies AppThemeLight/Dark via theme.applyStyle, not the night resource qualifier).
+    private val highlightColors by lazy {
+        YamlHighlighter.Colors(
+            key = themeColor(R.attr.yamlKey),
+            string = themeColor(R.attr.yamlString),
+            number = themeColor(R.attr.yamlNumber),
+            keyword = themeColor(R.attr.yamlKeyword),
+            comment = themeColor(R.attr.yamlComment),
+            punctuation = themeColor(R.attr.yamlPunctuation),
+            plain = themeColor(R.attr.yamlPlain),
+        )
+    }
+
+    private fun themeColor(attr: Int): Int = MaterialColors.getColor(binding.configText, attr)
+
+    override val root: View
+        get() = binding.root
+
+    suspend fun setTitle(title: String) {
+        withContext(Dispatchers.Main) {
+            binding.screenTitle.text = title
+        }
+    }
+
+    suspend fun setConfig(text: String?) {
+        val content = text.orEmpty()
+        // Resolve theme colors on the main thread before highlighting off-main.
+        val colors = if (content.isBlank() || content.length > MAX_HIGHLIGHT_CHARS) null else highlightColors
+        val rendered: CharSequence = if (colors == null) {
+            content
+        } else {
+            withContext(Dispatchers.Default) { YamlHighlighter.highlight(content, colors) }
+        }
+        withContext(Dispatchers.Main) {
+            binding.empty = content.isBlank()
+            binding.configText.text = rendered
+        }
+    }
+
+    init {
+        binding.self = this
+        binding.empty = false
+    }
+
+    companion object {
+        // Above this size, skip highlighting (rare multi-MB configs) and show plain text.
+        private const val MAX_HIGHLIGHT_CHARS = 300_000
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/util/YamlHighlighter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/util/YamlHighlighter.kt
@@ -1,0 +1,120 @@
+package com.github.kr328.clash.design.util
+
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+
+/**
+ * Lightweight, dependency-free YAML syntax highlighter that returns a spanned [CharSequence]
+ * for a monospace TextView. Line-based and intentionally forgiving — it aims for a readable
+ * view of a profile's config.yaml, not a strict YAML parser. Run it off the main thread.
+ */
+object YamlHighlighter {
+    data class Colors(
+        val key: Int,
+        val string: Int,
+        val number: Int,
+        val keyword: Int,
+        val comment: Int,
+        val punctuation: Int,
+        val plain: Int,
+    )
+
+    // key: value  /  - key: value  (colon must be followed by whitespace or end-of-line,
+    // so "http://" inside a value is not mistaken for a key separator).
+    private val KEY_REGEX = Regex("""^(\s*(?:-\s+)*)([^:#\n]+?)(:)(?=\s|$)""")
+    private val LIST_REGEX = Regex("""^(\s*)(-)(\s+)(.*)$""")
+
+    fun highlight(text: String, colors: Colors): CharSequence {
+        val sb = SpannableStringBuilder()
+        val lines = text.split("\n")
+        for ((i, line) in lines.withIndex()) {
+            appendLine(sb, line, colors)
+            if (i < lines.size - 1) sb.append("\n")
+        }
+        return sb
+    }
+
+    private fun appendLine(sb: SpannableStringBuilder, line: String, colors: Colors) {
+        if (line.isEmpty()) return
+        if (line.trimStart().startsWith("#")) {
+            appendColored(sb, line, colors.comment, italic = true)
+            return
+        }
+        if (line.isBlank()) {
+            sb.append(line)
+            return
+        }
+
+        // Split off a trailing inline comment (# not inside quotes, preceded by whitespace).
+        val commentIdx = findInlineComment(line)
+        val code = if (commentIdx >= 0) line.substring(0, commentIdx) else line
+        val comment = if (commentIdx >= 0) line.substring(commentIdx) else null
+
+        val keyMatch = KEY_REGEX.find(code)
+        if (keyMatch != null) {
+            appendColored(sb, keyMatch.groupValues[1], colors.punctuation)
+            appendColored(sb, keyMatch.groupValues[2], colors.key)
+            appendColored(sb, keyMatch.groupValues[3], colors.punctuation)
+            appendValue(sb, code.substring(keyMatch.range.last + 1), colors)
+        } else {
+            val listMatch = LIST_REGEX.find(code)
+            if (listMatch != null) {
+                appendColored(sb, listMatch.groupValues[1], colors.plain)
+                appendColored(sb, listMatch.groupValues[2], colors.punctuation)
+                appendColored(sb, listMatch.groupValues[3], colors.plain)
+                appendValue(sb, listMatch.groupValues[4], colors)
+            } else {
+                appendValue(sb, code, colors)
+            }
+        }
+        if (comment != null) appendColored(sb, comment, colors.comment, italic = true)
+    }
+
+    private fun appendValue(sb: SpannableStringBuilder, raw: String, colors: Colors) {
+        if (raw.isEmpty()) return
+        val leading = raw.takeWhile { it == ' ' || it == '\t' }
+        if (leading.isNotEmpty()) sb.append(leading)
+        val value = raw.substring(leading.length)
+        if (value.isEmpty()) return
+        val color = when {
+            value == "true" || value == "false" || value == "null" || value == "~" -> colors.keyword
+            value.startsWith("&") || value.startsWith("*") || value.startsWith("!") -> colors.keyword
+            value.toDoubleOrNull() != null -> colors.number
+            // Most YAML scalar values are unquoted (type: vmess, server: 1.2.3.4, name: Hong Kong);
+            // colour them as strings so the view reads like a real editor, not mostly plain text.
+            else -> colors.string
+        }
+        appendColored(sb, value, color)
+    }
+
+    private fun findInlineComment(line: String): Int {
+        var inSingle = false
+        var inDouble = false
+        for (i in line.indices) {
+            when (val c = line[i]) {
+                '\'' -> if (!inDouble) inSingle = !inSingle
+                '"' -> if (!inSingle) inDouble = !inDouble
+                '#' -> if (!inSingle && !inDouble && (i == 0 || line[i - 1] == ' ' || line[i - 1] == '\t')) {
+                    return i
+                }
+            }
+        }
+        return -1
+    }
+
+    private fun appendColored(
+        sb: SpannableStringBuilder,
+        text: CharSequence,
+        color: Int,
+        italic: Boolean = false,
+    ) {
+        if (text.isEmpty()) return
+        val start = sb.length
+        sb.append(text)
+        sb.setSpan(ForegroundColorSpan(color), start, sb.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        if (italic) sb.setSpan(StyleSpan(Typeface.ITALIC), start, sb.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+}

--- a/design/src/main/res/layout/design_profile_config.xml
+++ b/design/src/main/res/layout/design_profile_config.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <variable
+            name="self"
+            type="com.github.kr328.clash.design.ProfileConfigDesign" />
+        <variable
+            name="empty"
+            type="boolean" />
+        <import type="android.view.View" />
+        <import type="com.github.kr328.clash.design.ProfileConfigDesign.Request" />
+    </data>
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurface"
+        android:paddingStart="@{self.surface.insets.start}"
+        android:paddingEnd="@{self.surface.insets.end}">
+
+        <TextView
+            android:id="@+id/screen_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingTop="@{self.surface.insets.top}"
+            android:paddingBottom="12dp"
+            android:text="@string/profile_menu_view_config"
+            android:textAppearance="@style/TextAppearance.App.TitleLarge"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold" />
+
+        <ScrollView
+            android:id="@+id/config_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingTop="@{self.surface.insets.top + context.resources.getDimensionPixelSize(com.github.kr328.clash.design.R.dimen.toolbar_height)}"
+            android:paddingBottom="@{self.surface.insets.bottom}"
+            android:scrollbars="vertical"
+            android:visibility="@{empty ? View.GONE : View.VISIBLE}">
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:scrollbars="horizontal">
+
+                <TextView
+                    android:id="@+id/config_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="monospace"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="8dp"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textIsSelectable="true"
+                    android:textSize="13sp"
+                    tools:text="proxies:\n  - name: Example" />
+            </HorizontalScrollView>
+        </ScrollView>
+
+        <TextView
+            android:id="@+id/empty_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:paddingHorizontal="28dp"
+            android:text="@string/profile_config_empty"
+            android:textAppearance="@style/TextAppearance.App.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:visibility="@{empty ? View.VISIBLE : View.GONE}" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:paddingTop="@{self.surface.insets.top}"
+            android:paddingEnd="@dimen/item_tailing_margin">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical">
+
+                <ImageView
+                    android:layout_width="@dimen/item_tailing_component_size"
+                    android:layout_height="@dimen/item_tailing_component_size"
+                    android:layout_marginStart="@dimen/item_tailing_margin"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:contentDescription="@string/profile_config_copy"
+                    android:focusable="true"
+                    android:onClick="@{() -> self.requests.offer(Request.Copy)}"
+                    android:padding="@dimen/toolbar_image_action_padding"
+                    android:src="@drawable/ic_baseline_content_copy" />
+
+                <ImageView
+                    android:layout_width="@dimen/item_tailing_component_size"
+                    android:layout_height="@dimen/item_tailing_component_size"
+                    android:layout_marginStart="@dimen/item_tailing_margin"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:contentDescription="@string/profile_config_download"
+                    android:focusable="true"
+                    android:onClick="@{() -> self.requests.offer(Request.Download)}"
+                    android:padding="@dimen/toolbar_image_action_padding"
+                    android:src="@drawable/ic_baseline_get_app" />
+            </LinearLayout>
+        </FrameLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>

--- a/design/src/main/res/menu/menu_profile_home.xml
+++ b/design/src/main/res/menu/menu_profile_home.xml
@@ -4,17 +4,14 @@
         android:id="@+id/profile_menu_set_active"
         android:title="@string/profile_menu_set_active" />
     <item
-        android:id="@+id/profile_menu_update"
-        android:title="@string/update" />
-    <item
-        android:id="@+id/profile_menu_share"
-        android:title="@string/profile_menu_share" />
-    <item
         android:id="@+id/profile_menu_edit"
         android:title="@string/edit" />
     <item
         android:id="@+id/profile_menu_subscription_sources"
         android:title="@string/profile_menu_subscription_sources" />
+    <item
+        android:id="@+id/profile_menu_view_config"
+        android:title="@string/profile_menu_view_config" />
     <item
         android:id="@+id/profile_menu_duplicate"
         android:title="@string/duplicate" />

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -368,7 +368,6 @@
     <string name="profile_quick_edit_title">Быстрое редактирование подписки</string>
     <string name="profile_quick_open_advanced">Открыть полный редактор</string>
     <string name="profile_quick_saved">Подписка обновлена</string>
-    <string name="profile_menu_share">Поделиться ссылкой подписки</string>
     <string name="subscription_source_locked">URL этой подписки нельзя менять (политика оператора).</string>
     <string name="sub_meta_allow_http">Разрешить HTTP для запроса метаданных подписки</string>
     <string name="sub_meta_allow_http_summary">Если выключено, метаданные запрашиваются только по HTTPS. Включайте только если панель отдаёт метаданные по HTTP (небезопасно).</string>
@@ -671,6 +670,10 @@
     <string name="proxy_providers_merged_remove_confirm">Удалить proxy-group «%s» из этого профиля?</string>
     <string name="proxy_providers_merged_removed_ok">Группа удалена из конфига.</string>
     <string name="profile_menu_subscription_sources">Источники подписок</string>
+    <string name="profile_menu_view_config">Посмотреть конфиг</string>
+    <string name="profile_config_empty">У этого профиля ещё нет сгенерированного конфига.</string>
+    <string name="profile_config_copy">Скопировать конфиг</string>
+    <string name="profile_config_download">Скачать конфиг</string>
     <string name="profile_menu_sheet_subtitle">Выберите действие для этого профиля</string>
     <string name="properties_section_subscription">Подписка</string>
     <string name="properties_editor_intro">Вставьте ссылку подписки, задайте имя и интервал обновления, затем сохраните.</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -319,7 +319,6 @@
     <string name="profile_quick_edit_title">快速编辑订阅</string>
     <string name="profile_quick_open_advanced">打开完整编辑器</string>
     <string name="profile_quick_saved">订阅已更新</string>
-    <string name="profile_menu_share">分享订阅链接</string>
     <string name="subscription_source_locked">根据运营商策略，无法编辑此订阅 URL。</string>
     <string name="sub_meta_allow_http">允许通过 HTTP 拉取订阅元数据</string>
     <string name="sub_meta_allow_http_summary">关闭时仅通过 HTTPS 获取元数据头。仅在面板使用 HTTP（明文）时开启。</string>
@@ -438,6 +437,10 @@
     <string name="profile_force_update">从 URL 更新订阅</string>
     <string name="profile_menu_set_active">设为活动</string>
     <string name="profile_menu_subscription_sources">订阅源</string>
+    <string name="profile_menu_view_config">查看配置</string>
+    <string name="profile_config_empty">该配置文件尚未生成配置。</string>
+    <string name="profile_config_copy">复制配置</string>
+    <string name="profile_config_download">下载配置</string>
     <string name="profile_menu_sheet_subtitle">为此配置选择操作</string>
     <string name="profile_ping_all">延迟测试（全部节点）</string>
     <string name="profile_ping_ms_result">延迟约 %d ms（直连）</string>

--- a/design/src/main/res/values/attrs.xml
+++ b/design/src/main/res/values/attrs.xml
@@ -9,6 +9,15 @@
     <attr name="colorControlDisabled" format="color" />
     <attr name="colorLogo" format="color" />
 
+    <!-- YAML config viewer syntax highlighting (resolves per AppThemeLight / AppThemeDark) -->
+    <attr name="yamlKey" format="color" />
+    <attr name="yamlString" format="color" />
+    <attr name="yamlNumber" format="color" />
+    <attr name="yamlKeyword" format="color" />
+    <attr name="yamlComment" format="color" />
+    <attr name="yamlPunctuation" format="color" />
+    <attr name="yamlPlain" format="color" />
+
     <!-- Main dashboard (home): resolves per AppThemeLight / AppThemeDark -->
     <attr name="mainDashboardBackground" format="reference" />
     <attr name="colorMainDashboardText" format="color" />

--- a/design/src/main/res/values/colors.xml
+++ b/design/src/main/res/values/colors.xml
@@ -42,4 +42,22 @@
     <color name="theme_true_black_surface">#050505</color>
     <color name="theme_true_black_surface_high">#101010</color>
 
+    <!-- YAML config viewer syntax highlighting (editor-style). Mapped to yaml* theme attrs
+         in AppThemeLightBase / AppThemeDarkBase so they follow the app's in-app day/night. -->
+    <color name="yaml_key_light">#0550AE</color>
+    <color name="yaml_string_light">#B25000</color>
+    <color name="yaml_number_light">#6F42C1</color>
+    <color name="yaml_keyword_light">#B3261E</color>
+    <color name="yaml_comment_light">#4E7A3A</color>
+    <color name="yaml_punctuation_light">#57606A</color>
+    <color name="yaml_plain_light">#1F2430</color>
+
+    <color name="yaml_key_dark">#4FC1FF</color>
+    <color name="yaml_string_dark">#FFA657</color>
+    <color name="yaml_number_dark">#C792EA</color>
+    <color name="yaml_keyword_dark">#FF7B72</color>
+    <color name="yaml_comment_dark">#7FB37A</color>
+    <color name="yaml_punctuation_dark">#8B98A9</color>
+    <color name="yaml_plain_dark">#E6EDF3</color>
+
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -395,7 +395,6 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="profile_quick_edit_title">Quick edit subscription</string>
     <string name="profile_quick_open_advanced">Open full editor</string>
     <string name="profile_quick_saved">Subscription updated</string>
-    <string name="profile_menu_share">Share subscription link</string>
     <string name="subscription_source_locked">This subscription URL cannot be edited (operator policy).</string>
     <string name="sub_meta_allow_http">Allow HTTP for subscription metadata probe</string>
     <string name="sub_meta_allow_http_summary">When off, metadata headers are only fetched over HTTPS. Enable only if your panel uses HTTP (cleartext).</string>
@@ -782,6 +781,10 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="proxy_providers_merged_remove_confirm">Remove proxy-group \"%s\" from this profile?</string>
     <string name="proxy_providers_merged_removed_ok">Group removed from config.</string>
     <string name="profile_menu_subscription_sources">Subscription sources</string>
+    <string name="profile_menu_view_config">View config</string>
+    <string name="profile_config_empty">This profile has no generated config yet.</string>
+    <string name="profile_config_copy">Copy config</string>
+    <string name="profile_config_download">Download config</string>
     <string name="profile_menu_sheet_subtitle">Choose an action for this profile</string>
     <string name="properties_section_subscription">Subscription</string>
     <string name="properties_editor_intro">Paste the subscription link, set a name and interval, then tap save.</string>

--- a/design/src/main/res/values/themes.xml
+++ b/design/src/main/res/values/themes.xml
@@ -193,6 +193,14 @@
 
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogLight</item>
         <item name="fullScreenDialogTheme">@style/AppFullScreenDialogLight</item>
+
+        <item name="yamlKey">@color/yaml_key_light</item>
+        <item name="yamlString">@color/yaml_string_light</item>
+        <item name="yamlNumber">@color/yaml_number_light</item>
+        <item name="yamlKeyword">@color/yaml_keyword_light</item>
+        <item name="yamlComment">@color/yaml_comment_light</item>
+        <item name="yamlPunctuation">@color/yaml_punctuation_light</item>
+        <item name="yamlPlain">@color/yaml_plain_light</item>
     </style>
 
     <!-- Material 3 Shape Styles -->
@@ -288,6 +296,14 @@
 
         <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogDark</item>
         <item name="fullScreenDialogTheme">@style/AppFullScreenDialogDark</item>
+
+        <item name="yamlKey">@color/yaml_key_dark</item>
+        <item name="yamlString">@color/yaml_string_dark</item>
+        <item name="yamlNumber">@color/yaml_number_dark</item>
+        <item name="yamlKeyword">@color/yaml_keyword_dark</item>
+        <item name="yamlComment">@color/yaml_comment_dark</item>
+        <item name="yamlPunctuation">@color/yaml_punctuation_dark</item>
+        <item name="yamlPlain">@color/yaml_plain_dark</item>
     </style>
 
     <style name="AppThemeLight" parent="AppThemeLightBase">

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -597,6 +597,23 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
+    override suspend fun readConfigYaml(uuid: UUID): String? {
+        return withContext(Dispatchers.IO) {
+            if (ImportedDao().queryByUUID(uuid) == null) {
+                return@withContext null
+            }
+            val file = File(context.importedDir, "$uuid/config.yaml")
+            if (!file.isFile) {
+                return@withContext null
+            }
+            try {
+                file.readText()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
     override suspend fun replaceRuleProvidersYaml(uuid: UUID, yaml: String): Boolean {
         return withContext(Dispatchers.IO) {
             if (ImportedDao().queryByUUID(uuid) == null) {

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -75,6 +75,9 @@ interface IProfileManager {
     /** `rule-providers` YAML block or null. */
     suspend fun readRuleProvidersYaml(uuid: UUID): String?
 
+    /** Full processed `config.yaml` text for [uuid], or null if missing. Read-only. */
+    suspend fun readConfigYaml(uuid: UUID): String?
+
     suspend fun replaceRuleProvidersYaml(uuid: UUID, yaml: String): Boolean
 
     suspend fun previewReplaceRuleProvidersYaml(uuid: UUID, yaml: String): String?


### PR DESCRIPTION
- Add 'View config' to the profile overflow menu: read-only, scrollable, monospace viewer of the profile's processed config.yaml with editor-style YAML syntax highlighting (light/dark via theme attrs), copy, and download (Storage Access Framework -> save as <profile>.yaml).
- New IProfileManager.readConfigYaml(uuid) mirrors readRuleProvidersYaml; ProfileConfigActivity/Design mirrors LogcatDesign; dependency-free YamlHighlighter runs off-main with a plain-text fallback for huge configs.
- Trim the profile overflow menu: drop redundant Update (force-update is on the card; Update-all in the tab header) and Share-subscription-link; remove the now-orphaned profile_menu_share string. Per-subscription, works offline for any profile; never writes the source file.