### PR TITLE
chore(code-health): drop unused ping var and url parameter

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -970,7 +970,7 @@ class MainActivity : BaseActivity<MainDesign>() {
             showImportCommitFailureDialog(uuid, e)
             return
         }
-        val displayName = upgradeProfileNameIfBetter(uuid, pending, url)
+        val displayName = upgradeProfileNameIfBetter(uuid, pending)
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
@@ -991,11 +991,9 @@ class MainActivity : BaseActivity<MainDesign>() {
      * Returns the effective display name (better one if applied, preliminary
      * otherwise).
      */
-    @Suppress("UNUSED_PARAMETER")
     private suspend fun upgradeProfileNameIfBetter(
         uuid: java.util.UUID,
         pending: com.github.kr328.clash.util.AsyncNameResolver.Pending,
-        url: String,
     ): String {
         val better = runCatching { pending.betterName.await() }.getOrNull()
             ?: return pending.preliminaryName

--- a/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/NewProfileActivity.kt
@@ -211,7 +211,7 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
             showImportCommitFailureDialog(uuid, e)
             return
         }
-        val displayName = upgradeProfileNameIfBetter(uuid, pending, trimmed)
+        val displayName = upgradeProfileNameIfBetter(uuid, pending)
         val profile = withProfile { queryByUUID(uuid) }
         if (profile?.imported == true) {
             withProfile { setActive(profile) }
@@ -222,11 +222,9 @@ class NewProfileActivity : BaseActivity<NewProfileDesign>() {
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private suspend fun upgradeProfileNameIfBetter(
         uuid: UUID,
         pending: com.github.kr328.clash.util.AsyncNameResolver.Pending,
-        url: String,
     ): String {
         val better = runCatching { pending.betterName.await() }.getOrNull()
             ?: return pending.preliminaryName

--- a/common/src/main/java/com/github/kr328/clash/common/util/StandalonePing.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/StandalonePing.kt
@@ -61,8 +61,9 @@ object StandalonePing {
                 val t0 = SystemClock.elapsedRealtime()
                 try {
                     conn.connect()
-                    @Suppress("UNUSED_VARIABLE")
-                    val code = conn.responseCode
+                    // Force the full request/response round-trip (not just the TCP connect) so the
+                    // measured time reflects a real HTTP exchange. Return value intentionally ignored.
+                    conn.responseCode
                     (SystemClock.elapsedRealtime() - t0).coerceAtLeast(1L)
                 } finally {
                     conn.disconnect()


### PR DESCRIPTION
Remove the unused 'code' local in StandalonePing (keep the conn.responseCode call for its round-trip side effect) and the unused 'url' parameter from upgradeProfileNameIfBetter in MainActivity and NewProfileActivity, dropping the @Suppress annotations. No behaviour change.