### PR TITLE
perf(profiles): fix N+1 queries when listing profiles

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -484,11 +484,13 @@ class ProfileManager(private val context: Context) : IProfileManager,
     }
 
     override suspend fun queryAll(): List<Profile> {
-        val uuids = withContext(Dispatchers.IO) {
-            ImportedDao().queryAllOrderedUUIDs().map { it.uuid }.distinct()
+        return withContext(Dispatchers.IO) {
+            // Bulk-load both tables once instead of two per-uuid queries (N+1) inside the loop.
+            val ordered = ImportedDao().queryAllOrderedUUIDs().map { it.uuid }.distinct()
+            val importedByUuid = ImportedDao().queryAll().associateBy { it.uuid }
+            val pendingByUuid = PendingDao().queryAll().associateBy { it.uuid }
+            ordered.mapNotNull { uuid -> buildProfile(uuid, importedByUuid[uuid], pendingByUuid[uuid]) }
         }
-
-        return uuids.mapNotNull { resolveProfile(it) }
     }
 
     override suspend fun reorder(uuids: List<String>) {
@@ -1124,7 +1126,14 @@ class ProfileManager(private val context: Context) : IProfileManager,
     private suspend fun resolveProfile(uuid: UUID): Profile? {
         val imported = ImportedDao().queryByUUID(uuid)
         val pending = PendingDao().queryByUUID(uuid)
+        return buildProfile(uuid, imported, pending)
+    }
 
+    /**
+     * Merge the imported + pending rows for [uuid] into a [Profile]. Pure (no DB) so callers that
+     * already loaded the rows in bulk (see [queryAll]) avoid an N+1 of per-uuid queries.
+     */
+    private fun buildProfile(uuid: UUID, imported: Imported?, pending: Pending?): Profile? {
         val active = store.activeProfile
         val name = pending?.name ?: imported?.name ?: return null
         val type = pending?.type ?: imported?.type ?: return null

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileReceiver.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileReceiver.kt
@@ -57,8 +57,7 @@ class ProfileReceiver : BroadcastReceiver() {
 
             Log.i("Reschedule all profiles update")
 
-            ImportedDao().queryAllUUIDs()
-                .mapNotNull { ImportedDao().queryByUUID(it) }
+            ImportedDao().queryAll()
                 .filter { it.type != Profile.Type.File }
                 .forEach { scheduleNext(context, it) }
         }

--- a/service/src/main/java/com/github/kr328/clash/service/data/ImportedDao.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/ImportedDao.kt
@@ -12,6 +12,9 @@ interface ImportedDao {
     @Query("SELECT uuid FROM imported ORDER BY profileOrder, createdAt")
     suspend fun queryAllUUIDs(): List<UUID>
 
+    @Query("SELECT * FROM imported ORDER BY profileOrder, createdAt")
+    suspend fun queryAll(): List<Imported>
+
     @Query("SELECT uuid, profileOrder FROM imported UNION SELECT uuid, profileOrder FROM pending ORDER BY profileOrder, uuid")
     suspend fun queryAllOrderedUUIDs(): List<ProfileOrderEntry>
 

--- a/service/src/main/java/com/github/kr328/clash/service/data/PendingDao.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/PendingDao.kt
@@ -18,6 +18,9 @@ interface PendingDao {
     @Query("SELECT uuid FROM pending ORDER BY profileOrder, createdAt")
     suspend fun queryAllUUIDs(): List<UUID>
 
+    @Query("SELECT * FROM pending ORDER BY profileOrder, createdAt")
+    suspend fun queryAll(): List<Pending>
+
     @Query("SELECT MAX(profileOrder) FROM pending")
     suspend fun queryMaxProfileOrder(): Long?
 


### PR DESCRIPTION
ProfileManager.queryAll did 1 + 2N Room queries (resolveProfile fetched Imported + Pending per uuid in a loop) and ProfileReceiver did 1 + N. Add bulk ImportedDao.queryAll()/PendingDao.queryAll(), extract a pure buildProfile(uuid, imported, pending), and resolve the list from maps loaded once (3 queries total; ProfileReceiver = 1). Behaviour-identical, fewer DB round-trips.