### PR TITLE
fix(security): confirm install-config deeplink before creating a profile

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -3,8 +3,10 @@ package com.github.kr328.clash
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.ContextThemeWrapper
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -37,25 +39,29 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
                 val uri = intent.data ?: return finish()
                 if (uri.host != "install-config" && uri.host != "installconfig") return finish()
                 val url = uri.getQueryParameter("url") ?: return finish()
+                val name = uri.getQueryParameter("name")
+                    ?: getString(R.string.subscription_default_name)
 
-                launch {
-                    val uuid = withProfile {
-                        // DL-1: external deeplinks only create a URL-source profile.
-                        // File import must come from the in-app picker (which grants
-                        // a content-URI), never from an untrusted deeplink path.
-                        val name = uri.getQueryParameter("name")
-                            ?: getString(R.string.subscription_default_name)
-
-                        create(Profile.Type.Url, name).also {
-                            patch(it, name, url, 0)
+                // SEC: this deeplink is exported, so any site/app can fire it. Never create
+                // a profile from an untrusted external source without explicit consent —
+                // show the source URL and only proceed if the user confirms.
+                confirmInstallConfig(name, url) {
+                    launch {
+                        val uuid = withProfile {
+                            // DL-1: external deeplinks only create a URL-source profile.
+                            // File import must come from the in-app picker (which grants
+                            // a content-URI), never from an untrusted deeplink path.
+                            create(Profile.Type.Url, name).also {
+                                patch(it, name, url, 0)
+                            }
                         }
+                        startActivity(PropertiesActivity::class.intent.setUUID(uuid))
+                        finish()
                     }
-                    startActivity(PropertiesActivity::class.intent.setUUID(uuid))
-                    finish()
                 }
                 // Don't fall through to the synchronous finish() below — the
-                // activity must stay alive until the coroutine completes (then
-                // it finishes itself; onDestroy cancels the scope).
+                // activity must stay alive until the dialog (and, on confirm, the
+                // coroutine) completes; it finishes itself, onDestroy cancels the scope.
                 return
             }
 
@@ -84,6 +90,22 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
             }
         }
         return finish()
+    }
+
+    /**
+     * Shows an explicit consent dialog naming the external source before a profile is created.
+     * The activity's theme is a translucent platform theme, so wrap the dialog context in a
+     * Material theme. Decline / dismiss finishes without creating anything.
+     */
+    private fun confirmInstallConfig(name: String, url: String, onConfirm: () -> Unit) {
+        val themed = ContextThemeWrapper(this, com.google.android.material.R.style.Theme_Material3_DayNight)
+        MaterialAlertDialogBuilder(themed)
+            .setTitle(R.string.deeplink_install_confirm_title)
+            .setMessage(getString(R.string.deeplink_install_confirm_message, name, url))
+            .setPositiveButton(R.string.deeplink_install_confirm_add) { _, _ -> onConfirm() }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> finish() }
+            .setOnCancelListener { finish() }
+            .show()
     }
 
     private fun startClash() {

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -960,6 +960,9 @@
     <string name="sniff_tls_override_destination">Sniff: переопределять назначение TLS</string>
     <string name="sniff_tls_ports">Порты TLS для сниффинга</string>
     <string name="subscription_default_name">Подписка</string>
+    <string name="deeplink_install_confirm_title">Добавить подписку?</string>
+    <string name="deeplink_install_confirm_message">Внешняя ссылка хочет добавить подписку в ClashFest:\n\n%1$s\n%2$s\n\nДобавляйте подписки только из источников, которым доверяете.</string>
+    <string name="deeplink_install_confirm_add">Добавить</string>
     <string name="tun_stack_gvisor">Стек gVisor</string>
     <string name="tun_stack_mixed">Смешанный стек</string>
     <string name="tun_stack_mode">Режим стека</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -861,6 +861,9 @@
     <string name="sub_meta_lock_user">忽略运营商覆盖</string>
     <string name="sub_meta_lock_user_summary">不允许订阅服务器覆盖本地编辑的支持链接或公告。</string>
     <string name="subscription_default_name">订阅</string>
+    <string name="deeplink_install_confirm_title">添加订阅？</string>
+    <string name="deeplink_install_confirm_message">外部链接请求向 ClashFest 添加订阅：\n\n%1$s\n%2$s\n\n请仅添加你信任来源的订阅。</string>
+    <string name="deeplink_install_confirm_add">添加</string>
     <string name="support_url">支持链接</string>
     <string name="support_url_placeholder">https://t.me/your_support_bot</string>
     <string name="theme_auto">自动</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -482,6 +482,9 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
 
     <string name="new_profile">New Profile</string>
     <string name="subscription_default_name">Subscription</string>
+    <string name="deeplink_install_confirm_title">Add subscription?</string>
+    <string name="deeplink_install_confirm_message">An external link wants to add a subscription to ClashFest:\n\n%1$s\n%2$s\n\nOnly add subscriptions from sources you trust.</string>
+    <string name="deeplink_install_confirm_add">Add</string>
 
     <string name="delay">Delay</string>
     <string name="sort">Sort</string>


### PR DESCRIPTION
The exported clash://install-config deeplink created a profile from an external URL with no user interaction, so any site/app could push an arbitrary subscription. Gate it behind an explicit Material confirmation dialog that shows the source URL; decline/dismiss creates nothing. Wrap the dialog in a Material3 theme since the activity uses a translucent platform theme. Strings in EN/RU/zh.