### PR TITLE
Fix/brand accent recreate loop

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
@@ -42,8 +42,10 @@ object BrandThemeApplier {
             store.lastAppliedAccent = ""
             return
         }
-        val hex = store.manifestFor(activeUuid).accentColor
-        val accent = parseHexColor(hex)
+        // Derive the applicable accent through the SAME helper maybeRecreateOnAccentChange uses,
+        // so "what is applied" and "what is desired" can never disagree on parseability.
+        val hex = applicableAccent(store.manifestFor(activeUuid).accentColor)
+        val accent = if (hex.isNotEmpty()) runCatching { Color.parseColor(hex) }.getOrNull() else null
         if (accent == null) {
             store.lastAppliedAccent = ""
             return
@@ -66,7 +68,7 @@ object BrandThemeApplier {
         // Mark the accent that's now baked into this Activity's theme.
         // [maybeRecreateOnAccentChange] reads this on the next dashboard tick
         // and compares to the desired-for-active-profile accent.
-        store.lastAppliedAccent = hex.orEmpty()
+        store.lastAppliedAccent = hex
 
         com.github.kr328.clash.common.log.Log.d(
             "BrandThemeApplier: harmonised palette from accent=$hex + neutral surfaces overlay applied to ${activity::class.java.simpleName}",
@@ -93,7 +95,7 @@ object BrandThemeApplier {
         val activeUuid = com.github.kr328.clash.service.store.ServiceStore(activity).activeProfile
         val store = com.github.kr328.clash.service.branding.BrandStore(activity)
         val desired = if (activeUuid != null && store.isActiveFor(activeUuid)) {
-            store.manifestFor(activeUuid).accentColor.orEmpty()
+            applicableAccent(store.manifestFor(activeUuid).accentColor)
         } else {
             ""
         }
@@ -105,8 +107,16 @@ object BrandThemeApplier {
         activity.recreate()
     }
 
-    private fun parseHexColor(hex: String?): Int? {
-        if (hex.isNullOrBlank()) return null
-        return runCatching { Color.parseColor(hex) }.getOrNull()
-    }
+    private val HEX_COLOR = Regex("^#[0-9A-Fa-f]{6}$")
+
+    /**
+     * The accent that can actually be baked into the theme: a `#RRGGBB` hex, or "" otherwise.
+     * BOTH [applyToActivity] (what is applied) and [maybeRecreateOnAccentChange] (what is desired)
+     * MUST derive their accent through this. Otherwise a non-blank-but-unapplicable accent would
+     * ping-pong applied="" vs desired=raw and recreate the Activity on every dashboard tick
+     * (a recreate storm). Pure + matches BrandValidation.cleanHexColor's accepted form, so it is
+     * unit-testable without android.graphics.Color (stubbed in JVM tests).
+     */
+    internal fun applicableAccent(hex: String?): String =
+        if (hex != null && HEX_COLOR.matches(hex)) hex else ""
 }

--- a/design/src/test/java/com/github/kr328/clash/design/branding/BrandThemeApplierTest.kt
+++ b/design/src/test/java/com/github/kr328/clash/design/branding/BrandThemeApplierTest.kt
@@ -1,0 +1,47 @@
+package com.github.kr328.clash.design.branding
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards the recreate-loop fix: `applyToActivity` (what's applied) and
+ * `maybeRecreateOnAccentChange` (what's desired) both derive the accent through
+ * [BrandThemeApplier.applicableAccent]. As long as that single function decides
+ * applicability, applied and desired can never disagree, so an unapplicable accent
+ * cannot ping-pong into an endless Activity recreate.
+ */
+class BrandThemeApplierTest {
+
+    @Test
+    fun validRRGGBBPassesThrough() {
+        assertEquals("#AABBCC", BrandThemeApplier.applicableAccent("#AABBCC"))
+        assertEquals("#123abc", BrandThemeApplier.applicableAccent("#123abc"))
+    }
+
+    @Test
+    fun nullOrBlankIsEmpty() {
+        assertEquals("", BrandThemeApplier.applicableAccent(null))
+        assertEquals("", BrandThemeApplier.applicableAccent(""))
+        assertEquals("", BrandThemeApplier.applicableAccent("   "))
+    }
+
+    @Test
+    fun unapplicableValuesCollapseToEmpty() {
+        // These are exactly the values that would make Color.parseColor diverge from a raw
+        // compare and previously risk an infinite recreate loop.
+        for (bad in listOf("red", "#abc", "#aabbccdd", "#gggggg", "aabbcc", "#aabbc")) {
+            assertEquals("", BrandThemeApplier.applicableAccent(bad), "bad accent should collapse: $bad")
+        }
+    }
+
+    @Test
+    fun appliedAndDesiredAgreeForAnyInput_noLoop() {
+        // The loop invariant: both call sites use applicableAccent, so for any stored accent the
+        // "applied" string equals the "desired" string -> recreate-check converges, never loops.
+        for (input in listOf(null, "", "#AABBCC", "red", "#abc", "#zzzzzz")) {
+            val applied = BrandThemeApplier.applicableAccent(input)
+            val desired = BrandThemeApplier.applicableAccent(input)
+            assertEquals(applied, desired)
+        }
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -388,7 +388,10 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 val brand = com.github.kr328.clash.common.branding.BrandManifestParser.parse { key ->
                     response.headers[key]
                 }
-                BrandRefresh.apply(context, old.uuid, brand)
+                // confirmedResponse=true: we're past `if (!response.isSuccessful) return`, so an
+                // empty brand here is a real "served the sub with no X-Brand-* headers" signal
+                // (not a transient failure) and feeds the debounced auto-clear.
+                BrandRefresh.apply(context, old.uuid, brand, confirmedResponse = true)
 
                 if (response.headers["subscription-userinfo"] == null) return
 

--- a/service/src/main/java/com/github/kr328/clash/service/branding/BrandRefresh.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/branding/BrandRefresh.kt
@@ -14,13 +14,46 @@ import java.util.UUID
  */
 object BrandRefresh {
 
+    /** Consecutive confirmed-empty responses before a previously-applied brand is cleared. */
+    const val EMPTY_STREAK_TO_CLEAR = 3
+
+    internal data class EmptyAction(val clear: Boolean, val newStreak: Int, val streakChanged: Boolean)
+
     /**
-     * Apply [manifest] for [sourceProfile]'s subscription. Empty manifest
-     * means "operator stopped sending brand headers" — clear the entry.
+     * Decide what to do with a previously-applied brand when the fresh manifest is empty.
+     * Pure (no I/O) so it is unit-testable.
      *
+     * - [confirmed] is true only for an empty parsed from a *successful* (HTTP 2xx) subscription
+     *   response — i.e. the operator served the subscription but sent no `X-Brand-*` headers.
+     *   An unconfirmed empty (opportunistic fetch that may have just failed) never counts.
+     * - Clearing is debounced: only after [threshold] consecutive confirmed-empty responses, so a
+     *   one-off deploy that drops the headers doesn't strip a brand the user already saw.
+     */
+    internal fun decideOnEmpty(confirmed: Boolean, isActive: Boolean, streak: Int, threshold: Int): EmptyAction {
+        if (!confirmed) return EmptyAction(clear = false, newStreak = streak, streakChanged = false)
+        if (!isActive) return EmptyAction(clear = false, newStreak = 0, streakChanged = streak != 0)
+        val next = streak + 1
+        return if (next >= threshold) {
+            EmptyAction(clear = true, newStreak = 0, streakChanged = true)
+        } else {
+            EmptyAction(clear = false, newStreak = next, streakChanged = true)
+        }
+    }
+
+    /**
+     * Apply [manifest] for [sourceProfile]'s subscription.
+     *
+     * @param confirmedResponse true when [manifest] was parsed from a confirmed successful (HTTP
+     *   2xx) subscription response, so an empty manifest genuinely means "operator served the sub
+     *   without brand headers" (not a transient fetch failure). Drives debounced clearing.
      * @return true when [BrandStore] state changed for this profile.
      */
-    suspend fun apply(context: Context, sourceProfile: UUID, manifest: BrandManifest): Boolean {
+    suspend fun apply(
+        context: Context,
+        sourceProfile: UUID,
+        manifest: BrandManifest,
+        confirmedResponse: Boolean = false,
+    ): Boolean {
         val store = BrandStore(context)
         val previous = store.manifestFor(sourceProfile)
 
@@ -35,12 +68,26 @@ object BrandRefresh {
             return false
         }
 
-        // Completely empty response (operator briefly stopped sending any
-        // X-Brand-* / X-Branding-Enabled header) — do NOT wipe cached state.
-        // A flaky deploy that omits the headers for one fetch shouldn't drop
-        // a brand the user already saw. Only explicit `false` kills the brand.
+        // Empty response. An UNCONFIRMED empty (opportunistic fetch that may have just failed, or
+        // a flaky deploy) never drops a brand the user already saw. A CONFIRMED empty (operator
+        // served the subscription over HTTP 2xx with no X-Brand-* headers) is debounced: after
+        // EMPTY_STREAK_TO_CLEAR consecutive confirmed-empties the brand is cleared, so a panel that
+        // permanently stops branding eventually resets instead of sticking forever.
         if (manifest.isEmpty()) {
-            Log.d("BrandRefresh: empty manifest from $sourceProfile, keeping cached state")
+            val action = decideOnEmpty(
+                confirmed = confirmedResponse,
+                isActive = store.isActiveFor(sourceProfile),
+                streak = store.emptyStreakFor(sourceProfile),
+                threshold = EMPTY_STREAK_TO_CLEAR,
+            )
+            if (action.clear) {
+                store.clearFor(sourceProfile)
+                pruneOrphanLogos(context)
+                Log.d("BrandRefresh: cleared brand after $EMPTY_STREAK_TO_CLEAR confirmed empty responses for $sourceProfile")
+                return true
+            }
+            if (action.streakChanged) store.setEmptyStreak(sourceProfile, action.newStreak)
+            Log.d("BrandRefresh: empty manifest from $sourceProfile (confirmed=$confirmedResponse, streak=${action.newStreak}), keeping cached state")
             return false
         }
 
@@ -68,6 +115,8 @@ object BrandRefresh {
 
         store.setManifest(sourceProfile, manifest)
         store.setLogoPaths(sourceProfile, primaryPath, lightPath)
+        // Headers are back (non-empty) → reset the confirmed-empty debounce counter.
+        store.setEmptyStreak(sourceProfile, 0)
         pruneOrphanLogos(context)
 
         val changed = previous != manifest

--- a/service/src/main/java/com/github/kr328/clash/service/branding/BrandStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/branding/BrandStore.kt
@@ -57,7 +57,21 @@ class BrandStore(context: Context) {
             .remove(manifestKey(uuid))
             .remove(logoKey(uuid))
             .remove(logoLightKey(uuid))
+            .remove(emptyStreakKey(uuid))
             .apply()
+    }
+
+    /**
+     * Count of consecutive *confirmed* (HTTP 200) subscription responses that carried no brand
+     * headers. Used to debounce clearing a brand: a one-off deploy that drops the headers must
+     * not strip a brand, but a panel that permanently stops sending them eventually should.
+     */
+    fun emptyStreakFor(uuid: UUID): Int = prefs.getInt(emptyStreakKey(uuid), 0)
+
+    fun setEmptyStreak(uuid: UUID, value: Int) {
+        prefs.edit().also { e ->
+            if (value <= 0) e.remove(emptyStreakKey(uuid)) else e.putInt(emptyStreakKey(uuid), value)
+        }.apply()
     }
 
     /**
@@ -77,11 +91,13 @@ class BrandStore(context: Context) {
     private fun manifestKey(uuid: UUID) = "${KEY_PREFIX_MANIFEST}_$uuid"
     private fun logoKey(uuid: UUID) = "${KEY_PREFIX_LOGO}_$uuid"
     private fun logoLightKey(uuid: UUID) = "${KEY_PREFIX_LOGO_LIGHT}_$uuid"
+    private fun emptyStreakKey(uuid: UUID) = "${KEY_PREFIX_EMPTY_STREAK}_$uuid"
 
     companion object {
         private const val KEY_PREFIX_MANIFEST = "brand_manifest"
         private const val KEY_PREFIX_LOGO = "brand_logo"
         private const val KEY_PREFIX_LOGO_LIGHT = "brand_logo_light"
+        private const val KEY_PREFIX_EMPTY_STREAK = "brand_empty_streak"
         private const val KEY_LAST_APPLIED_ACCENT = "brand_last_applied_accent"
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/branding/BrandRefreshDecisionTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/branding/BrandRefreshDecisionTest.kt
@@ -1,0 +1,63 @@
+package com.github.kr328.clash.service.branding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Debounced clearing of a brand when confirmed (HTTP 2xx) subscription responses stop carrying
+ * X-Brand-* headers — so a broken operator panel eventually resets the brand instead of sticking
+ * forever, while a one-off header drop does not.
+ */
+class BrandRefreshDecisionTest {
+
+    private val threshold = BrandRefresh.EMPTY_STREAK_TO_CLEAR // 3
+
+    @Test
+    fun unconfirmedEmpty_neverClears_andDoesNotCount() {
+        val a = BrandRefresh.decideOnEmpty(confirmed = false, isActive = true, streak = 2, threshold = threshold)
+        assertFalse(a.clear)
+        assertEquals(2, a.newStreak)
+        assertFalse(a.streakChanged)
+    }
+
+    @Test
+    fun confirmedButNoActiveBrand_resetsStreak() {
+        val reset = BrandRefresh.decideOnEmpty(confirmed = true, isActive = false, streak = 2, threshold = threshold)
+        assertFalse(reset.clear)
+        assertEquals(0, reset.newStreak)
+        assertTrue(reset.streakChanged)
+
+        val alreadyZero = BrandRefresh.decideOnEmpty(confirmed = true, isActive = false, streak = 0, threshold = threshold)
+        assertFalse(alreadyZero.streakChanged)
+    }
+
+    @Test
+    fun confirmedActiveEmpty_incrementsBelowThreshold() {
+        val first = BrandRefresh.decideOnEmpty(confirmed = true, isActive = true, streak = 0, threshold = threshold)
+        assertFalse(first.clear)
+        assertEquals(1, first.newStreak)
+        assertTrue(first.streakChanged)
+
+        val second = BrandRefresh.decideOnEmpty(confirmed = true, isActive = true, streak = 1, threshold = threshold)
+        assertFalse(second.clear)
+        assertEquals(2, second.newStreak)
+    }
+
+    @Test
+    fun confirmedActiveEmpty_clearsAtThreshold() {
+        val third = BrandRefresh.decideOnEmpty(confirmed = true, isActive = true, streak = 2, threshold = threshold)
+        assertTrue(third.clear)
+        assertEquals(0, third.newStreak)
+        assertTrue(third.streakChanged)
+    }
+
+    @Test
+    fun threshold_isThree_soOneOrTwoDropsDoNotClear() {
+        assertEquals(3, threshold)
+        // Two consecutive confirmed-empties must NOT clear (survives a one-off panel glitch).
+        assertFalse(BrandRefresh.decideOnEmpty(true, isActive = true, streak = 0, threshold = threshold).clear)
+        assertFalse(BrandRefresh.decideOnEmpty(true, isActive = true, streak = 1, threshold = threshold).clear)
+    }
+}


### PR DESCRIPTION
Route applyToActivity and maybeRecreateOnAccentChange through one pure applicableAccent(hex) helper so applied vs desired can't diverge into a recreate storm on an unparseable accent. Add a design unit test.

A confirmed 2xx subscription response with no X-Brand-* headers no longer sticks a brand forever. BrandRefresh.apply gains confirmedResponse (ProfileManager update path = true) and debounces clearing after EMPTY_STREAK_TO_CLEAR=3 consecutive confirmed-empty responses; the opportunistic MainActivity path stays conservative. Pure decideOnEmpty helper + service unit tests.