### PR TITLE
feat(dns): per-profile DNS & Hosts editor (experimental)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,6 +150,11 @@
             android:exported="false"
             android:label="@string/network" />
         <activity
+            android:name=".DnsHostsSettingsActivity"
+            android:configChanges="uiMode"
+            android:exported="false"
+            android:label="@string/dns_hosts_title" />
+        <activity
             android:name=".AppSettingsActivity"
             android:configChanges="uiMode"
             android:exported="false"

--- a/app/src/main/java/com/github/kr328/clash/DnsHostsSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/DnsHostsSettingsActivity.kt
@@ -1,0 +1,146 @@
+package com.github.kr328.clash
+
+import android.os.Bundle
+import androidx.core.view.WindowCompat
+import com.github.kr328.clash.design.DnsHostsSettingsDesign
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.service.model.YamlPreview
+import com.github.kr328.clash.service.util.DnsHostsConfig
+import com.github.kr328.clash.service.util.DnsHostsValidator
+import com.github.kr328.clash.util.withProfile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+/**
+ * Per-profile DNS & Hosts editor over the active profile. Reads the profile's
+ * parsed `dns:`/`hosts:` (Path B snapshot), writes them back via the engine-
+ * validated preview pipeline, and toggles the per-profile "managed" marker that
+ * drives subscription-refresh preservation. Master toggle OFF tears the blocks
+ * down cleanly.
+ */
+class DnsHostsSettingsActivity : BaseActivity<DnsHostsSettingsDesign>() {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private var uuid: UUID? = null
+    private var profileName: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+    }
+
+    override suspend fun main() {
+        val design = DnsHostsSettingsDesign(this)
+        setContentDesign(design)
+
+        val active = withProfile { queryActive() }
+        if (active == null) {
+            withContext(Dispatchers.Main) { design.showNoProfile() }
+        } else {
+            uuid = active.uuid
+            profileName = active.name
+            loadInto(design)
+        }
+
+        while (isActive) {
+            select<Unit> {
+                design.requests.onReceive { req ->
+                    val id = uuid ?: return@onReceive
+                    when (req) {
+                        is DnsHostsSettingsDesign.Request.MasterToggle ->
+                            launch { onMasterToggle(design, id, req.on) }
+                        DnsHostsSettingsDesign.Request.Save ->
+                            launch { onSave(design, id) }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun loadInto(design: DnsHostsSettingsDesign) {
+        val id = uuid ?: return
+        val managed = withProfile { isDnsHostsManaged(id) }
+        val configJson = withProfile { queryDnsHostsConfigJson(id) }
+        val config = configJson
+            ?.let { runCatching { json.decodeFromString(DnsHostsConfig.serializer(), it) }.getOrNull() }
+            ?: DnsHostsConfig()
+        withContext(Dispatchers.Main) { design.bind(profileName, managed, config) }
+    }
+
+    private suspend fun onMasterToggle(design: DnsHostsSettingsDesign, id: UUID, on: Boolean) {
+        if (on) {
+            withContext(Dispatchers.Main) {
+                design.setContentEnabled(true)
+                design.showStatus(null, false)
+            }
+            return
+        }
+        // OFF: clean teardown only if the profile was actually managed (saved before).
+        if (withProfile { isDnsHostsManaged(id) }) {
+            val emptyJson = json.encodeToString(DnsHostsConfig.serializer(), DnsHostsConfig())
+            val previewJson = withProfile { previewSetDnsHosts(id, emptyJson) }
+            applyPreview(previewJson)
+            withProfile { setDnsHostsManaged(id, false) }
+        }
+        loadInto(design)
+        withContext(Dispatchers.Main) {
+            design.setContentEnabled(false)
+            design.showStatus(getString(R.string.dns_hosts_disabled), false)
+        }
+    }
+
+    private suspend fun onSave(design: DnsHostsSettingsDesign, id: UUID) {
+        val model = withContext(Dispatchers.Main) { design.readModel() }
+
+        if (DnsHostsValidator.listenError(model.listen) != null) {
+            withContext(Dispatchers.Main) {
+                design.showStatus(getString(R.string.dns_hosts_err_listen), true)
+            }
+            return
+        }
+
+        withContext(Dispatchers.Main) { design.setSaveBusy(true) }
+        try {
+            val cfgJson = json.encodeToString(DnsHostsConfig.serializer(), model)
+            val previewJson = withProfile { previewSetDnsHosts(id, cfgJson) }
+            val preview = previewJson
+                ?.let { runCatching { json.decodeFromString(YamlPreview.serializer(), it) }.getOrNull() }
+            if (preview == null || !preview.valid) {
+                withContext(Dispatchers.Main) {
+                    design.showStatus(
+                        preview?.error?.takeIf { it.isNotBlank() }
+                            ?: getString(R.string.dns_hosts_err_invalid),
+                        true,
+                    )
+                }
+                return
+            }
+            val ok = withProfile { applyYamlPreview(preview.id) }
+            if (ok) {
+                withProfile { setDnsHostsManaged(id, true) }
+                withContext(Dispatchers.Main) {
+                    design.showStatus(getString(R.string.dns_hosts_saved), false)
+                }
+            } else {
+                withContext(Dispatchers.Main) {
+                    design.showStatus(getString(R.string.dns_hosts_err_invalid), true)
+                }
+            }
+        } finally {
+            withContext(Dispatchers.Main) { design.setSaveBusy(false) }
+        }
+    }
+
+    private suspend fun applyPreview(previewJson: String?): Boolean {
+        val preview = previewJson
+            ?.let { runCatching { json.decodeFromString(YamlPreview.serializer(), it) }.getOrNull() }
+            ?: return false
+        if (!preview.valid) return false
+        return withProfile { applyYamlPreview(preview.id) }
+    }
+}

--- a/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
@@ -26,6 +26,8 @@ class SettingsActivity : BaseActivity<SettingsDesign>() {
                             startActivity(GeoSettingsActivity::class.intent)
                         SettingsDesign.Request.StartNetwork ->
                             startActivity(NetworkSettingsActivity::class.intent)
+                        SettingsDesign.Request.StartDnsHosts ->
+                            startActivity(DnsHostsSettingsActivity::class.intent)
                     }
                 }
             }

--- a/core/src/main/golang/native/snapshot/dns_hosts_test.go
+++ b/core/src/main/golang/native/snapshot/dns_hosts_test.go
@@ -1,0 +1,89 @@
+package snapshot
+
+import (
+	"strings"
+	"testing"
+)
+
+const dnsHostsProfile = `
+mixed-port: 7890
+dns:
+  enable: true
+  enhanced-mode: fake-ip
+  listen: 127.0.0.1:0
+  cache-algorithm: arc
+  nameserver:
+    - https://1.1.1.1/dns-query
+  direct-nameserver:
+    - https://common.dot.dns.yandex.net/dns-query
+  proxy-server-nameserver:
+    - https://8.8.8.8/dns-query
+hosts:
+  example.com: 1.2.3.4
+  router.lan: 192.168.1.1
+proxies:
+  - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}
+proxy-groups:
+  - {name: G, type: select, proxies: [p1]}
+rules:
+  - MATCH,G
+`
+
+const noDnsHostsProfile = `
+mixed-port: 7890
+proxies:
+  - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}
+proxy-groups:
+  - {name: G, type: select, proxies: [p1]}
+rules:
+  - MATCH,G
+`
+
+func TestSnapshot_DnsHosts_RoundTrips(t *testing.T) {
+	snap, err := ParseBytes([]byte(dnsHostsProfile))
+	if err != nil {
+		t.Fatalf("ParseBytes failed: %v", err)
+	}
+	if snap.Dns == nil {
+		t.Fatal("expected dns block, got nil")
+	}
+	if snap.Dns["enhanced-mode"] != "fake-ip" {
+		t.Errorf("enhanced-mode = %v, want fake-ip", snap.Dns["enhanced-mode"])
+	}
+	if snap.Dns["cache-algorithm"] != "arc" {
+		t.Errorf("cache-algorithm = %v, want arc", snap.Dns["cache-algorithm"])
+	}
+	ns, ok := snap.Dns["direct-nameserver"].([]any)
+	if !ok || len(ns) != 1 || ns[0] != "https://common.dot.dns.yandex.net/dns-query" {
+		t.Errorf("direct-nameserver = %v", snap.Dns["direct-nameserver"])
+	}
+	if snap.Hosts["example.com"] != "1.2.3.4" {
+		t.Errorf("hosts[example.com] = %v, want 1.2.3.4", snap.Hosts["example.com"])
+	}
+
+	// The envelope must marshal to valid JSON (interface-keyed maps would break it).
+	env := MarshalJSONFromBytes([]byte(dnsHostsProfile))
+	if !strings.HasPrefix(env, `{"ok":true`) {
+		t.Fatalf("envelope not ok: %s", env)
+	}
+	if !strings.Contains(env, `"cache-algorithm":"arc"`) || !strings.Contains(env, `"example.com":"1.2.3.4"`) {
+		t.Errorf("envelope missing dns/hosts: %s", env)
+	}
+}
+
+func TestSnapshot_NoDnsHosts_OmitsKeys(t *testing.T) {
+	snap, err := ParseBytes([]byte(noDnsHostsProfile))
+	if err != nil {
+		t.Fatalf("ParseBytes failed: %v", err)
+	}
+	if snap.Dns != nil {
+		t.Errorf("expected nil dns, got %v", snap.Dns)
+	}
+	if snap.Hosts != nil {
+		t.Errorf("expected nil hosts, got %v", snap.Hosts)
+	}
+	env := MarshalJSONFromBytes([]byte(noDnsHostsProfile))
+	if strings.Contains(env, `"dns"`) || strings.Contains(env, `"hosts"`) {
+		t.Errorf("envelope should omit dns/hosts: %s", env)
+	}
+}

--- a/core/src/main/golang/native/snapshot/snapshot.go
+++ b/core/src/main/golang/native/snapshot/snapshot.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	P "path"
 
+	"github.com/metacubex/mihomo/common/yaml"
 	"github.com/metacubex/mihomo/config"
 )
 
@@ -34,6 +35,12 @@ type ProfileSnapshot struct {
 	ProxyProviders map[string]map[string]any `json:"proxy-providers,omitempty"`
 	RuleProviders  map[string]map[string]any `json:"rule-providers,omitempty"`
 	Listeners      []map[string]any          `json:"listeners,omitempty"`
+	// Dns and Hosts are taken from a generic parse of the raw YAML — i.e. exactly
+	// what the user wrote — NOT from RawConfig (UnmarshalRawConfig starts from
+	// DefaultRawConfig, so RawConfig.DNS is always populated with defaults). The
+	// DNS & Hosts editor must distinguish "user set a dns: block" from "absent".
+	Dns   map[string]any `json:"dns,omitempty"`
+	Hosts map[string]any `json:"hosts,omitempty"`
 }
 
 // Build projects a parsed RawConfig into the wire-format snapshot. Exposed
@@ -69,7 +76,71 @@ func ParseBytes(data []byte) (ProfileSnapshot, error) {
 	if err != nil {
 		return ProfileSnapshot{}, err
 	}
-	return Build(rawCfg), nil
+	snapshot := Build(rawCfg)
+	snapshot.Dns, snapshot.Hosts = extractDnsHosts(data)
+	return snapshot, nil
+}
+
+// extractDnsHosts re-parses the raw YAML generically to recover the `dns:` and
+// `hosts:` blocks exactly as the user wrote them (no engine defaults). Returns
+// nil for an absent block. Best-effort: a parse failure (e.g. age-encrypted
+// config) yields nils and is not fatal — the structured parse already
+// succeeded.
+func extractDnsHosts(data []byte) (dns map[string]any, hosts map[string]any) {
+	var generic map[string]any
+	if err := yaml.Unmarshal(data, &generic); err != nil {
+		return nil, nil
+	}
+	return asStringMap(generic["dns"]), asStringMap(generic["hosts"])
+}
+
+// asStringMap coerces a generic YAML value into a JSON-marshalable
+// map[string]any (recursively), or nil if it is not a map.
+func asStringMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return normalizeMap(m)
+	case map[any]any:
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			out[toString(k)] = normalizeValue(val)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func normalizeMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = normalizeValue(v)
+	}
+	return out
+}
+
+func normalizeValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return normalizeMap(t)
+	case map[any]any:
+		return asStringMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = normalizeValue(e)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
 }
 
 // envelope wraps the snapshot in an ok/error frame so that the synchronous

--- a/core/src/main/java/com/github/kr328/clash/core/model/ProfileSnapshot.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/ProfileSnapshot.kt
@@ -27,6 +27,13 @@ data class ProfileSnapshot(
     @SerialName("proxy-providers") val proxyProviders: Map<String, JsonObject> = emptyMap(),
     @SerialName("rule-providers") val ruleProviders: Map<String, JsonObject> = emptyMap(),
     val listeners: List<JsonObject> = emptyList(),
+    /**
+     * `dns:` and `hosts:` exactly as the user wrote them (null when absent),
+     * used by the DNS & Hosts editor. Kept as [JsonObject] like the other
+     * free-form sections.
+     */
+    val dns: JsonObject? = null,
+    val hosts: JsonObject? = null,
 )
 
 /**

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -87,6 +87,13 @@ class AppSettingsDesign(
                 }
             }
 
+            switch(
+                value = uiStore::dnsHostsEnabled,
+                icon = R.drawable.ic_baseline_language,
+                title = R.string.dns_hosts_experimental_title,
+                summary = R.string.dns_hosts_experimental_summary,
+            )
+
             category(R.string.service)
 
             switch(

--- a/design/src/main/java/com/github/kr328/clash/design/DnsHostsSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/DnsHostsSettingsDesign.kt
@@ -1,0 +1,195 @@
+package com.github.kr328.clash.design
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.widget.NestedScrollView
+import com.github.kr328.clash.design.util.layoutInflater
+import com.github.kr328.clash.design.util.root
+import com.github.kr328.clash.service.util.DnsHostsConfig
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.button.MaterialButtonToggleGroup
+import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.textfield.TextInputEditText
+
+/**
+ * Per-profile DNS & Hosts editor. Lists (nameservers) and hosts are edited as
+ * one-per-line text for v1 simplicity. The master toggle owns whether the
+ * feature manages this profile; turning it off triggers a clean teardown
+ * (handled by the activity).
+ */
+class DnsHostsSettingsDesign(context: Context) : Design<DnsHostsSettingsDesign.Request>(context) {
+    sealed class Request {
+        object Save : Request()
+        data class MasterToggle(val on: Boolean) : Request()
+    }
+
+    private val rootView: View = context.layoutInflater.inflate(
+        R.layout.design_dns_hosts_settings, context.root, false,
+    )
+    override val root: View get() = rootView
+
+    private val scroll: NestedScrollView = rootView.findViewById(R.id.dns_hosts_scroll)
+    private val profileName: TextView = rootView.findViewById(R.id.profile_name)
+    private val noProfileNotice: TextView = rootView.findViewById(R.id.no_profile_notice)
+    private val masterCard: View = rootView.findViewById(R.id.master_card)
+    private val content: View = rootView.findViewById(R.id.content)
+    private val masterToggle: MaterialSwitch = rootView.findViewById(R.id.master_toggle)
+    private val dnsEnable: MaterialSwitch = rootView.findViewById(R.id.dns_enable)
+    private val modeGroup: MaterialButtonToggleGroup = rootView.findViewById(R.id.mode_group)
+    private val cacheGroup: MaterialButtonToggleGroup = rootView.findViewById(R.id.cache_group)
+    private val listenInput: TextInputEditText = rootView.findViewById(R.id.listen_input)
+    private val nsProxy: TextInputEditText = rootView.findViewById(R.id.ns_proxy)
+    private val nsDirect: TextInputEditText = rootView.findViewById(R.id.ns_direct)
+    private val nsProxyServer: TextInputEditText = rootView.findViewById(R.id.ns_proxy_server)
+    private val nsBootstrap: TextInputEditText = rootView.findViewById(R.id.ns_bootstrap)
+    private val hostsInput: TextInputEditText = rootView.findViewById(R.id.hosts_input)
+    private val statusText: TextView = rootView.findViewById(R.id.status_text)
+    private val btnSave: MaterialButton = rootView.findViewById(R.id.btn_save)
+
+    init {
+        rootView.findViewById<TextView>(R.id.screen_title).text =
+            context.getString(R.string.dns_hosts_title)
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPaddingRelative(bars.left, 0, bars.right, 0)
+            scroll.setPadding(scroll.paddingLeft, bars.top, scroll.paddingRight, bars.bottom + 16)
+            insets
+        }
+        rootView.post { ViewCompat.requestApplyInsets(rootView) }
+
+        masterToggle.setOnClickListener {
+            requests.trySend(Request.MasterToggle(masterToggle.isChecked))
+        }
+        btnSave.setOnClickListener { requests.trySend(Request.Save) }
+    }
+
+    /** No active profile: hide everything but the notice. */
+    fun showNoProfile() {
+        noProfileNotice.visibility = View.VISIBLE
+        masterCard.visibility = View.GONE
+        content.visibility = View.GONE
+        profileName.visibility = View.GONE
+    }
+
+    fun bind(profile: String, managed: Boolean, config: DnsHostsConfig) {
+        noProfileNotice.visibility = View.GONE
+        masterCard.visibility = View.VISIBLE
+        content.visibility = View.VISIBLE
+        profileName.visibility = View.VISIBLE
+        profileName.text = profile
+
+        masterToggle.isChecked = managed
+        dnsEnable.isChecked = config.enable == true
+        checkMode(config.enhancedMode)
+        checkCache(config.cacheAlgorithm)
+        listenInput.setText(config.listen.orEmpty())
+        nsProxy.setText(config.nameserver.joinToString("\n"))
+        nsDirect.setText(config.directNameserver.joinToString("\n"))
+        nsProxyServer.setText(config.proxyServerNameserver.joinToString("\n"))
+        nsBootstrap.setText(config.defaultNameserver.joinToString("\n"))
+        hostsInput.setText(config.hosts.entries.joinToString("\n") { "${it.key} = ${it.value}" })
+
+        setContentEnabled(managed)
+    }
+
+    /** Reads the form into a model. */
+    fun readModel(): DnsHostsConfig = DnsHostsConfig(
+        enable = if (dnsEnable.isChecked) true else null,
+        enhancedMode = modeValue(),
+        listen = listenInput.text?.toString()?.trim()?.takeIf { it.isNotEmpty() },
+        cacheAlgorithm = cacheValue(),
+        nameserver = lines(nsProxy),
+        directNameserver = lines(nsDirect),
+        proxyServerNameserver = lines(nsProxyServer),
+        defaultNameserver = lines(nsBootstrap),
+        hosts = parseHosts(hostsInput),
+    )
+
+    fun setContentEnabled(enabled: Boolean) {
+        content.alpha = if (enabled) 1f else 0.5f
+        setEnabledRecursive(content, enabled)
+    }
+
+    fun setSaveBusy(busy: Boolean) {
+        btnSave.isEnabled = !busy
+    }
+
+    fun showStatus(message: String?, isError: Boolean) {
+        if (message.isNullOrBlank()) {
+            statusText.visibility = View.GONE
+            return
+        }
+        statusText.visibility = View.VISIBLE
+        statusText.text = message
+        statusText.setTextColor(
+            com.google.android.material.color.MaterialColors.getColor(
+                statusText,
+                if (isError) com.google.android.material.R.attr.colorError
+                else com.google.android.material.R.attr.colorPrimary,
+            ),
+        )
+    }
+
+    private fun setEnabledRecursive(view: View, enabled: Boolean) {
+        view.isEnabled = enabled
+        if (view is android.view.ViewGroup) {
+            for (i in 0 until view.childCount) setEnabledRecursive(view.getChildAt(i), enabled)
+        }
+    }
+
+    private fun lines(input: TextInputEditText): List<String> =
+        input.text?.toString().orEmpty().split('\n').map { it.trim() }.filter { it.isNotEmpty() }
+
+    private fun parseHosts(input: TextInputEditText): Map<String, String> {
+        val out = LinkedHashMap<String, String>()
+        for (raw in input.text?.toString().orEmpty().split('\n')) {
+            val line = raw.trim()
+            if (line.isEmpty()) continue
+            val sep = line.indexOfFirst { it == '=' || it == ':' }
+            val (k, v) = if (sep >= 0) {
+                line.substring(0, sep) to line.substring(sep + 1)
+            } else {
+                val ws = line.indexOfFirst { it == ' ' || it == '\t' }
+                if (ws < 0) continue else line.substring(0, ws) to line.substring(ws + 1)
+            }
+            val key = k.trim()
+            val value = v.trim()
+            if (key.isNotEmpty() && value.isNotEmpty()) out[key] = value
+        }
+        return out
+    }
+
+    private fun modeValue(): String? = when (modeGroup.checkedButtonId) {
+        R.id.mode_off -> "normal"
+        R.id.mode_redir -> "redir-host"
+        R.id.mode_fakeip -> "fake-ip"
+        else -> null
+    }
+
+    private fun checkMode(value: String?) {
+        when (value) {
+            "normal" -> modeGroup.check(R.id.mode_off)
+            "redir-host" -> modeGroup.check(R.id.mode_redir)
+            "fake-ip" -> modeGroup.check(R.id.mode_fakeip)
+            else -> modeGroup.clearChecked()
+        }
+    }
+
+    private fun cacheValue(): String? = when (cacheGroup.checkedButtonId) {
+        R.id.cache_lru -> "lru"
+        R.id.cache_arc -> "arc"
+        else -> null
+    }
+
+    private fun checkCache(value: String?) {
+        when (value) {
+            "lru" -> cacheGroup.check(R.id.cache_lru)
+            "arc" -> cacheGroup.check(R.id.cache_arc)
+            else -> cacheGroup.check(R.id.cache_default)
+        }
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.github.kr328.clash.design.databinding.DesignSettingsBinding
+import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.design.util.root
 
@@ -13,6 +14,7 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
         StartGeo,
         StartNetwork,
         StartMetaFeatures,
+        StartDnsHosts,
     }
 
     private val binding = DesignSettingsBinding
@@ -24,6 +26,9 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
     init {
         binding.self = this
         binding.header.screenTitle.text = context.getString(R.string.main_advanced_settings)
+        // Experimental DNS & Hosts entry is hidden until opted in (AppSettings).
+        binding.cardDnsHosts.visibility =
+            if (UiStore(context).dnsHostsEnabled) View.VISIBLE else View.GONE
     }
 
     fun request(request: Request) {

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -75,6 +75,12 @@ class UiStore(context: Context) {
         defaultValue = false,
     )
 
+    /** Experimental gate for the per-profile DNS & Hosts editor (OFF by default). */
+    var dnsHostsEnabled: Boolean by store.boolean(
+        key = "dns_hosts_enabled",
+        defaultValue = false,
+    )
+
     var proxyExcludeNotSelectable by store.boolean(
         key = "proxy_exclude_not_selectable",
         defaultValue = false,

--- a/design/src/main/res/layout/design_dns_hosts_settings.xml
+++ b/design/src/main/res/layout/design_dns_hosts_settings.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/dns_hosts_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="12dp"
+            android:paddingBottom="32dp">
+
+            <include layout="@layout/include_screen_header" />
+
+            <TextView
+                android:id="@+id/profile_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:ignore="MissingDefaultResource" />
+
+            <TextView
+                android:id="@+id/no_profile_notice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/dns_hosts_no_active_profile"
+                android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:visibility="gone" />
+
+            <!-- Master toggle -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/master_card"
+                style="@style/AppCard.Filled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                app:cardBackgroundColor="?attr/colorPrimaryContainer"
+                app:cardCornerRadius="20dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/dns_hosts_master_title"
+                            android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                            android:textColor="?attr/colorOnPrimaryContainer"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/dns_hosts_master_summary"
+                            android:textAppearance="@style/TextAppearance.App.BodySmall"
+                            android:textColor="?attr/colorOnPrimaryContainer" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/master_toggle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Editable content -->
+            <LinearLayout
+                android:id="@+id/content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/dns_hosts_section_dns"
+                    android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                    android:textColor="?attr/colorPrimary"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/dns_enable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/dns_hosts_enable_dns" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/dns_hosts_mode"
+                    android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/mode_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/mode_off"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_mode_off"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/mode_redir"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_mode_redir"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/mode_fakeip"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_mode_fakeip"
+                        android:textAllCaps="false" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:hint="@string/dns_hosts_listen">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/listen_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/dns_hosts_cache"
+                    android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/cache_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/cache_default"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_cache_default"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/cache_lru"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_cache_lru"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/cache_arc"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/dns_hosts_cache_arc"
+                        android:textAllCaps="false" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    android:hint="@string/dns_hosts_proxy_dns"
+                    app:helperText="@string/dns_hosts_list_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/ns_proxy"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top"
+                        android:inputType="textMultiLine|textNoSuggestions"
+                        android:minLines="2" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/dns_hosts_direct_dns"
+                    app:helperText="@string/dns_hosts_list_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/ns_direct"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top"
+                        android:inputType="textMultiLine|textNoSuggestions"
+                        android:minLines="2" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/dns_hosts_proxy_server_dns"
+                    app:helperText="@string/dns_hosts_list_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/ns_proxy_server"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top"
+                        android:inputType="textMultiLine|textNoSuggestions"
+                        android:minLines="2" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/dns_hosts_bootstrap_dns"
+                    app:helperText="@string/dns_hosts_list_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/ns_bootstrap"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top"
+                        android:inputType="textMultiLine|textNoSuggestions"
+                        android:minLines="2" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="22dp"
+                    android:text="@string/dns_hosts_section_hosts"
+                    android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                    android:textColor="?attr/colorPrimary"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:hint="@string/dns_hosts_hosts_hint"
+                    app:helperText="@string/dns_hosts_hosts_helper">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/hosts_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top"
+                        android:inputType="textMultiLine|textNoSuggestions"
+                        android:minLines="3" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/status_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySmall"
+                    android:textColor="?attr/colorError"
+                    android:visibility="gone"
+                    tools:ignore="MissingDefaultResource" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_save"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    android:text="@string/dns_hosts_save"
+                    android:textAllCaps="false" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/design/src/main/res/layout/design_settings.xml
+++ b/design/src/main/res/layout/design_settings.xml
@@ -256,6 +256,61 @@
                         </LinearLayout>
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/card_dns_hosts"
+                    style="@style/AppCard.Filled"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:onClick="@{() -> self.request(Request.StartDnsHosts)}"
+                    android:visibility="gone"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+                    app:cardCornerRadius="22dp"
+                    app:cardElevation="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:padding="16dp">
+
+                        <ImageView
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:contentDescription="@string/dns_hosts_title"
+                            android:src="@drawable/ic_baseline_language"
+                            app:tint="?attr/colorPrimary" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="14dp"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/dns_hosts_title"
+                                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                                android:textColor="?attr/colorOnSurface"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="3dp"
+                                android:text="@string/dns_hosts_entry_summary"
+                                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
         </com.github.kr328.clash.design.view.ObservableScrollView>
 

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -55,6 +55,39 @@
     <string name="home_import_qr_sub">Считать QR-код подписки камерой.</string>
     <string name="home_import_file_row">Из файла</string>
     <string name="home_import_file_sub">Выберите локальный конфиг (.yaml) и импортируйте как профиль.</string>
+
+    <!-- DNS & Hosts -->
+    <string name="dns_hosts_title">DNS и Hosts</string>
+    <string name="dns_hosts_entry_summary">Разрешение имён по профилю: DNS-серверы, fake-ip и статические hosts.</string>
+    <string name="dns_hosts_experimental_title">DNS и Hosts (эксперимент)</string>
+    <string name="dns_hosts_experimental_summary">Показывать редактор DNS и Hosts по профилю в настройках.</string>
+    <string name="dns_hosts_no_active_profile">Активируйте профиль, чтобы править его DNS и Hosts.</string>
+    <string name="dns_hosts_master_title">Управлять DNS и Hosts для этого профиля</string>
+    <string name="dns_hosts_master_summary">Включено — настройки применяются и переживают обновление подписки. Выключение откатывает чисто.</string>
+    <string name="dns_hosts_section_dns">DNS</string>
+    <string name="dns_hosts_enable_dns">Включить DNS</string>
+    <string name="dns_hosts_mode">Режим разрешения</string>
+    <string name="dns_hosts_mode_off">Выкл</string>
+    <string name="dns_hosts_mode_redir">Redir-host</string>
+    <string name="dns_hosts_mode_fakeip">Fake-IP</string>
+    <string name="dns_hosts_listen">Адрес прослушивания DNS (только loopback)</string>
+    <string name="dns_hosts_cache">Алгоритм кэша</string>
+    <string name="dns_hosts_cache_default">По умолчанию</string>
+    <string name="dns_hosts_cache_lru">LRU</string>
+    <string name="dns_hosts_cache_arc">ARC</string>
+    <string name="dns_hosts_proxy_dns">DNS для прокси (nameserver)</string>
+    <string name="dns_hosts_direct_dns">DNS для direct</string>
+    <string name="dns_hosts_proxy_server_dns">DNS proxy-server</string>
+    <string name="dns_hosts_bootstrap_dns">Bootstrap DNS</string>
+    <string name="dns_hosts_list_hint">По одному серверу на строку (напр. https://1.1.1.1/dns-query)</string>
+    <string name="dns_hosts_section_hosts">Hosts</string>
+    <string name="dns_hosts_hosts_hint">Переопределения hosts</string>
+    <string name="dns_hosts_hosts_helper">По одному на строку: домен = 1.2.3.4</string>
+    <string name="dns_hosts_save">Сохранить</string>
+    <string name="dns_hosts_saved">Сохранено.</string>
+    <string name="dns_hosts_disabled">DNS и Hosts откатаны для этого профиля.</string>
+    <string name="dns_hosts_err_listen">Адрес DNS listen: loopback (127.0.0.1:порт), форма по умолчанию (:порт) или пусто.</string>
+    <string name="dns_hosts_err_invalid">Движок отклонил эту конфигурацию.</string>
     <string name="profiles_header_subtitle_empty">Подписок пока нет.</string>
     <string name="profiles_header_subtitle_ready">Управляйте подписками, редактором и источниками в одном месте.</string>
     <string name="profiles_header_total_fmt">Всего: %1$d</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -424,6 +424,39 @@
     <string name="home_import_qr_sub">使用相机读取订阅二维码。</string>
     <string name="home_import_file_row">从文件</string>
     <string name="home_import_file_sub">选择本地配置文件 (.yaml) 并作为配置导入。</string>
+
+    <!-- DNS & Hosts -->
+    <string name="dns_hosts_title">DNS 与 Hosts</string>
+    <string name="dns_hosts_entry_summary">按配置的名称解析：DNS 服务器、fake-ip 与静态 hosts 覆盖。</string>
+    <string name="dns_hosts_experimental_title">DNS 与 Hosts（实验）</string>
+    <string name="dns_hosts_experimental_summary">在设置中显示按配置的 DNS 与 Hosts 编辑器。</string>
+    <string name="dns_hosts_no_active_profile">请先激活一个配置以编辑其 DNS 与 Hosts。</string>
+    <string name="dns_hosts_master_title">为此配置管理 DNS 与 Hosts</string>
+    <string name="dns_hosts_master_summary">开启后设置生效并在订阅更新后保留；关闭将干净还原。</string>
+    <string name="dns_hosts_section_dns">DNS</string>
+    <string name="dns_hosts_enable_dns">启用 DNS</string>
+    <string name="dns_hosts_mode">解析模式</string>
+    <string name="dns_hosts_mode_off">关闭</string>
+    <string name="dns_hosts_mode_redir">Redir-host</string>
+    <string name="dns_hosts_mode_fakeip">Fake-IP</string>
+    <string name="dns_hosts_listen">DNS 监听地址（仅回环）</string>
+    <string name="dns_hosts_cache">缓存算法</string>
+    <string name="dns_hosts_cache_default">默认</string>
+    <string name="dns_hosts_cache_lru">LRU</string>
+    <string name="dns_hosts_cache_arc">ARC</string>
+    <string name="dns_hosts_proxy_dns">代理 DNS (nameserver)</string>
+    <string name="dns_hosts_direct_dns">直连 DNS</string>
+    <string name="dns_hosts_proxy_server_dns">代理服务器 DNS</string>
+    <string name="dns_hosts_bootstrap_dns">Bootstrap DNS</string>
+    <string name="dns_hosts_list_hint">每行一个服务器（如 https://1.1.1.1/dns-query）</string>
+    <string name="dns_hosts_section_hosts">Hosts</string>
+    <string name="dns_hosts_hosts_hint">Hosts 覆盖</string>
+    <string name="dns_hosts_hosts_helper">每行一个：domain = 1.2.3.4</string>
+    <string name="dns_hosts_save">保存</string>
+    <string name="dns_hosts_saved">已保存。</string>
+    <string name="dns_hosts_disabled">已为此配置还原 DNS 与 Hosts。</string>
+    <string name="dns_hosts_err_listen">DNS 监听需为回环 (127.0.0.1:端口)、默认形式 (:端口) 或留空。</string>
+    <string name="dns_hosts_err_invalid">引擎拒绝了此配置。</string>
     <string name="home_import_sheet_title">添加订阅</string>
     <string name="home_import_sheet_summary">选择导入方式：剪贴板、链接或二维码。</string>
     <string name="home_import_url_row">输入 URL</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -193,6 +193,39 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="home_import_qr_sub">Use the camera to read a subscription QR code.</string>
     <string name="home_import_file_row">From file</string>
     <string name="home_import_file_sub">Pick a local config file (.yaml) and import it as a profile.</string>
+
+    <!-- DNS & Hosts -->
+    <string name="dns_hosts_title">DNS &amp; Hosts</string>
+    <string name="dns_hosts_entry_summary">Per-profile name resolution: DNS servers, fake-ip, and static host overrides.</string>
+    <string name="dns_hosts_experimental_title">DNS &amp; Hosts (experimental)</string>
+    <string name="dns_hosts_experimental_summary">Show the per-profile DNS &amp; Hosts editor in Settings.</string>
+    <string name="dns_hosts_no_active_profile">Activate a profile to edit its DNS &amp; Hosts.</string>
+    <string name="dns_hosts_master_title">Manage DNS &amp; Hosts for this profile</string>
+    <string name="dns_hosts_master_summary">When on, your settings apply and survive subscription updates. Turning off reverts cleanly.</string>
+    <string name="dns_hosts_section_dns">DNS</string>
+    <string name="dns_hosts_enable_dns">Enable DNS</string>
+    <string name="dns_hosts_mode">Resolution mode</string>
+    <string name="dns_hosts_mode_off">Off</string>
+    <string name="dns_hosts_mode_redir">Redir-host</string>
+    <string name="dns_hosts_mode_fakeip">Fake-IP</string>
+    <string name="dns_hosts_listen">DNS listen address (loopback only)</string>
+    <string name="dns_hosts_cache">Cache algorithm</string>
+    <string name="dns_hosts_cache_default">Default</string>
+    <string name="dns_hosts_cache_lru">LRU</string>
+    <string name="dns_hosts_cache_arc">ARC</string>
+    <string name="dns_hosts_proxy_dns">Proxy DNS (nameserver)</string>
+    <string name="dns_hosts_direct_dns">Direct DNS</string>
+    <string name="dns_hosts_proxy_server_dns">Proxy-server DNS</string>
+    <string name="dns_hosts_bootstrap_dns">Bootstrap DNS</string>
+    <string name="dns_hosts_list_hint">One server per line (e.g. https://1.1.1.1/dns-query)</string>
+    <string name="dns_hosts_section_hosts">Hosts</string>
+    <string name="dns_hosts_hosts_hint">Host overrides</string>
+    <string name="dns_hosts_hosts_helper">One per line: domain = 1.2.3.4</string>
+    <string name="dns_hosts_save">Save</string>
+    <string name="dns_hosts_saved">Saved.</string>
+    <string name="dns_hosts_disabled">DNS &amp; Hosts reverted for this profile.</string>
+    <string name="dns_hosts_err_listen">DNS listen must be loopback (127.0.0.1:port), the default form (:port), or empty.</string>
+    <string name="dns_hosts_err_invalid">The engine rejected this configuration.</string>
     <string name="connections_title">Connections</string>
     <string name="connections_intro">Live flows from the core (VPN on). Totals are session counters; list refreshes about every second. Subtitle: process, Chain (policy path: selector / groups / leaf; [tag] is proxy-provider when present), network. dialer-proxy is not shown here — the core only records routing hops, not the extra hop used to dial a proxy server.</string>
     <string name="connections_chain_label">Chain: %1$s</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -25,6 +25,8 @@ import com.github.kr328.clash.service.model.YamlPreview
 import com.github.kr328.clash.service.remote.IFetchObserver
 import com.github.kr328.clash.service.remote.IProfileManager
 import com.github.kr328.clash.service.store.ServiceStore
+import com.github.kr328.clash.service.util.DnsHostsConfig
+import com.github.kr328.clash.service.util.DnsHostsYamlEdit
 import com.github.kr328.clash.service.util.directoryLastModified
 import com.github.kr328.clash.service.util.generateProfileUUID
 import com.github.kr328.clash.service.util.importedDir
@@ -888,6 +890,33 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
+
+    override suspend fun queryDnsHostsConfigJson(uuid: UUID): String? {
+        return withContext(Dispatchers.IO) {
+            if (ImportedDao().queryByUUID(uuid) == null) return@withContext null
+            val dir = File(context.importedDir, uuid.toString())
+            if (!File(dir, "config.yaml").isFile) return@withContext null
+            val snapshot = runCatching { Clash.parseProfileSnapshot(dir) }.getOrNull()
+                ?: return@withContext null
+            val config = DnsHostsConfig.fromSnapshot(snapshot)
+            previewJson.encodeToString(DnsHostsConfig.serializer(), config)
+        }
+    }
+
+    override suspend fun previewSetDnsHosts(uuid: UUID, configJson: String): String? {
+        return previewConfigMutation(uuid, "DNS & Hosts") { current ->
+            val config = previewJson.decodeFromString(DnsHostsConfig.serializer(), configJson)
+            DnsHostsYamlEdit.render(current, config)
+        }
+    }
+
+    override suspend fun isDnsHostsManaged(uuid: UUID): Boolean {
+        return withContext(Dispatchers.IO) { store.isDnsHostsManaged(uuid) }
+    }
+
+    override suspend fun setDnsHostsManaged(uuid: UUID, managed: Boolean) {
+        withContext(Dispatchers.IO) { store.setDnsHostsManaged(uuid, managed) }
+    }
 
     override suspend fun applyYamlPreview(previewId: String): Boolean {
         return withContext(Dispatchers.IO) {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -212,9 +212,10 @@ object ProfileProcessor {
                 }
 
                 val configFile = File(context.processingDir, "config.yaml")
+                val dnsHostsManaged = ServiceStore(context).isDnsHostsManaged(snapshot.uuid)
                 val preserved = if (configFile.isFile) {
                     runCatching { Clash.parseProfileSnapshot(context.processingDir) }
-                        .map { SubscriptionUpdateMerge.extractPreserved(it) }
+                        .map { SubscriptionUpdateMerge.extractPreserved(it, includeDnsHosts = dnsHostsManaged) }
                         .getOrElse {
                             Log.w("Failed to snapshot pre-fetch profile for preservation; continuing without overlay", it)
                             SubscriptionUpdateMerge.PreservedOverlay.EMPTY

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -134,6 +134,17 @@ interface IProfileManager {
 
     suspend fun applyYamlPreview(previewId: String): Boolean
 
+    /** Current `dns:`/`hosts:` of a profile as a JSON `DnsHostsConfig`, or null. */
+    suspend fun queryDnsHostsConfigJson(uuid: UUID): String?
+
+    /** Preview applying a JSON `DnsHostsConfig` into the profile's `dns:`/`hosts:` blocks. */
+    suspend fun previewSetDnsHosts(uuid: UUID, configJson: String): String?
+
+    /** Per-profile DNS & Hosts master-toggle (managed = user-owned + preserved). */
+    suspend fun isDnsHostsManaged(uuid: UUID): Boolean
+
+    suspend fun setDnsHostsManaged(uuid: UUID, managed: Boolean)
+
     /** Single entry from `proxies:` as YAML, for display. */
     suspend fun readProxyEntryYaml(uuid: UUID, proxyName: String): String?
 

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -182,6 +182,19 @@ class ServiceStore(context: Context) {
         rawPrefs.edit().remove("subscription_share_links_locked_$uuid").apply()
     }
 
+    /**
+     * Per-profile DNS & Hosts master-toggle state. When true the profile's
+     * `dns:`/`hosts:` are user-owned: editable in the DNS & Hosts screen and
+     * preserved across subscription refreshes. Cleared by the master-toggle
+     * teardown.
+     */
+    fun isDnsHostsManaged(uuid: UUID): Boolean =
+        rawPrefs.getBoolean("dns_hosts_managed_$uuid", false)
+
+    fun setDnsHostsManaged(uuid: UUID, managed: Boolean) {
+        rawPrefs.edit().putBoolean("dns_hosts_managed_$uuid", managed).apply()
+    }
+
     companion object {
         private const val KEY_ALLOW_BYPASS = "allow_bypass"
         private const val MIGRATION_ALLOW_BYPASS_OFF_V1 = "migration_allow_bypass_off_v1"

--- a/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsConfig.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsConfig.kt
@@ -1,0 +1,163 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.core.model.ProfileSnapshot
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Editable model for a profile's name-resolution config (the `dns:` block and
+ * the top-level `hosts:` map). Read from [ProfileSnapshot] (engine-parsed,
+ * exactly as the user wrote it), serialized back into ordered YAML blocks for
+ * the WRITE pipeline. Absent / empty fields are omitted so we never write
+ * engine defaults or empty blocks.
+ *
+ * `enhancedMode` carries the raw mihomo value: `normal` (UI "Off"), `redir-host`,
+ * or `fake-ip`.
+ */
+@Serializable
+data class DnsHostsConfig(
+    var enable: Boolean? = null,
+    var enhancedMode: String? = null,
+    var listen: String? = null,
+    var cacheAlgorithm: String? = null,
+    var nameserver: List<String> = emptyList(),
+    var directNameserver: List<String> = emptyList(),
+    var proxyServerNameserver: List<String> = emptyList(),
+    var defaultNameserver: List<String> = emptyList(),
+    var hosts: Map<String, String> = emptyMap(),
+) {
+    /** The `dns:` block value as an ordered map, or null when nothing is set. */
+    fun toDnsBlock(): Map<String, Any?>? {
+        val m = LinkedHashMap<String, Any?>()
+        enable?.let { m["enable"] = it }
+        enhancedMode?.takeIf { it.isNotBlank() }?.let { m["enhanced-mode"] = it }
+        listen?.takeIf { it.isNotBlank() }?.let { m["listen"] = it }
+        cacheAlgorithm?.takeIf { it.isNotBlank() }?.let { m["cache-algorithm"] = it }
+        nameserver.cleaned().ifNotEmpty { m["nameserver"] = it }
+        directNameserver.cleaned().ifNotEmpty { m["direct-nameserver"] = it }
+        proxyServerNameserver.cleaned().ifNotEmpty { m["proxy-server-nameserver"] = it }
+        defaultNameserver.cleaned().ifNotEmpty { m["default-nameserver"] = it }
+        return m.takeIf { it.isNotEmpty() }
+    }
+
+    /** The `hosts:` block value as an ordered map, or null when empty. */
+    fun toHostsBlock(): Map<String, String>? {
+        val out = LinkedHashMap<String, String>()
+        for ((k, v) in hosts) {
+            val key = k.trim()
+            val value = v.trim()
+            if (key.isNotEmpty() && value.isNotEmpty()) out[key] = value
+        }
+        return out.takeIf { it.isNotEmpty() }
+    }
+
+    /** True when the model would write nothing (used by the master-toggle teardown). */
+    fun isEmpty(): Boolean = toDnsBlock() == null && toHostsBlock() == null
+
+    /**
+     * Overlays the managed DNS fields onto an EXISTING `dns:` map, preserving
+     * any keys this editor doesn't model (respect-rules, nameserver-policy,
+     * fake-ip-filter, ipv6, prefer-h3, use-hosts, …). A managed field that is
+     * empty/cleared is removed from the map (so the user can drop it) without
+     * touching unknown keys. This prevents Save from wiping the rest of a rich
+     * provider `dns:` block.
+     */
+    fun mergeIntoDns(existing: MutableMap<String, Any?>) {
+        fun set(key: String, value: Any?) {
+            if (value != null) existing[key] = value else existing.remove(key)
+        }
+        set("enable", enable)
+        set("enhanced-mode", enhancedMode?.takeIf { it.isNotBlank() })
+        set("listen", listen?.takeIf { it.isNotBlank() })
+        set("cache-algorithm", cacheAlgorithm?.takeIf { it.isNotBlank() })
+        set("nameserver", nameserver.cleaned().takeIf { it.isNotEmpty() })
+        set("direct-nameserver", directNameserver.cleaned().takeIf { it.isNotEmpty() })
+        set("proxy-server-nameserver", proxyServerNameserver.cleaned().takeIf { it.isNotEmpty() })
+        set("default-nameserver", defaultNameserver.cleaned().takeIf { it.isNotEmpty() })
+    }
+
+    private fun List<String>.cleaned(): List<String> =
+        map { it.trim() }.filter { it.isNotEmpty() }
+
+    private inline fun List<String>.ifNotEmpty(block: (List<String>) -> Unit) {
+        if (isNotEmpty()) block(this)
+    }
+
+    companion object {
+        fun fromSnapshot(snapshot: ProfileSnapshot): DnsHostsConfig =
+            from(snapshot.dns, snapshot.hosts)
+
+        fun from(dns: JsonObject?, hosts: JsonObject?): DnsHostsConfig {
+            val c = DnsHostsConfig()
+            if (dns != null) {
+                c.enable = dns["enable"]?.jsonPrimitive?.booleanOrNull
+                c.enhancedMode = dns.str("enhanced-mode")
+                c.listen = dns.str("listen")
+                c.cacheAlgorithm = dns.str("cache-algorithm")
+                c.nameserver = dns.strList("nameserver")
+                c.directNameserver = dns.strList("direct-nameserver")
+                c.proxyServerNameserver = dns.strList("proxy-server-nameserver")
+                c.defaultNameserver = dns.strList("default-nameserver")
+            }
+            if (hosts != null) {
+                val map = LinkedHashMap<String, String>()
+                for ((k, v) in hosts) {
+                    val value = v.jsonPrimitive.contentOrNull ?: continue
+                    map[k] = value
+                }
+                c.hosts = map
+            }
+            return c
+        }
+
+        private fun JsonObject.str(key: String): String? =
+            this[key]?.jsonPrimitive?.contentOrNull
+
+        private fun JsonObject.strList(key: String): List<String> =
+            (this[key] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+    }
+}
+
+/** Pure validators used both by the UI (inline errors) and unit tests. */
+object DnsHostsValidator {
+    enum class Error {
+        LISTEN_NOT_LOOPBACK,
+        RESPECT_RULES_NEEDS_PROXY_NAMESERVER,
+    }
+
+    private val loopbackHosts = setOf("127.0.0.1", "::1", "[::1]", "localhost")
+
+    /**
+     * `dns.listen` must be empty, loopback, or the idiomatic empty-host `:port`
+     * form (mihomo's default listen notation, e.g. `:1053`). An explicit
+     * non-loopback IP (e.g. `192.168.1.5:53`) is rejected as a likely mistake.
+     */
+    fun listenError(listen: String?): Error? {
+        val v = listen?.trim().orEmpty()
+        if (v.isEmpty()) return null
+        val host = hostOf(v)
+        return if (host.isEmpty() || host in loopbackHosts) null else Error.LISTEN_NOT_LOOPBACK
+    }
+
+    /** Engine: `respect-rules: true` requires a non-empty `proxy-server-nameserver`. */
+    fun proxyServerNameserverError(respectRules: Boolean, proxyServerNameserver: List<String>): Error? {
+        if (!respectRules) return null
+        val any = proxyServerNameserver.any { it.trim().isNotEmpty() }
+        return if (any) null else Error.RESPECT_RULES_NEEDS_PROXY_NAMESERVER
+    }
+
+    /** Host portion of `host:port` / `[ipv6]:port` / bare host. */
+    private fun hostOf(addr: String): String {
+        val s = addr.trim()
+        if (s.startsWith("[")) {
+            val end = s.indexOf(']')
+            if (end > 0) return s.substring(0, end + 1)
+        }
+        val colon = s.lastIndexOf(':')
+        return if (colon >= 0) s.substring(0, colon) else s
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsYamlEdit.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsYamlEdit.kt
@@ -1,0 +1,57 @@
+package com.github.kr328.clash.service.util
+
+/**
+ * Writes a profile's name-resolution config into `config.yaml`, touching only
+ * the `dns:` and top-level `hosts:` blocks. Uses the block-level patcher so
+ * comments, anchors and every unrelated section are preserved.
+ *
+ * A non-null block is set/replaced; a null block (the model serialized nothing,
+ * e.g. master-toggle teardown) is **removed** from the file rather than written
+ * as an empty map.
+ */
+object DnsHostsYamlEdit {
+    /**
+     * @return the proposed `config.yaml` text after applying [config]. If
+     * [config] is empty, both blocks are removed (clean teardown).
+     */
+    fun render(configText: String, config: DnsHostsConfig): String {
+        val replaceKeys = ArrayList<String>(2)
+        val removeKeys = ArrayList<String>(2)
+
+        val document = MihomoConfigDocument.parseOrThrow(configText)
+
+        // DNS: overlay managed fields onto the existing block, keeping unknown
+        // keys (respect-rules, nameserver-policy, fake-ip-filter, ...) intact.
+        val dns = LinkedHashMap<String, Any?>()
+        (document.root["dns"] as? Map<*, *>)?.forEach { (k, v) -> dns[k.toString()] = v }
+        config.mergeIntoDns(dns)
+        if (dns.isNotEmpty()) {
+            document.root["dns"] = dns
+            replaceKeys += "dns"
+        } else {
+            removeKeys += "dns"
+        }
+
+        // Hosts is a flat map this editor fully owns: replace, or drop if empty.
+        val hosts = config.toHostsBlock()
+        if (hosts != null) {
+            document.root["hosts"] = hosts
+            replaceKeys += "hosts"
+        } else {
+            removeKeys += "hosts"
+        }
+
+        var text = configText
+        if (replaceKeys.isNotEmpty()) {
+            text = document.renderReplacing(*replaceKeys.toTypedArray())
+        }
+        if (removeKeys.isNotEmpty()) {
+            text = MihomoConfigDocument.parseOrEmpty(text).renderRemoving(*removeKeys.toTypedArray())
+        }
+        return text
+    }
+
+    /** Convenience: remove both blocks (master-toggle OFF) without a model. */
+    fun renderCleared(configText: String): String =
+        MihomoConfigDocument.parseOrEmpty(configText).renderRemoving("dns", "hosts")
+}

--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -24,6 +24,15 @@ object SubscriptionUpdateMerge {
          * entries originally bound to a remote interface.
          */
         val listeners: Any? = null,
+        /**
+         * User-owned `dns:` / `hosts:` blocks, captured ONLY for profiles the
+         * DNS & Hosts editor manages (the per-profile master toggle is ON). On
+         * refresh these REPLACE the fetched values (the user owns name
+         * resolution for this profile) — unlike the additive merge used for
+         * rules/providers.
+         */
+        val dns: Any? = null,
+        val hosts: Any? = null,
     ) {
         fun isEmpty(): Boolean {
             val rpEmpty =
@@ -34,7 +43,9 @@ object SubscriptionUpdateMerge {
             val pgEmpty =
                 proxyGroups == null || (proxyGroups is List<*> && proxyGroups.isEmpty())
             val lEmpty = listeners == null || (listeners is List<*> && listeners.isEmpty())
-            return rpEmpty && rEmpty && ppEmpty && pgEmpty && lEmpty
+            val dnsEmpty = dns == null || (dns is Map<*, *> && dns.isEmpty())
+            val hostsEmpty = hosts == null || (hosts is Map<*, *> && hosts.isEmpty())
+            return rpEmpty && rEmpty && ppEmpty && pgEmpty && lEmpty && dnsEmpty && hostsEmpty
         }
 
         companion object {
@@ -49,7 +60,12 @@ object SubscriptionUpdateMerge {
      * converted to plain Map/List/scalar trees so the existing mergeAfterFetch
      * pipeline (which dumps back via SnakeYAML) keeps working unchanged.
      */
-    fun extractPreserved(snapshot: ProfileSnapshot): PreservedOverlay {
+    /**
+     * @param includeDnsHosts capture `dns:`/`hosts:` too — pass `true` only for
+     * profiles whose DNS & Hosts editor master toggle is ON (`dnsHostsManaged`).
+     * Untouched profiles must keep whatever the subscription ships.
+     */
+    fun extractPreserved(snapshot: ProfileSnapshot, includeDnsHosts: Boolean = false): PreservedOverlay {
         val rp = snapshot.ruleProviders.takeIf { it.isNotEmpty() }
             ?.let { JsonElementToYaml.convertObjectMap(it) }
         val rules = snapshot.rules.takeIf { it.isNotEmpty() }
@@ -60,10 +76,14 @@ object SubscriptionUpdateMerge {
             ?.let { JsonElementToYaml.convertObjectList(it) }
         val listeners = snapshot.listeners.takeIf { it.isNotEmpty() }
             ?.let { JsonElementToYaml.convertObjectList(it) }
-        if (rp == null && rules == null && pp == null && pg == null && listeners == null) {
+        val dns = if (includeDnsHosts) snapshot.dns?.let { JsonElementToYaml.convertObject(it) } else null
+        val hosts = if (includeDnsHosts) snapshot.hosts?.let { JsonElementToYaml.convertObject(it) } else null
+        if (rp == null && rules == null && pp == null && pg == null && listeners == null &&
+            dns == null && hosts == null
+        ) {
             return PreservedOverlay.EMPTY
         }
-        return PreservedOverlay(rp, rules, pp, pg, listeners)
+        return PreservedOverlay(rp, rules, pp, pg, listeners, dns, hosts)
     }
 
     /**
@@ -90,6 +110,15 @@ object SubscriptionUpdateMerge {
         if (preserved.listeners != null) {
             root["listeners"] = mergeListenersLists(root["listeners"], preserved.listeners)
         }
+        // dns/hosts are user-owned for managed profiles: REPLACE the fetched
+        // values outright (not an additive merge). A removed user block leaves
+        // the subscription's own value in place (preserved.dns is null then).
+        if (preserved.dns != null) {
+            root["dns"] = preserved.dns
+        }
+        if (preserved.hosts != null) {
+            root["hosts"] = preserved.hosts
+        }
         // Garbage-collect providers nothing references. After overlaying the
         // pre-fetch state on top of the fresh subscription, a rule-provider
         // may exist that no `RULE-SET,name,...` rule mentions, or a
@@ -106,6 +135,8 @@ object SubscriptionUpdateMerge {
             "proxy-providers",
             "proxy-groups",
             "listeners",
+            "dns",
+            "hosts",
         )
     }
 

--- a/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsConfigTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsConfigTest.kt
@@ -1,0 +1,97 @@
+package com.github.kr328.clash.service.util
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DnsHostsConfigTest {
+    private fun obj(json: String): JsonObject =
+        Json.parseToJsonElement(json) as JsonObject
+
+    @Test
+    fun reads_dns_and_hosts_from_snapshot_objects() {
+        val dns = obj(
+            """
+            {"enable":true,"enhanced-mode":"fake-ip","listen":"127.0.0.1:0",
+             "cache-algorithm":"arc",
+             "nameserver":["https://1.1.1.1/dns-query"],
+             "direct-nameserver":["https://dns.yandex/dns-query"]}
+            """.trimIndent(),
+        )
+        val hosts = obj("""{"example.com":"1.2.3.4","router.lan":"192.168.1.1"}""")
+
+        val c = DnsHostsConfig.from(dns, hosts)
+
+        assertEquals(true, c.enable)
+        assertEquals("fake-ip", c.enhancedMode)
+        assertEquals("arc", c.cacheAlgorithm)
+        assertEquals(listOf("https://1.1.1.1/dns-query"), c.nameserver)
+        assertEquals(listOf("https://dns.yandex/dns-query"), c.directNameserver)
+        assertEquals("1.2.3.4", c.hosts["example.com"])
+    }
+
+    @Test
+    fun serializes_only_set_fields_and_omits_empties() {
+        val c = DnsHostsConfig(
+            enable = true,
+            enhancedMode = "fake-ip",
+            nameserver = listOf(" https://1.1.1.1/dns-query ", "  "),
+        )
+        val dns = c.toDnsBlock()!!
+        assertEquals(true, dns["enable"])
+        assertEquals("fake-ip", dns["enhanced-mode"])
+        assertEquals(listOf("https://1.1.1.1/dns-query"), dns["nameserver"]) // trimmed + blank dropped
+        assertTrue(!dns.containsKey("listen"))
+        assertTrue(!dns.containsKey("cache-algorithm"))
+        assertNull(c.toHostsBlock()) // no hosts
+    }
+
+    @Test
+    fun empty_model_writes_nothing() {
+        val c = DnsHostsConfig()
+        assertNull(c.toDnsBlock())
+        assertNull(c.toHostsBlock())
+        assertTrue(c.isEmpty())
+    }
+
+    @Test
+    fun hosts_block_drops_blank_entries_or_is_null() {
+        val c = DnsHostsConfig(
+            hosts = linkedMapOf("a.com" to "1.1.1.1", "" to "2.2.2.2", "b.com" to "  "),
+        )
+        val hosts = c.toHostsBlock()!!
+        assertEquals(mapOf("a.com" to "1.1.1.1"), hosts)
+    }
+
+    @Test
+    fun listen_validator_allows_loopback_or_empty_only() {
+        assertNull(DnsHostsValidator.listenError(null))
+        assertNull(DnsHostsValidator.listenError(""))
+        assertNull(DnsHostsValidator.listenError("127.0.0.1:0"))
+        assertNull(DnsHostsValidator.listenError("[::1]:53"))
+        assertNull(DnsHostsValidator.listenError("localhost:53"))
+        assertNull(DnsHostsValidator.listenError(":1053")) // empty-host default form
+        assertNull(DnsHostsValidator.listenError(":53"))
+        assertEquals(
+            DnsHostsValidator.Error.LISTEN_NOT_LOOPBACK,
+            DnsHostsValidator.listenError("0.0.0.0:53"),
+        )
+        assertEquals(
+            DnsHostsValidator.Error.LISTEN_NOT_LOOPBACK,
+            DnsHostsValidator.listenError("192.168.1.5:53"),
+        )
+    }
+
+    @Test
+    fun respect_rules_requires_proxy_server_nameserver() {
+        assertNull(DnsHostsValidator.proxyServerNameserverError(false, emptyList()))
+        assertNull(DnsHostsValidator.proxyServerNameserverError(true, listOf("https://1.1.1.1/dns-query")))
+        assertEquals(
+            DnsHostsValidator.Error.RESPECT_RULES_NEEDS_PROXY_NAMESERVER,
+            DnsHostsValidator.proxyServerNameserverError(true, listOf("  ")),
+        )
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsPreservationTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsPreservationTest.kt
@@ -1,0 +1,58 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.core.model.ProfileSnapshot
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DnsHostsPreservationTest {
+    private fun obj(json: String): JsonObject = Json.parseToJsonElement(json) as JsonObject
+
+    private val userSnapshot = ProfileSnapshot(
+        dns = obj("""{"enable":true,"nameserver":["1.1.1.1"]}"""),
+        hosts = obj("""{"a.com":"9.9.9.9"}"""),
+    )
+
+    // The fresh subscription ships its own (different) dns/hosts.
+    private val fetched = """
+        mixed-port: 7890
+        proxies:
+          - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}
+        dns:
+          enable: false
+          nameserver:
+            - 8.8.8.8
+        hosts:
+          a.com: 1.1.1.1
+    """.trimIndent() + "\n"
+
+    @Test
+    fun managed_profile_replaces_fetched_dns_hosts() {
+        val preserved = SubscriptionUpdateMerge.extractPreserved(userSnapshot, includeDnsHosts = true)
+        assertNotNull(preserved.dns)
+        assertNotNull(preserved.hosts)
+
+        val merged = SubscriptionUpdateMerge.mergeAfterFetch(fetched, preserved)
+
+        assertTrue(merged.contains("1.1.1.1"), "user nameserver kept")
+        assertFalse(merged.contains("8.8.8.8"), "fetched nameserver replaced")
+        assertTrue(merged.contains("9.9.9.9"), "user host kept")
+        assertTrue(merged.contains("proxies:"), "unrelated preserved")
+    }
+
+    @Test
+    fun unmanaged_profile_keeps_subscription_dns_hosts() {
+        val preserved = SubscriptionUpdateMerge.extractPreserved(userSnapshot, includeDnsHosts = false)
+        assertNull(preserved.dns)
+        assertNull(preserved.hosts)
+
+        val merged = SubscriptionUpdateMerge.mergeAfterFetch(fetched, preserved)
+
+        assertTrue(merged.contains("8.8.8.8"), "subscription nameserver kept")
+        assertFalse(merged.contains("1.1.1.1") && !merged.contains("8.8.8.8"))
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsYamlEditTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/DnsHostsYamlEditTest.kt
@@ -1,0 +1,96 @@
+package com.github.kr328.clash.service.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DnsHostsYamlEditTest {
+    private val base = """
+        # my profile
+        mixed-port: 7890
+        proxies:
+          - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}
+        rules:
+          - MATCH,p1
+    """.trimIndent() + "\n"
+
+    @Test
+    fun adds_dns_and_hosts_when_absent_preserving_everything_else() {
+        val cfg = DnsHostsConfig(
+            enable = true,
+            enhancedMode = "fake-ip",
+            nameserver = listOf("https://1.1.1.1/dns-query"),
+            hosts = linkedMapOf("example.com" to "1.2.3.4"),
+        )
+        val out = DnsHostsYamlEdit.render(base, cfg)
+
+        // unrelated content preserved
+        assertTrue(out.contains("# my profile"))
+        assertTrue(out.contains("mixed-port: 7890"))
+        assertTrue(out.contains("MATCH,p1"))
+        // new blocks present
+        assertTrue(out.contains("dns:"))
+        assertTrue(out.contains("enhanced-mode: fake-ip"))
+        assertTrue(out.contains("https://1.1.1.1/dns-query"))
+        assertTrue(out.contains("hosts:"))
+        assertTrue(out.contains("example.com"))
+    }
+
+    @Test
+    fun replaces_existing_dns_without_touching_other_blocks() {
+        val withDns = base + "dns:\n  enable: false\n  nameserver:\n    - 8.8.8.8\n"
+        val cfg = DnsHostsConfig(enable = true, nameserver = listOf("1.1.1.1"))
+        val out = DnsHostsYamlEdit.render(withDns, cfg)
+
+        assertTrue(out.contains("1.1.1.1"))
+        assertFalse(out.contains("8.8.8.8")) // old nameserver gone
+        assertTrue(out.contains("MATCH,p1")) // rules intact
+    }
+
+    @Test
+    fun preserves_unmodeled_dns_fields_on_save() {
+        val richDns = base +
+            "dns:\n" +
+            "  enable: true\n" +
+            "  respect-rules: true\n" +
+            "  prefer-h3: false\n" +
+            "  nameserver:\n    - 8.8.8.8\n" +
+            "  nameserver-policy:\n    +.ru:\n      - https://dns.yandex/dns-query\n" +
+            "  fake-ip-filter:\n    - '*.lan'\n"
+        val cfg = DnsHostsConfig(enable = true, nameserver = listOf("1.1.1.1"))
+        val out = DnsHostsYamlEdit.render(richDns, cfg)
+
+        // managed field replaced
+        assertTrue(out.contains("1.1.1.1"))
+        assertFalse(out.contains("8.8.8.8"))
+        // unmodeled fields preserved
+        assertTrue(out.contains("respect-rules"))
+        assertTrue(out.contains("nameserver-policy"))
+        assertTrue(out.contains("fake-ip-filter"))
+        assertTrue(out.contains("dns.yandex"))
+    }
+
+    @Test
+    fun empty_model_removes_blocks_teardown() {
+        val withBoth = base +
+            "dns:\n  enable: true\n  nameserver:\n    - 1.1.1.1\n" +
+            "hosts:\n  example.com: 1.2.3.4\n"
+        val out = DnsHostsYamlEdit.render(withBoth, DnsHostsConfig())
+
+        assertFalse(out.contains("dns:"))
+        assertFalse(out.contains("hosts:"))
+        assertFalse(out.contains("example.com"))
+        // unrelated preserved
+        assertTrue(out.contains("mixed-port: 7890"))
+        assertTrue(out.contains("MATCH,p1"))
+    }
+
+    @Test
+    fun render_cleared_removes_both_blocks() {
+        val withBoth = base + "dns:\n  enable: true\n" + "hosts:\n  a.com: 1.1.1.1\n"
+        val out = DnsHostsYamlEdit.renderCleared(withBoth)
+        assertFalse(out.contains("dns:"))
+        assertFalse(out.contains("hosts:"))
+        assertTrue(out.contains("proxies:"))
+    }
+}


### PR DESCRIPTION
Gated, per-profile DNS & Hosts settings screen over the active profile: per-mode nameservers, fake-ip, listen, cache algorithm, and static hosts. Reads via Path B snapshot, writes via the block-patcher with engine validation and preservation across subscription refresh; global experimental gate + per-profile master toggle with clean teardown. Closes #69