### PR TITLE
test(service): unit tests for ProxyHardener, ProxyPropertyGuard, ProxyProvidersUi

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     testImplementation(kotlin("test"))
+    // Real org.json for JVM unit tests (android.jar's is stubbed under isReturnDefaultValues).
+    testImplementation("org.json:json:20240303")
 }
 
 android {

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyHardenerTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyHardenerTest.kt
@@ -1,0 +1,98 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.core.model.ConfigurationOverride
+import com.github.kr328.clash.service.model.ProxyHardeningMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for the runtime hardening dispatch. NOTE: Strict's local-listener disabling is gated on
+ * `Build.VERSION.SDK_INT >= Q`, which is 0 under JVM unit tests, so the port=0 path is only
+ * reachable via instrumentation — asserted here only as "not applied off-device".
+ */
+class ProxyHardenerTest {
+
+    // -- geo mirror seeding (fail-closed allowlist) ----------------------
+
+    @Test
+    fun geoSeed_seedsTrustedMirrors_whenBlank() {
+        val config = ConfigurationOverride()
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Off, seedGeoMirrors = true)
+
+        assertTrue(changed)
+        assertTrue(GeoMirrors.isTrusted(config.geoxurl.geoip!!))
+        assertTrue(GeoMirrors.isTrusted(config.geoxurl.geosite!!))
+        assertTrue(GeoMirrors.isTrusted(config.geoxurl.mmdb!!))
+    }
+
+    @Test
+    fun geoSeed_rewritesUntrustedHostToTrusted() {
+        val config = ConfigurationOverride().apply {
+            geoxurl.geoip = "https://evil.example.com/geoip.dat"
+            geoxurl.geosite = "https://evil.example.com/geosite.dat"
+            geoxurl.mmdb = "https://evil.example.com/country.mmdb"
+        }
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Off, seedGeoMirrors = true)
+
+        assertTrue(changed)
+        assertTrue(GeoMirrors.isTrusted(config.geoxurl.geoip!!))
+        assertFalse(config.geoxurl.geoip!!.contains("evil.example.com"))
+    }
+
+    @Test
+    fun geoSeed_noChange_whenAlreadyTrusted() {
+        val config = ConfigurationOverride().apply {
+            geoxurl.geoip = GeoMirrors.primaryGeoIpDat()
+            geoxurl.geosite = GeoMirrors.primaryGeoSiteDat()
+            geoxurl.mmdb = GeoMirrors.primaryGeoIpMmdb()
+        }
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Off, seedGeoMirrors = true)
+
+        assertFalse(changed)
+    }
+
+    // -- mode dispatch ---------------------------------------------------
+
+    @Test
+    fun off_doesNotMutate_whenNoSeed() {
+        val config = ConfigurationOverride()
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Off, seedGeoMirrors = false)
+
+        assertFalse(changed)
+        assertNull(config.socksPort)
+        assertNull(config.allowLan)
+    }
+
+    @Test
+    fun compat_appliesSocksAuthHardening() {
+        val config = ConfigurationOverride().apply { allowLan = true }
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Compat, seedGeoMirrors = false)
+
+        assertTrue(changed)
+        // RuntimeSocksAuth forces allow-lan off so the local listener is not LAN-reachable.
+        assertEquals(false, config.allowLan)
+    }
+
+    @Test
+    fun strict_appliesSocksAuth_butPortDisableIsSdkGatedOffDevice() {
+        val config = ConfigurationOverride().apply {
+            allowLan = true
+            socksPort = 7891
+        }
+
+        val changed = ProxyHardener.applyTo(config, ProxyHardeningMode.Strict, seedGeoMirrors = false)
+
+        assertTrue(changed)
+        assertEquals(false, config.allowLan)
+        // SDK_INT is 0 under JVM tests, so disableLocalListeners() does not run here.
+        assertEquals(7891, config.socksPort)
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyPropertyGuardTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyPropertyGuardTest.kt
@@ -1,0 +1,54 @@
+package com.github.kr328.clash.service.util
+
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/** Verifies process-wide JVM proxy properties are cleared so traffic can't leak around the VPN. */
+class ProxyPropertyGuardTest {
+
+    private val keys = listOf(
+        "http.proxyHost", "http.proxyPort",
+        "https.proxyHost", "https.proxyPort",
+        "socksProxyHost", "socksProxyPort",
+        "java.net.useSystemProxies",
+    )
+
+    private lateinit var saved: Map<String, String?>
+
+    @Before
+    fun saveProps() {
+        saved = keys.associateWith { System.getProperty(it) }
+    }
+
+    @After
+    fun restoreProps() {
+        for (k in keys) {
+            val v = saved[k]
+            if (v == null) System.clearProperty(k) else System.setProperty(k, v)
+        }
+    }
+
+    @Test
+    fun clearsAllManagedProxyProperties() {
+        keys.forEach { System.setProperty(it, "leak") }
+
+        ProxyPropertyGuard.clearGlobalProxyProperties()
+
+        keys.forEach { assertNull("still set: $it", System.getProperty(it)) }
+    }
+
+    @Test
+    fun noOpWhenNothingSet_andLeavesUnmanagedPropsAlone() {
+        keys.forEach { System.clearProperty(it) }
+        System.setProperty("user.defined.keep", "keep-me")
+
+        ProxyPropertyGuard.clearGlobalProxyProperties()
+
+        keys.forEach { assertNull(System.getProperty(it)) }
+        assertEquals("keep-me", System.getProperty("user.defined.keep"))
+        System.clearProperty("user.defined.keep")
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyProvidersUiTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyProvidersUiTest.kt
@@ -1,0 +1,113 @@
+package com.github.kr328.clash.service.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Coverage for proxy-provider document generation/parsing and JSON label handling. */
+class ProxyProvidersUiTest {
+
+    // -- buildProxyProvidersDocument -------------------------------------
+
+    @Test
+    fun build_emptyRows_yieldsEmptyProxyProvidersBlock() {
+        val doc = ProxyProvidersUi.buildProxyProvidersDocument(emptyList())
+        assertTrue(doc.trimStart().startsWith("proxy-providers"))
+    }
+
+    @Test
+    fun build_singleRow_hasNoAdditionalPrefix() {
+        val doc = ProxyProvidersUi.buildProxyProvidersDocument(
+            listOf(ProxyProviderUiRow("My VPN", "https://sub.example.com/a", 600)),
+        )
+        assertTrue(doc.contains("sub1"))
+        assertTrue(doc.contains("https://sub.example.com/a"))
+        assertTrue(doc.contains("health-check"))
+        assertFalse("single provider must not get a name prefix", doc.contains("additional-prefix"))
+    }
+
+    @Test
+    fun build_multipleRows_eachGetsUniqueAdditionalPrefix() {
+        val doc = ProxyProvidersUi.buildProxyProvidersDocument(
+            listOf(
+                ProxyProviderUiRow("A", "https://a.example.com", 600),
+                ProxyProviderUiRow("B", "https://b.example.com", 600),
+            ),
+        )
+        assertTrue(doc.contains("additional-prefix"))
+        assertTrue(doc.contains("[sub1] "))
+        assertTrue(doc.contains("[sub2] "))
+    }
+
+    @Test
+    fun build_coercesIntervalToMinimum() {
+        val doc = ProxyProvidersUi.buildProxyProvidersDocument(
+            listOf(ProxyProviderUiRow("A", "https://a.example.com", intervalSeconds = 10)),
+        )
+        // Round-trip the document so we read the provider interval (not the health-check one).
+        val rows = ProxyProvidersUi.parseRows(doc, emptyMap())
+        assertEquals(1, rows.size)
+        assertEquals(60L, rows[0].intervalSeconds)
+    }
+
+    // -- parseRows round-trip --------------------------------------------
+
+    @Test
+    fun parseRows_roundTripsUrlsAndLabels() {
+        val input = listOf(
+            ProxyProviderUiRow("A", "https://a.example.com", 600),
+            ProxyProviderUiRow("B", "https://b.example.com", 900),
+        )
+        val doc = ProxyProvidersUi.buildProxyProvidersDocument(input)
+        val labels = mapOf("sub1" to "Alpha", "sub2" to "Beta")
+
+        val rows = ProxyProvidersUi.parseRows(doc, labels)
+
+        assertEquals(2, rows.size)
+        assertEquals("https://a.example.com", rows[0].url)
+        assertEquals("Alpha", rows[0].title)
+        assertEquals("https://b.example.com", rows[1].url)
+        assertEquals(900L, rows[1].intervalSeconds)
+    }
+
+    @Test
+    fun parseRows_blankOrMalformed_yieldsEmpty() {
+        assertTrue(ProxyProvidersUi.parseRows(null, emptyMap()).isEmpty())
+        assertTrue(ProxyProvidersUi.parseRows("", emptyMap()).isEmpty())
+        assertTrue(ProxyProvidersUi.parseRows("not: [valid", emptyMap()).isEmpty())
+    }
+
+    // -- buildLabels -----------------------------------------------------
+
+    @Test
+    fun buildLabels_skipsEmptyTitles() {
+        val labels = ProxyProvidersUi.buildLabels(
+            listOf(
+                ProxyProviderUiRow("Named", "https://a", 600),
+                ProxyProviderUiRow("  ", "https://b", 600),
+            ),
+        )
+        assertEquals(mapOf("sub1" to "Named"), labels)
+    }
+
+    // -- parseLabelsJson / labelsToJson (real org.json) ------------------
+
+    @Test
+    fun parseLabelsJson_validNullAndMalformed() {
+        assertEquals(
+            mapOf("sub1" to "My VPN", "sub2" to "Work"),
+            ProxyProvidersUi.parseLabelsJson("""{"sub1":"My VPN","sub2":"Work"}"""),
+        )
+        assertTrue(ProxyProvidersUi.parseLabelsJson(null).isEmpty())
+        assertTrue(ProxyProvidersUi.parseLabelsJson("").isEmpty())
+        assertTrue(ProxyProvidersUi.parseLabelsJson("not json").isEmpty())
+    }
+
+    @Test
+    fun labelsJson_roundTrips() {
+        val labels = mapOf("sub1" to "Alpha", "sub2" to "Beta")
+        val json = ProxyProvidersUi.labelsToJson(labels)
+        assertEquals(labels, ProxyProvidersUi.parseLabelsJson(json))
+    }
+}


### PR DESCRIPTION
Cover the runtime hardening dispatch (geo-mirror fail-closed allowlist, Off/ Compat/Strict; Strict port-disable is SDK-gated and documented off-device), JVM proxy-property clearing, and proxy-provider document build/parse + JSON label handling. Add a real org.json test dependency (android.jar's is stubbed under isReturnDefaultValues). No production changes.