### PR TITLE
Feat/tunnels editor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -155,6 +155,11 @@
             android:exported="false"
             android:label="@string/dns_hosts_title" />
         <activity
+            android:name=".TunnelsSettingsActivity"
+            android:configChanges="uiMode"
+            android:exported="false"
+            android:label="@string/tunnels_title" />
+        <activity
             android:name=".AppSettingsActivity"
             android:configChanges="uiMode"
             android:exported="false"

--- a/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
@@ -28,6 +28,8 @@ class SettingsActivity : BaseActivity<SettingsDesign>() {
                             startActivity(NetworkSettingsActivity::class.intent)
                         SettingsDesign.Request.StartDnsHosts ->
                             startActivity(DnsHostsSettingsActivity::class.intent)
+                        SettingsDesign.Request.StartTunnels ->
+                            startActivity(TunnelsSettingsActivity::class.intent)
                     }
                 }
             }

--- a/app/src/main/java/com/github/kr328/clash/TunnelsSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/TunnelsSettingsActivity.kt
@@ -1,0 +1,184 @@
+package com.github.kr328.clash
+
+import android.os.Bundle
+import androidx.core.view.WindowCompat
+import com.github.kr328.clash.core.Clash
+import com.github.kr328.clash.core.model.ProfileSnapshot
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.TunnelsSettingsDesign
+import com.github.kr328.clash.service.model.YamlPreview
+import com.github.kr328.clash.service.util.ProxyGroupsYamlPreview
+import com.github.kr328.clash.service.util.TunnelsConfig
+import com.github.kr328.clash.service.util.TunnelsValidator
+import com.github.kr328.clash.util.withProfile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import java.util.UUID
+
+/**
+ * Per-profile `tunnels:` editor over the active profile. Reads via engine
+ * snapshot, writes through the preview pipeline, and toggles the per-profile
+ * managed marker that drives subscription-refresh preservation. Master toggle
+ * OFF tears the block down cleanly.
+ */
+class TunnelsSettingsActivity : BaseActivity<TunnelsSettingsDesign>() {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private var uuid: UUID? = null
+    private var profileName: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+    }
+
+    override suspend fun main() {
+        val design = TunnelsSettingsDesign(this)
+        setContentDesign(design)
+
+        val active = withProfile { queryActive() }
+        if (active == null) {
+            withContext(Dispatchers.Main) { design.showNoProfile() }
+        } else {
+            uuid = active.uuid
+            profileName = active.name
+            loadInto(design)
+        }
+
+        while (isActive) {
+            select<Unit> {
+                design.requests.onReceive { req ->
+                    val id = uuid ?: return@onReceive
+                    when (req) {
+                        is TunnelsSettingsDesign.Request.MasterToggle ->
+                            launch { onMasterToggle(design, id, req.on) }
+                        TunnelsSettingsDesign.Request.Save ->
+                            launch { onSave(design, id) }
+                        TunnelsSettingsDesign.Request.AddEntry ->
+                            withContext(Dispatchers.Main) { design.addEntry() }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun loadInto(design: TunnelsSettingsDesign) {
+        val id = uuid ?: return
+        val managed = withProfile { isTunnelsManaged(id) }
+        val configJson = withProfile { queryTunnelsConfigJson(id) }
+        val config = configJson
+            ?.let { runCatching { json.decodeFromString(TunnelsConfig.serializer(), it) }.getOrNull() }
+            ?: TunnelsConfig()
+        val proxyOptions = loadProxyOptions(id)
+        withContext(Dispatchers.Main) {
+            design.bind(profileName, managed, config, proxyOptions)
+        }
+    }
+
+    private suspend fun loadProxyOptions(id: UUID): List<String> {
+        val yaml = withProfile { readImportedConfigYaml(id) }.orEmpty()
+        if (yaml.isBlank()) return emptyList()
+        val snapshot = runCatching { Clash.parseProfileSnapshotFromYaml(yaml) }.getOrNull()
+            ?: return emptyList()
+        return proxyOptionsFromSnapshot(snapshot)
+    }
+
+    private fun proxyOptionsFromSnapshot(snapshot: ProfileSnapshot): List<String> {
+        val proxies = snapshot.proxies.mapNotNull { obj ->
+            (obj["name"] as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+        }
+        val groups = ProxyGroupsYamlPreview.listProxyGroupNames(snapshot)
+        return (proxies + groups).distinct().sorted()
+    }
+
+    private suspend fun onMasterToggle(design: TunnelsSettingsDesign, id: UUID, on: Boolean) {
+        if (on) {
+            withContext(Dispatchers.Main) {
+                design.setContentEnabled(true)
+                design.showStatus(null, false)
+            }
+            return
+        }
+        if (withProfile { isTunnelsManaged(id) }) {
+            val emptyJson = json.encodeToString(TunnelsConfig.serializer(), TunnelsConfig())
+            val previewJson = withProfile { previewSetTunnels(id, emptyJson) }
+            applyPreview(previewJson)
+            withProfile { setTunnelsManaged(id, false) }
+        }
+        loadInto(design)
+        withContext(Dispatchers.Main) {
+            design.setContentEnabled(false)
+            design.showStatus(getString(R.string.tunnels_disabled), false)
+        }
+    }
+
+    private suspend fun onSave(design: TunnelsSettingsDesign, id: UUID) {
+        val model = withContext(Dispatchers.Main) { design.readModel() }
+
+        for ((index, entry) in model.entries.withIndex()) {
+            val err = TunnelsValidator.validate(entry)
+            if (err != null) {
+                withContext(Dispatchers.Main) {
+                    design.showStatus(validationMessage(index, err), true)
+                }
+                return
+            }
+        }
+
+        withContext(Dispatchers.Main) { design.setSaveBusy(true) }
+        try {
+            val cfgJson = json.encodeToString(TunnelsConfig.serializer(), model)
+            val previewJson = withProfile { previewSetTunnels(id, cfgJson) }
+            val preview = previewJson
+                ?.let { runCatching { json.decodeFromString(YamlPreview.serializer(), it) }.getOrNull() }
+            if (preview == null || !preview.valid) {
+                withContext(Dispatchers.Main) {
+                    design.showStatus(
+                        preview?.error?.takeIf { it.isNotBlank() }
+                            ?: getString(R.string.tunnels_err_invalid),
+                        true,
+                    )
+                }
+                return
+            }
+            val ok = withProfile { applyYamlPreview(preview.id) }
+            if (ok) {
+                withProfile { setTunnelsManaged(id, true) }
+                withContext(Dispatchers.Main) {
+                    design.showStatus(getString(R.string.tunnels_saved), false)
+                }
+            } else {
+                withContext(Dispatchers.Main) {
+                    design.showStatus(getString(R.string.tunnels_err_invalid), true)
+                }
+            }
+        } finally {
+            withContext(Dispatchers.Main) { design.setSaveBusy(false) }
+        }
+    }
+
+    private fun validationMessage(index: Int, err: TunnelsValidator.Error): String {
+        val row = getString(R.string.tunnels_entry_title_fmt, index + 1)
+        val detail = when (err) {
+            TunnelsValidator.Error.ADDRESS_INVALID -> getString(R.string.tunnels_err_address)
+            TunnelsValidator.Error.TARGET_EMPTY -> getString(R.string.tunnels_err_target)
+            TunnelsValidator.Error.PROXY_EMPTY -> getString(R.string.tunnels_err_proxy)
+            TunnelsValidator.Error.NETWORK_INVALID -> getString(R.string.tunnels_err_network)
+        }
+        return "$row: $detail"
+    }
+
+    private suspend fun applyPreview(previewJson: String?): Boolean {
+        val preview = previewJson
+            ?.let { runCatching { json.decodeFromString(YamlPreview.serializer(), it) }.getOrNull() }
+            ?: return false
+        if (!preview.valid) return false
+        return withProfile { applyYamlPreview(preview.id) }
+    }
+}

--- a/core/src/main/golang/native/snapshot/snapshot.go
+++ b/core/src/main/golang/native/snapshot/snapshot.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/metacubex/mihomo/common/yaml"
 	"github.com/metacubex/mihomo/config"
+	LC "github.com/metacubex/mihomo/listener/config"
 )
 
 // ProfileSnapshot is the wire shape sent to Kotlin via JNI. Field names
@@ -35,6 +36,10 @@ type ProfileSnapshot struct {
 	ProxyProviders map[string]map[string]any `json:"proxy-providers,omitempty"`
 	RuleProviders  map[string]map[string]any `json:"rule-providers,omitempty"`
 	Listeners      []map[string]any          `json:"listeners,omitempty"`
+	// Tunnels come from rawCfg (the engine already normalizes both the string
+	// `tcp/udp,addr,target,proxy` and the full-map YAML forms into LC.Tunnel).
+	// Tunnels have no defaults, so rawCfg is clean here (unlike DNS).
+	Tunnels []map[string]any `json:"tunnels,omitempty"`
 	// Dns and Hosts are taken from a generic parse of the raw YAML — i.e. exactly
 	// what the user wrote — NOT from RawConfig (UnmarshalRawConfig starts from
 	// DefaultRawConfig, so RawConfig.DNS is always populated with defaults). The
@@ -54,7 +59,26 @@ func Build(rawCfg *config.RawConfig) ProfileSnapshot {
 		ProxyProviders: rawCfg.ProxyProvider,
 		RuleProviders:  rawCfg.RuleProvider,
 		Listeners:      rawCfg.Listeners,
+		Tunnels:        tunnelsToMaps(rawCfg.Tunnels),
 	}
+}
+
+// tunnelsToMaps projects engine-normalized tunnels into the lowercase map shape
+// the UI consumes, regardless of which YAML form the subscription used.
+func tunnelsToMaps(ts []LC.Tunnel) []map[string]any {
+	if len(ts) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, map[string]any{
+			"network": t.Network,
+			"address": t.Address,
+			"target":  t.Target,
+			"proxy":   t.Proxy,
+		})
+	}
+	return out
 }
 
 // Parse reads <profileDir>/config.yaml and runs mihomo's YAML→RawConfig

--- a/core/src/main/golang/native/snapshot/tunnels_test.go
+++ b/core/src/main/golang/native/snapshot/tunnels_test.go
@@ -1,0 +1,49 @@
+package snapshot
+
+import "testing"
+
+func TestSnapshotTunnels(t *testing.T) {
+	cfg := "" +
+		"proxies:\n" +
+		"  - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}\n" +
+		"proxy-groups:\n" +
+		"  - {name: G, type: select, proxies: [p1]}\n" +
+		"rules:\n" +
+		"  - MATCH,G\n" +
+		"tunnels:\n" +
+		"  - tcp/udp,127.0.0.1:6553,1.1.1.1:53,G\n" +
+		"  - network: [tcp]\n" +
+		"    address: 127.0.0.1:7777\n" +
+		"    target: target.com:80\n" +
+		"    proxy: G\n"
+
+	snap, err := ParseBytes([]byte(cfg))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(snap.Tunnels) != 2 {
+		t.Fatalf("want 2 tunnels, got %d (%v)", len(snap.Tunnels), snap.Tunnels)
+	}
+	// string form normalized to the map shape
+	t0 := snap.Tunnels[0]
+	if t0["address"] != "127.0.0.1:6553" || t0["target"] != "1.1.1.1:53" || t0["proxy"] != "G" {
+		t.Errorf("string-form tunnel not normalized: %v", t0)
+	}
+	if nets, ok := t0["network"].([]string); !ok || len(nets) != 2 {
+		t.Errorf("string-form network want [tcp udp], got %v", t0["network"])
+	}
+	// map form
+	if snap.Tunnels[1]["address"] != "127.0.0.1:7777" {
+		t.Errorf("map-form tunnel wrong: %v", snap.Tunnels[1])
+	}
+}
+
+func TestSnapshotTunnelsAbsentOmitted(t *testing.T) {
+	snap, err := ParseBytes([]byte("proxies:\n  - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}\nrules:\n  - MATCH,p1\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if snap.Tunnels != nil {
+		t.Errorf("tunnels should be nil when absent, got %v", snap.Tunnels)
+	}
+}

--- a/core/src/main/java/com/github/kr328/clash/core/model/ProfileSnapshot.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/ProfileSnapshot.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.core.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -34,6 +35,12 @@ data class ProfileSnapshot(
      */
     val dns: JsonObject? = null,
     val hosts: JsonObject? = null,
+    /**
+     * `tunnels:` normalized to the map form `{network, address, target, proxy}`
+     * by the engine (both YAML forms collapse here), used by the Tunnels editor.
+     * Null when absent.
+     */
+    val tunnels: JsonArray? = null,
 )
 
 /**

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -94,6 +94,13 @@ class AppSettingsDesign(
                 summary = R.string.dns_hosts_experimental_summary,
             )
 
+            switch(
+                value = uiStore::tunnelsEnabled,
+                icon = R.drawable.ic_baseline_swap_horiz,
+                title = R.string.tunnels_experimental_title,
+                summary = R.string.tunnels_experimental_summary,
+            )
+
             category(R.string.service)
 
             switch(

--- a/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
@@ -15,6 +15,7 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
         StartNetwork,
         StartMetaFeatures,
         StartDnsHosts,
+        StartTunnels,
     }
 
     private val binding = DesignSettingsBinding
@@ -26,9 +27,12 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
     init {
         binding.self = this
         binding.header.screenTitle.text = context.getString(R.string.main_advanced_settings)
-        // Experimental DNS & Hosts entry is hidden until opted in (AppSettings).
+        val ui = UiStore(context)
+        // Experimental entries are hidden until opted in (AppSettings).
         binding.cardDnsHosts.visibility =
-            if (UiStore(context).dnsHostsEnabled) View.VISIBLE else View.GONE
+            if (ui.dnsHostsEnabled) View.VISIBLE else View.GONE
+        binding.cardTunnels.visibility =
+            if (ui.tunnelsEnabled) View.VISIBLE else View.GONE
     }
 
     fun request(request: Request) {

--- a/design/src/main/java/com/github/kr328/clash/design/TunnelEntryRowsAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/TunnelEntryRowsAdapter.kt
@@ -1,0 +1,158 @@
+package com.github.kr328.clash.design
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.github.kr328.clash.service.util.TunnelEntry
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.checkbox.MaterialCheckBox
+import com.google.android.material.textfield.TextInputEditText
+
+class TunnelEntryRowsAdapter(
+    private val items: MutableList<TunnelEntry>,
+    private var proxyOptions: List<String>,
+    private val onRowsChanged: () -> Unit,
+) : RecyclerView.Adapter<TunnelEntryRowsAdapter.Holder>() {
+
+    class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        val title: TextView = view.findViewById(R.id.entry_title)
+        val tcp: MaterialCheckBox = view.findViewById(R.id.network_tcp)
+        val udp: MaterialCheckBox = view.findViewById(R.id.network_udp)
+        val address: TextInputEditText = view.findViewById(R.id.input_address)
+        val target: TextInputEditText = view.findViewById(R.id.input_target)
+        val proxy: AutoCompleteTextView = view.findViewById(R.id.input_proxy)
+        val remove: MaterialButton = view.findViewById(R.id.btn_remove)
+        var addressWatcher: TextWatcher? = null
+        var targetWatcher: TextWatcher? = null
+        var proxyWatcher: TextWatcher? = null
+        var tcpListener: ((Boolean) -> Unit)? = null
+        var udpListener: ((Boolean) -> Unit)? = null
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        val v = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_tunnel_entry, parent, false)
+        return Holder(v)
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        val row = items[position]
+        val ctx = holder.itemView.context
+
+        holder.addressWatcher?.let { holder.address.removeTextChangedListener(it) }
+        holder.targetWatcher?.let { holder.target.removeTextChangedListener(it) }
+        holder.proxyWatcher?.let { holder.proxy.removeTextChangedListener(it) }
+        holder.tcpListener?.let { holder.tcp.setOnCheckedChangeListener(null) }
+        holder.udpListener?.let { holder.udp.setOnCheckedChangeListener(null) }
+
+        holder.title.text = ctx.getString(R.string.tunnels_entry_title_fmt, position + 1)
+        holder.tcp.isChecked = "tcp" in row.network.map { it.lowercase() }
+        holder.udp.isChecked = "udp" in row.network.map { it.lowercase() }
+        holder.address.setText(row.address)
+        holder.target.setText(row.target)
+        holder.proxy.setAdapter(
+            ArrayAdapter(ctx, android.R.layout.simple_dropdown_item_1line, proxyOptions),
+        )
+        holder.proxy.setText(row.proxy, false)
+
+        holder.tcpListener = { checked ->
+            val pos = holder.bindingAdapterPosition
+            if (pos in items.indices) updateNetwork(pos, checked, holder.udp.isChecked)
+        }
+        holder.udpListener = { checked ->
+            val pos = holder.bindingAdapterPosition
+            if (pos in items.indices) updateNetwork(pos, holder.tcp.isChecked, checked)
+        }
+        holder.tcp.setOnCheckedChangeListener { _, checked -> holder.tcpListener?.invoke(checked) }
+        holder.udp.setOnCheckedChangeListener { _, checked -> holder.udpListener?.invoke(checked) }
+
+        holder.addressWatcher = textWatcher(holder, holder.address) { pos, text ->
+            items[pos] = items[pos].copy(address = text)
+        }
+        holder.targetWatcher = textWatcher(holder, holder.target) { pos, text ->
+            items[pos] = items[pos].copy(target = text)
+        }
+        holder.proxyWatcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                val pos = holder.bindingAdapterPosition
+                if (pos in items.indices) {
+                    items[pos] = items[pos].copy(proxy = s?.toString()?.trim().orEmpty())
+                    onRowsChanged()
+                }
+            }
+        }
+        holder.address.addTextChangedListener(holder.addressWatcher)
+        holder.target.addTextChangedListener(holder.targetWatcher)
+        holder.proxy.addTextChangedListener(holder.proxyWatcher)
+
+        holder.remove.setOnClickListener {
+            val pos = holder.bindingAdapterPosition
+            if (pos in items.indices) {
+                items.removeAt(pos)
+                notifyItemRemoved(pos)
+                notifyItemRangeChanged(pos, items.size - pos)
+                onRowsChanged()
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun setProxyOptions(options: List<String>) {
+        proxyOptions = options
+        notifyDataSetChanged()
+    }
+
+    fun setItems(rows: Collection<TunnelEntry>) {
+        items.clear()
+        items.addAll(rows.map { it.copy() })
+        notifyDataSetChanged()
+        onRowsChanged()
+    }
+
+    fun addEmptyRow() {
+        items.add(
+            TunnelEntry(
+                network = listOf("tcp", "udp"),
+                address = "127.0.0.1:6553",
+            ),
+        )
+        notifyItemInserted(items.size - 1)
+        onRowsChanged()
+    }
+
+    fun snapshot(): List<TunnelEntry> = items.map { it.copy() }
+
+    private fun updateNetwork(position: Int, tcp: Boolean, udp: Boolean) {
+        val net = buildList {
+            if (tcp) add("tcp")
+            if (udp) add("udp")
+        }
+        items[position] = items[position].copy(network = net)
+        onRowsChanged()
+    }
+
+    private fun textWatcher(
+        holder: Holder,
+        view: TextInputEditText,
+        apply: (Int, String) -> Unit,
+    ): TextWatcher = object : TextWatcher {
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        override fun afterTextChanged(s: Editable?) {
+            val pos = holder.bindingAdapterPosition
+            if (pos in items.indices) {
+                apply(pos, s?.toString()?.trim().orEmpty())
+                onRowsChanged()
+            }
+        }
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/TunnelsSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/TunnelsSettingsDesign.kt
@@ -1,0 +1,141 @@
+package com.github.kr328.clash.design
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.widget.NestedScrollView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.kr328.clash.design.util.layoutInflater
+import com.github.kr328.clash.design.util.root
+import com.github.kr328.clash.service.util.TunnelEntry
+import com.github.kr328.clash.service.util.TunnelsConfig
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.materialswitch.MaterialSwitch
+
+/**
+ * Per-profile `tunnels:` editor. Each row is a static loopback forward routed
+ * through a chosen proxy or group. The master toggle owns whether this profile
+ * is managed (preserved on subscription refresh); OFF triggers clean teardown
+ * in the activity.
+ */
+class TunnelsSettingsDesign(context: Context) : Design<TunnelsSettingsDesign.Request>(context) {
+    sealed class Request {
+        object Save : Request()
+        object AddEntry : Request()
+        data class MasterToggle(val on: Boolean) : Request()
+    }
+
+    private val rootView: View = context.layoutInflater.inflate(
+        R.layout.design_tunnels_settings, context.root, false,
+    )
+    override val root: View get() = rootView
+
+    private val scroll: NestedScrollView = rootView.findViewById(R.id.tunnels_scroll)
+    private val profileName: TextView = rootView.findViewById(R.id.profile_name)
+    private val noProfileNotice: TextView = rootView.findViewById(R.id.no_profile_notice)
+    private val masterCard: View = rootView.findViewById(R.id.master_card)
+    private val content: View = rootView.findViewById(R.id.content)
+    private val masterToggle: MaterialSwitch = rootView.findViewById(R.id.master_toggle)
+    private val recycler: RecyclerView = rootView.findViewById(R.id.entries_recycler)
+    private val statusText: TextView = rootView.findViewById(R.id.status_text)
+    private val btnSave: MaterialButton = rootView.findViewById(R.id.btn_save)
+    private val btnAdd: MaterialButton = rootView.findViewById(R.id.btn_add)
+
+    private val rows = mutableListOf<TunnelEntry>()
+    private val adapter = TunnelEntryRowsAdapter(rows, emptyList()) { }
+
+    init {
+        rootView.findViewById<TextView>(R.id.screen_title).text =
+            context.getString(R.string.tunnels_title)
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPaddingRelative(bars.left, 0, bars.right, 0)
+            scroll.setPadding(scroll.paddingLeft, bars.top, scroll.paddingRight, bars.bottom + 16)
+            insets
+        }
+        rootView.post { ViewCompat.requestApplyInsets(rootView) }
+
+        recycler.layoutManager = LinearLayoutManager(context)
+        recycler.adapter = adapter
+
+        masterToggle.setOnClickListener {
+            requests.trySend(Request.MasterToggle(masterToggle.isChecked))
+        }
+        btnSave.setOnClickListener { requests.trySend(Request.Save) }
+        btnAdd.setOnClickListener { requests.trySend(Request.AddEntry) }
+    }
+
+    fun showNoProfile() {
+        noProfileNotice.visibility = View.VISIBLE
+        masterCard.visibility = View.GONE
+        content.visibility = View.GONE
+        profileName.visibility = View.GONE
+    }
+
+    fun bind(
+        profile: String,
+        managed: Boolean,
+        config: TunnelsConfig,
+        proxyOptions: List<String>,
+    ) {
+        noProfileNotice.visibility = View.GONE
+        masterCard.visibility = View.VISIBLE
+        content.visibility = View.VISIBLE
+        profileName.visibility = View.VISIBLE
+        profileName.text = profile
+
+        masterToggle.isChecked = managed
+        adapter.setProxyOptions(proxyOptions)
+        adapter.setItems(config.entries)
+
+        setContentEnabled(managed)
+    }
+
+    fun readModel(): TunnelsConfig = TunnelsConfig(entries = adapter.snapshot())
+
+    fun addEntry() {
+        adapter.addEmptyRow()
+        scrollToLastEntry()
+    }
+
+    fun setContentEnabled(enabled: Boolean) {
+        content.alpha = if (enabled) 1f else 0.5f
+        setEnabledRecursive(content, enabled)
+    }
+
+    fun setSaveBusy(busy: Boolean) {
+        btnSave.isEnabled = !busy
+    }
+
+    fun showStatus(message: String?, isError: Boolean) {
+        if (message.isNullOrBlank()) {
+            statusText.visibility = View.GONE
+            return
+        }
+        statusText.visibility = View.VISIBLE
+        statusText.text = message
+        statusText.setTextColor(
+            com.google.android.material.color.MaterialColors.getColor(
+                statusText,
+                if (isError) com.google.android.material.R.attr.colorError
+                else com.google.android.material.R.attr.colorPrimary,
+            ),
+        )
+    }
+
+    private fun scrollToLastEntry() {
+        val n = adapter.itemCount
+        if (n > 0) recycler.smoothScrollToPosition(n - 1)
+    }
+
+    private fun setEnabledRecursive(view: View, enabled: Boolean) {
+        view.isEnabled = enabled
+        if (view is android.view.ViewGroup) {
+            for (i in 0 until view.childCount) setEnabledRecursive(view.getChildAt(i), enabled)
+        }
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -81,6 +81,12 @@ class UiStore(context: Context) {
         defaultValue = false,
     )
 
+    /** Experimental gate for the per-profile Tunnels editor (OFF by default). */
+    var tunnelsEnabled: Boolean by store.boolean(
+        key = "tunnels_enabled",
+        defaultValue = false,
+    )
+
     var proxyExcludeNotSelectable by store.boolean(
         key = "proxy_exclude_not_selectable",
         defaultValue = false,

--- a/design/src/main/res/layout/design_settings.xml
+++ b/design/src/main/res/layout/design_settings.xml
@@ -311,6 +311,61 @@
                         </LinearLayout>
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/card_tunnels"
+                    style="@style/AppCard.Filled"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:onClick="@{() -> self.request(Request.StartTunnels)}"
+                    android:visibility="gone"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+                    app:cardCornerRadius="22dp"
+                    app:cardElevation="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:padding="16dp">
+
+                        <ImageView
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:contentDescription="@string/tunnels_title"
+                            android:src="@drawable/ic_baseline_swap_horiz"
+                            app:tint="?attr/colorPrimary" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="14dp"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/tunnels_title"
+                                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                                android:textColor="?attr/colorOnSurface"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="3dp"
+                                android:text="@string/tunnels_entry_summary"
+                                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
         </com.github.kr328.clash.design.view.ObservableScrollView>
 

--- a/design/src/main/res/layout/design_tunnels_settings.xml
+++ b/design/src/main/res/layout/design_tunnels_settings.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/tunnels_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingHorizontal="16dp"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="12dp"
+            android:paddingBottom="32dp">
+
+            <include layout="@layout/include_screen_header" />
+
+            <TextView
+                android:id="@+id/profile_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                tools:ignore="MissingDefaultResource" />
+
+            <TextView
+                android:id="@+id/no_profile_notice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/tunnels_no_active_profile"
+                android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:visibility="gone" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/master_card"
+                style="@style/AppCard.Filled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                app:cardBackgroundColor="?attr/colorPrimaryContainer"
+                app:cardCornerRadius="20dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/tunnels_master_title"
+                            android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                            android:textColor="?attr/colorOnPrimaryContainer"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/tunnels_master_summary"
+                            android:textAppearance="@style/TextAppearance.App.BodySmall"
+                            android:textColor="?attr/colorOnPrimaryContainer" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/master_toggle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:id="@+id/content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/tunnels_section_entries"
+                    android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                    android:textColor="?attr/colorPrimary"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/tunnels_section_entries_summary"
+                    android:textAppearance="@style/TextAppearance.App.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/entries_recycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:nestedScrollingEnabled="false"
+                    tools:itemCount="1"
+                    tools:listitem="@layout/item_tunnel_entry" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_add"
+                    style="@style/AppButton.Tonal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/tunnels_add_entry" />
+
+                <TextView
+                    android:id="@+id/status_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySmall"
+                    android:textColor="?attr/colorError"
+                    android:visibility="gone"
+                    tools:ignore="MissingDefaultResource" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_save"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    android:text="@string/tunnels_save"
+                    android:textAllCaps="false" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/design/src/main/res/layout/item_tunnel_entry.xml
+++ b/design/src/main/res/layout/item_tunnel_entry.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/AppCard.Filled"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="10dp"
+    app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="0dp"
+    app:strokeWidth="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="14dp">
+
+        <TextView
+            android:id="@+id/entry_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.App.TitleSmall"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/tunnels_field_network"
+            android:textAppearance="@style/TextAppearance.App.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/network_tcp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/tunnels_network_tcp" />
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/network_udp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:text="@string/tunnels_network_udp" />
+        </LinearLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:hint="@string/tunnels_field_address"
+            app:helperText="@string/tunnels_address_helper">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/tunnels_field_target">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_target"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="2" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/tunnels_field_proxy">
+
+            <AutoCompleteTextView
+                android:id="@+id/input_proxy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_remove"
+            style="@style/AppButton.Text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="4dp"
+            android:text="@string/tunnels_remove_entry" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -90,6 +90,36 @@
     <string name="dns_hosts_disabled">DNS и Hosts откатаны для этого профиля.</string>
     <string name="dns_hosts_err_listen">Адрес DNS listen: loopback (127.0.0.1:порт), форма по умолчанию (:порт) или пусто.</string>
     <string name="dns_hosts_err_invalid">Движок отклонил эту конфигурацию.</string>
+
+    <!-- Tunnels -->
+    <string name="tunnels_title">Туннели</string>
+    <string name="tunnels_entry_summary">Статические форварды по профилю: loopback listen → target через прокси или группу.</string>
+    <string name="tunnels_experimental_title">Туннели (эксперимент)</string>
+    <string name="tunnels_experimental_summary">Показывать редактор туннелей по профилю в настройках.</string>
+    <string name="tunnels_no_active_profile">Активируйте профиль, чтобы править его туннели.</string>
+    <string name="tunnels_master_title">Управлять туннелями для этого профиля</string>
+    <string name="tunnels_master_summary">Включено — туннели применяются и переживают обновление подписки. Выключение откатывает чисто.</string>
+    <string name="tunnels_section_entries">Записи туннелей</string>
+    <string name="tunnels_section_entries_summary">Каждая запись слушает loopback и форвардит трафик через выбранный прокси или группу.</string>
+    <string name="tunnels_entry_title_fmt">Туннель %1$d</string>
+    <string name="tunnels_field_network">Сеть</string>
+    <string name="tunnels_network_tcp">TCP</string>
+    <string name="tunnels_network_udp">UDP</string>
+    <string name="tunnels_field_address">Адрес прослушивания</string>
+    <string name="tunnels_address_helper">Только loopback host:port (напр. 127.0.0.1:6553). Голый :port запрещён.</string>
+    <string name="tunnels_field_target">Цель (target)</string>
+    <string name="tunnels_field_proxy">Прокси или группа</string>
+    <string name="tunnels_add_entry">Добавить туннель</string>
+    <string name="tunnels_remove_entry">Удалить</string>
+    <string name="tunnels_save">Сохранить</string>
+    <string name="tunnels_saved">Сохранено.</string>
+    <string name="tunnels_disabled">Туннели откатаны для этого профиля.</string>
+    <string name="tunnels_err_address">Адрес listen: явный loopback host:port.</string>
+    <string name="tunnels_err_target">Укажите target.</string>
+    <string name="tunnels_err_proxy">Выберите прокси или группу.</string>
+    <string name="tunnels_err_network">Выберите TCP и/или UDP.</string>
+    <string name="tunnels_err_invalid">Движок отклонил эту конфигурацию.</string>
+
     <string name="profiles_header_subtitle_empty">Подписок пока нет.</string>
     <string name="profiles_header_subtitle_ready">Управляйте подписками, редактором и источниками в одном месте.</string>
     <string name="profiles_header_total_fmt">Всего: %1$d</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -459,6 +459,35 @@
     <string name="dns_hosts_disabled">已为此配置还原 DNS 与 Hosts。</string>
     <string name="dns_hosts_err_listen">DNS 监听需为回环 (127.0.0.1:端口)、默认形式 (:端口) 或留空。</string>
     <string name="dns_hosts_err_invalid">引擎拒绝了此配置。</string>
+
+    <!-- Tunnels -->
+    <string name="tunnels_title">隧道</string>
+    <string name="tunnels_entry_summary">按配置的静态转发：回环监听 → 经代理或组转发到目标。</string>
+    <string name="tunnels_experimental_title">隧道（实验）</string>
+    <string name="tunnels_experimental_summary">在设置中显示按配置的隧道编辑器。</string>
+    <string name="tunnels_no_active_profile">请先激活一个配置以编辑其隧道。</string>
+    <string name="tunnels_master_title">为此配置管理隧道</string>
+    <string name="tunnels_master_summary">开启后隧道生效并在订阅更新后保留；关闭将干净还原。</string>
+    <string name="tunnels_section_entries">隧道条目</string>
+    <string name="tunnels_section_entries_summary">每条在回环地址监听，并通过所选代理或组转发流量。</string>
+    <string name="tunnels_entry_title_fmt">隧道 %1$d</string>
+    <string name="tunnels_field_network">网络</string>
+    <string name="tunnels_network_tcp">TCP</string>
+    <string name="tunnels_network_udp">UDP</string>
+    <string name="tunnels_field_address">监听地址</string>
+    <string name="tunnels_address_helper">仅允许回环 host:port（如 127.0.0.1:6553），不允许单独的 :端口。</string>
+    <string name="tunnels_field_target">目标</string>
+    <string name="tunnels_field_proxy">代理或组</string>
+    <string name="tunnels_add_entry">添加隧道</string>
+    <string name="tunnels_remove_entry">删除</string>
+    <string name="tunnels_save">保存</string>
+    <string name="tunnels_saved">已保存。</string>
+    <string name="tunnels_disabled">已为此配置还原隧道。</string>
+    <string name="tunnels_err_address">监听地址必须是明确的回环 host:port。</string>
+    <string name="tunnels_err_target">请填写目标。</string>
+    <string name="tunnels_err_proxy">请选择代理或组。</string>
+    <string name="tunnels_err_network">请选择 TCP 和/或 UDP。</string>
+    <string name="tunnels_err_invalid">引擎拒绝了此配置。</string>
     <string name="home_import_sheet_title">添加订阅</string>
     <string name="home_import_sheet_summary">选择导入方式：剪贴板、链接或二维码。</string>
     <string name="home_import_url_row">输入 URL</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -228,6 +228,36 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="dns_hosts_disabled">DNS &amp; Hosts reverted for this profile.</string>
     <string name="dns_hosts_err_listen">DNS listen must be loopback (127.0.0.1:port), the default form (:port), or empty.</string>
     <string name="dns_hosts_err_invalid">The engine rejected this configuration.</string>
+
+    <!-- Tunnels -->
+    <string name="tunnels_title">Tunnels</string>
+    <string name="tunnels_entry_summary">Per-profile static forwards: loopback listen → target via a proxy or group.</string>
+    <string name="tunnels_experimental_title">Tunnels (experimental)</string>
+    <string name="tunnels_experimental_summary">Show the per-profile Tunnels editor in Settings.</string>
+    <string name="tunnels_no_active_profile">Activate a profile to edit its tunnels.</string>
+    <string name="tunnels_master_title">Manage tunnels for this profile</string>
+    <string name="tunnels_master_summary">When on, your tunnels apply and survive subscription updates. Turning off reverts cleanly.</string>
+    <string name="tunnels_section_entries">Tunnel entries</string>
+    <string name="tunnels_section_entries_summary">Each entry listens on loopback and forwards traffic through the chosen proxy or group.</string>
+    <string name="tunnels_entry_title_fmt">Tunnel %1$d</string>
+    <string name="tunnels_field_network">Network</string>
+    <string name="tunnels_network_tcp">TCP</string>
+    <string name="tunnels_network_udp">UDP</string>
+    <string name="tunnels_field_address">Listen address</string>
+    <string name="tunnels_address_helper">Loopback host:port only (e.g. 127.0.0.1:6553). Bare :port is not allowed.</string>
+    <string name="tunnels_field_target">Target</string>
+    <string name="tunnels_field_proxy">Proxy or group</string>
+    <string name="tunnels_add_entry">Add tunnel</string>
+    <string name="tunnels_remove_entry">Remove</string>
+    <string name="tunnels_save">Save</string>
+    <string name="tunnels_saved">Saved.</string>
+    <string name="tunnels_disabled">Tunnels reverted for this profile.</string>
+    <string name="tunnels_err_address">Listen address must be an explicit loopback host:port.</string>
+    <string name="tunnels_err_target">Target is required.</string>
+    <string name="tunnels_err_proxy">Proxy or group is required.</string>
+    <string name="tunnels_err_network">Select TCP and/or UDP.</string>
+    <string name="tunnels_err_invalid">The engine rejected this configuration.</string>
+
     <string name="connections_title">Connections</string>
     <string name="connections_intro">Live flows from the core (VPN on). Totals are session counters; list refreshes about every second. Subtitle: process, Chain (policy path: selector / groups / leaf; [tag] is proxy-provider when present), network. dialer-proxy is not shown here — the core only records routing hops, not the extra hop used to dial a proxy server.</string>
     <string name="connections_chain_label">Chain: %1$s</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -27,6 +27,8 @@ import com.github.kr328.clash.service.remote.IProfileManager
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.DnsHostsConfig
 import com.github.kr328.clash.service.util.DnsHostsYamlEdit
+import com.github.kr328.clash.service.util.TunnelsConfig
+import com.github.kr328.clash.service.util.TunnelsYamlEdit
 import com.github.kr328.clash.service.util.directoryLastModified
 import com.github.kr328.clash.service.util.generateProfileUUID
 import com.github.kr328.clash.service.util.importedDir
@@ -916,6 +918,33 @@ class ProfileManager(private val context: Context) : IProfileManager,
 
     override suspend fun setDnsHostsManaged(uuid: UUID, managed: Boolean) {
         withContext(Dispatchers.IO) { store.setDnsHostsManaged(uuid, managed) }
+    }
+
+    override suspend fun queryTunnelsConfigJson(uuid: UUID): String? {
+        return withContext(Dispatchers.IO) {
+            if (ImportedDao().queryByUUID(uuid) == null) return@withContext null
+            val dir = File(context.importedDir, uuid.toString())
+            if (!File(dir, "config.yaml").isFile) return@withContext null
+            val snapshot = runCatching { Clash.parseProfileSnapshot(dir) }.getOrNull()
+                ?: return@withContext null
+            val config = TunnelsConfig.fromSnapshot(snapshot)
+            previewJson.encodeToString(TunnelsConfig.serializer(), config)
+        }
+    }
+
+    override suspend fun previewSetTunnels(uuid: UUID, configJson: String): String? {
+        return previewConfigMutation(uuid, "Tunnels") { current ->
+            val config = previewJson.decodeFromString(TunnelsConfig.serializer(), configJson)
+            TunnelsYamlEdit.render(current, config)
+        }
+    }
+
+    override suspend fun isTunnelsManaged(uuid: UUID): Boolean {
+        return withContext(Dispatchers.IO) { store.isTunnelsManaged(uuid) }
+    }
+
+    override suspend fun setTunnelsManaged(uuid: UUID, managed: Boolean) {
+        withContext(Dispatchers.IO) { store.setTunnelsManaged(uuid, managed) }
     }
 
     override suspend fun applyYamlPreview(previewId: String): Boolean {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -217,9 +217,16 @@ object ProfileProcessor {
 
                 val configFile = File(context.processingDir, "config.yaml")
                 val dnsHostsManaged = ServiceStore(context).isDnsHostsManaged(snapshot.uuid)
+                val tunnelsManaged = ServiceStore(context).isTunnelsManaged(snapshot.uuid)
                 val preserved = if (configFile.isFile) {
                     runCatching { Clash.parseProfileSnapshot(context.processingDir) }
-                        .map { SubscriptionUpdateMerge.extractPreserved(it, includeDnsHosts = dnsHostsManaged) }
+                        .map {
+                            SubscriptionUpdateMerge.extractPreserved(
+                                it,
+                                includeDnsHosts = dnsHostsManaged,
+                                includeTunnels = tunnelsManaged,
+                            )
+                        }
                         .getOrElse {
                             Log.w("Failed to snapshot pre-fetch profile for preservation; continuing without overlay", it)
                             SubscriptionUpdateMerge.PreservedOverlay.EMPTY

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -145,6 +145,17 @@ interface IProfileManager {
 
     suspend fun setDnsHostsManaged(uuid: UUID, managed: Boolean)
 
+    /** Current `tunnels:` of a profile as a JSON `TunnelsConfig`, or null. */
+    suspend fun queryTunnelsConfigJson(uuid: UUID): String?
+
+    /** Preview applying a JSON `TunnelsConfig` into the profile's `tunnels:` block. */
+    suspend fun previewSetTunnels(uuid: UUID, configJson: String): String?
+
+    /** Per-profile tunnels master-toggle (managed = user-owned + preserved). */
+    suspend fun isTunnelsManaged(uuid: UUID): Boolean
+
+    suspend fun setTunnelsManaged(uuid: UUID, managed: Boolean)
+
     /** Single entry from `proxies:` as YAML, for display. */
     suspend fun readProxyEntryYaml(uuid: UUID, proxyName: String): String?
 

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -195,6 +195,14 @@ class ServiceStore(context: Context) {
         rawPrefs.edit().putBoolean("dns_hosts_managed_$uuid", managed).apply()
     }
 
+    /** Per-profile: the user manages this profile's `tunnels:` via the editor. */
+    fun isTunnelsManaged(uuid: UUID): Boolean =
+        rawPrefs.getBoolean("tunnels_managed_$uuid", false)
+
+    fun setTunnelsManaged(uuid: UUID, managed: Boolean) {
+        rawPrefs.edit().putBoolean("tunnels_managed_$uuid", managed).apply()
+    }
+
     /**
      * Per-profile one-shot marker: the last subscription update produced a config
      * the engine rejected even though the fetched subscription was valid (i.e. our

--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -33,6 +33,12 @@ object SubscriptionUpdateMerge {
          */
         val dns: Any? = null,
         val hosts: Any? = null,
+        /**
+         * User-managed `tunnels:` list, captured ONLY when the Tunnels editor
+         * manages this profile (master toggle ON). REPLACES fetched tunnels on
+         * refresh, like dns/hosts.
+         */
+        val tunnels: Any? = null,
     ) {
         fun isEmpty(): Boolean {
             val rpEmpty =
@@ -45,7 +51,8 @@ object SubscriptionUpdateMerge {
             val lEmpty = listeners == null || (listeners is List<*> && listeners.isEmpty())
             val dnsEmpty = dns == null || (dns is Map<*, *> && dns.isEmpty())
             val hostsEmpty = hosts == null || (hosts is Map<*, *> && hosts.isEmpty())
-            return rpEmpty && rEmpty && ppEmpty && pgEmpty && lEmpty && dnsEmpty && hostsEmpty
+            val tunnelsEmpty = tunnels == null || (tunnels is List<*> && tunnels.isEmpty())
+            return rpEmpty && rEmpty && ppEmpty && pgEmpty && lEmpty && dnsEmpty && hostsEmpty && tunnelsEmpty
         }
 
         companion object {
@@ -65,7 +72,11 @@ object SubscriptionUpdateMerge {
      * profiles whose DNS & Hosts editor master toggle is ON (`dnsHostsManaged`).
      * Untouched profiles must keep whatever the subscription ships.
      */
-    fun extractPreserved(snapshot: ProfileSnapshot, includeDnsHosts: Boolean = false): PreservedOverlay {
+    fun extractPreserved(
+        snapshot: ProfileSnapshot,
+        includeDnsHosts: Boolean = false,
+        includeTunnels: Boolean = false,
+    ): PreservedOverlay {
         val rp = snapshot.ruleProviders.takeIf { it.isNotEmpty() }
             ?.let { JsonElementToYaml.convertObjectMap(it) }
         val rules = snapshot.rules.takeIf { it.isNotEmpty() }
@@ -78,12 +89,13 @@ object SubscriptionUpdateMerge {
             ?.let { JsonElementToYaml.convertObjectList(it) }
         val dns = if (includeDnsHosts) snapshot.dns?.let { JsonElementToYaml.convertObject(it) } else null
         val hosts = if (includeDnsHosts) snapshot.hosts?.let { JsonElementToYaml.convertObject(it) } else null
+        val tunnels = if (includeTunnels) snapshot.tunnels?.let { JsonElementToYaml.convertArray(it) } else null
         if (rp == null && rules == null && pp == null && pg == null && listeners == null &&
-            dns == null && hosts == null
+            dns == null && hosts == null && tunnels == null
         ) {
             return PreservedOverlay.EMPTY
         }
-        return PreservedOverlay(rp, rules, pp, pg, listeners, dns, hosts)
+        return PreservedOverlay(rp, rules, pp, pg, listeners, dns, hosts, tunnels)
     }
 
     /**
@@ -119,6 +131,10 @@ object SubscriptionUpdateMerge {
         if (preserved.hosts != null) {
             root["hosts"] = preserved.hosts
         }
+        // tunnels are user-owned for managed profiles: REPLACE fetched outright.
+        if (preserved.tunnels != null) {
+            root["tunnels"] = preserved.tunnels
+        }
         // Garbage-collect providers nothing references. After overlaying the
         // pre-fetch state on top of the fresh subscription, a rule-provider
         // may exist that no `RULE-SET,name,...` rule mentions, or a
@@ -137,6 +153,7 @@ object SubscriptionUpdateMerge {
             "listeners",
             "dns",
             "hosts",
+            "tunnels",
         )
     }
 

--- a/service/src/main/java/com/github/kr328/clash/service/util/TunnelsConfig.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/TunnelsConfig.kt
@@ -1,0 +1,118 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.core.model.ProfileSnapshot
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Editable model for a profile's `tunnels:` block — static `address`→`target`
+ * forwards routed through a chosen `proxy`. Read from [ProfileSnapshot] (engine-
+ * normalized into the map form), written back as the explicit map form.
+ */
+@Serializable
+data class TunnelEntry(
+    var network: List<String> = listOf("tcp", "udp"),
+    var address: String = "",
+    var target: String = "",
+    var proxy: String = "",
+) {
+    /** Ordered map for the YAML block, or null if the entry is incomplete. */
+    fun toMap(): Map<String, Any?>? {
+        val net = network.map { it.trim().lowercase() }.filter { it.isNotEmpty() }
+        val addr = address.trim()
+        val tgt = target.trim()
+        val px = proxy.trim()
+        if (net.isEmpty() || addr.isEmpty() || tgt.isEmpty() || px.isEmpty()) return null
+        val m = LinkedHashMap<String, Any?>()
+        m["network"] = net
+        m["address"] = addr
+        m["target"] = tgt
+        m["proxy"] = px
+        return m
+    }
+}
+
+@Serializable
+data class TunnelsConfig(
+    var entries: List<TunnelEntry> = emptyList(),
+) {
+    /** The `tunnels:` block value (list of ordered maps), or null when empty. */
+    fun toTunnelsBlock(): List<Map<String, Any?>>? =
+        entries.mapNotNull { it.toMap() }.takeIf { it.isNotEmpty() }
+
+    /** True when the model would write nothing (used by the master-toggle teardown). */
+    fun isEmpty(): Boolean = toTunnelsBlock() == null
+
+    companion object {
+        fun fromSnapshot(snapshot: ProfileSnapshot): TunnelsConfig = from(snapshot.tunnels)
+
+        fun from(tunnels: JsonArray?): TunnelsConfig {
+            val list = tunnels?.mapNotNull { el ->
+                val obj = el as? JsonObject ?: return@mapNotNull null
+                TunnelEntry(
+                    network = obj.strList("network").ifEmpty { listOf("tcp", "udp") },
+                    address = obj.str("address") ?: "",
+                    target = obj.str("target") ?: "",
+                    proxy = obj.str("proxy") ?: "",
+                )
+            } ?: emptyList()
+            return TunnelsConfig(list)
+        }
+
+        private fun JsonObject.str(key: String): String? =
+            this[key]?.jsonPrimitive?.contentOrNull
+
+        private fun JsonObject.strList(key: String): List<String> =
+            (this[key] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+    }
+}
+
+/** Pure validators used by the UI (inline errors) and unit tests. */
+object TunnelsValidator {
+    enum class Error {
+        ADDRESS_INVALID, // not a loopback `host:port` — a tunnel must never bind the LAN
+        TARGET_EMPTY,
+        PROXY_EMPTY,
+        NETWORK_INVALID, // empty or not a subset of {tcp,udp}
+    }
+
+    private val loopbackHosts = setOf("127.0.0.1", "::1", "[::1]", "localhost")
+    private val validNetworks = setOf("tcp", "udp")
+
+    fun validate(entry: TunnelEntry): Error? {
+        val net = entry.network.map { it.trim().lowercase() }.filter { it.isNotEmpty() }
+        if (net.isEmpty() || net.any { it !in validNetworks }) return Error.NETWORK_INVALID
+        addressError(entry.address)?.let { return it }
+        if (entry.target.trim().isEmpty()) return Error.TARGET_EMPTY
+        if (entry.proxy.trim().isEmpty()) return Error.PROXY_EMPTY
+        return null
+    }
+
+    /**
+     * `address` must be an explicit loopback `host:port`. Unlike DNS listen, a
+     * tunnel forwards traffic, so a bare `:port` (binds all interfaces) or any
+     * routable host is rejected — the forward must stay on loopback.
+     */
+    fun addressError(address: String): Error? {
+        val v = address.trim()
+        if (v.isEmpty()) return Error.ADDRESS_INVALID
+        val colon = v.lastIndexOf(':')
+        if (colon <= 0 || colon == v.length - 1) return Error.ADDRESS_INVALID // need host:port
+        val host = hostOf(v)
+        return if (host in loopbackHosts) null else Error.ADDRESS_INVALID
+    }
+
+    /** Host portion of `host:port` / `[ipv6]:port`. */
+    private fun hostOf(addr: String): String {
+        val s = addr.trim()
+        if (s.startsWith("[")) {
+            val end = s.indexOf(']')
+            if (end > 0) return s.substring(0, end + 1)
+        }
+        val colon = s.lastIndexOf(':')
+        return if (colon >= 0) s.substring(0, colon) else s
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/util/TunnelsYamlEdit.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/TunnelsYamlEdit.kt
@@ -1,0 +1,21 @@
+package com.github.kr328.clash.service.util
+
+/**
+ * Writes a profile's `tunnels:` block into `config.yaml` via the block-level
+ * patcher, so comments, anchors and every unrelated section are preserved.
+ * A non-empty config replaces the block; an empty one removes it (clean
+ * teardown), never writing an empty list.
+ */
+object TunnelsYamlEdit {
+    fun render(configText: String, config: TunnelsConfig): String {
+        val block = config.toTunnelsBlock()
+            ?: return MihomoConfigDocument.parseOrEmpty(configText).renderRemoving("tunnels")
+        val document = MihomoConfigDocument.parseOrThrow(configText)
+        document.root["tunnels"] = block
+        return document.renderReplacing("tunnels")
+    }
+
+    /** Convenience: remove the block (master-toggle OFF) without a model. */
+    fun renderCleared(configText: String): String =
+        MihomoConfigDocument.parseOrEmpty(configText).renderRemoving("tunnels")
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
@@ -31,6 +31,26 @@ class SubscriptionUpdateMergeTest {
         JsonObject(pairs.toMap())
 
     @Test
+    fun tunnels_preserved_only_when_managed() {
+        val tunnelsJson = kotlinx.serialization.json.Json.parseToJsonElement(
+            """[{"network":["tcp"],"address":"127.0.0.1:6553","target":"1.1.1.1:53","proxy":"G"}]""",
+        ) as kotlinx.serialization.json.JsonArray
+        val snap = ProfileSnapshot(rules = listOf("MATCH,G"), tunnels = tunnelsJson)
+
+        assertNull(SubscriptionUpdateMerge.extractPreserved(snap, includeTunnels = false).tunnels)
+        val on = SubscriptionUpdateMerge.extractPreserved(snap, includeTunnels = true)
+        assertNotNull(on.tunnels)
+
+        // Managed tunnels REPLACE the fetched ones on refresh.
+        val fetched = "proxies:\n  - {name: G, type: socks5, server: 127.0.0.1, port: 1080}\n" +
+            "tunnels:\n  - {network: [udp], address: 127.0.0.1:9, target: old.example:1, proxy: G}\n" +
+            "rules:\n  - MATCH,G\n"
+        val merged = SubscriptionUpdateMerge.mergeAfterFetch(fetched, on)
+        assertTrue("preserved tunnel applied: $merged", merged.contains("1.1.1.1:53"))
+        assertFalse("fetched tunnel replaced", merged.contains("old.example:1"))
+    }
+
+    @Test
     fun gc_keepsProxyProvidersUnderIncludeAll() {
         val fetched = """
             proxies:

--- a/service/src/test/java/com/github/kr328/clash/service/util/TunnelsConfigTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/TunnelsConfigTest.kt
@@ -1,0 +1,96 @@
+package com.github.kr328.clash.service.util
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TunnelsConfigTest {
+    private fun entry() = TunnelEntry(
+        network = listOf("tcp", "udp"),
+        address = "127.0.0.1:6553",
+        target = "1.1.1.1:53",
+        proxy = "G",
+    )
+
+    // --- validator ---
+    @Test fun valid_loopback_entry_passes() {
+        assertNull(TunnelsValidator.validate(entry()))
+    }
+
+    @Test fun non_loopback_address_rejected() {
+        assertEquals(TunnelsValidator.Error.ADDRESS_INVALID,
+            TunnelsValidator.validate(entry().copy(address = "0.0.0.0:6553")))
+    }
+
+    @Test fun bare_port_rejected_for_tunnel() {
+        assertEquals(TunnelsValidator.Error.ADDRESS_INVALID,
+            TunnelsValidator.validate(entry().copy(address = ":6553")))
+    }
+
+    @Test fun missing_port_rejected() {
+        assertEquals(TunnelsValidator.Error.ADDRESS_INVALID,
+            TunnelsValidator.validate(entry().copy(address = "127.0.0.1")))
+    }
+
+    @Test fun bad_network_rejected() {
+        assertEquals(TunnelsValidator.Error.NETWORK_INVALID,
+            TunnelsValidator.validate(entry().copy(network = listOf("icmp"))))
+        assertEquals(TunnelsValidator.Error.NETWORK_INVALID,
+            TunnelsValidator.validate(entry().copy(network = emptyList())))
+    }
+
+    @Test fun empty_target_and_proxy_rejected() {
+        assertEquals(TunnelsValidator.Error.TARGET_EMPTY,
+            TunnelsValidator.validate(entry().copy(target = "  ")))
+        assertEquals(TunnelsValidator.Error.PROXY_EMPTY,
+            TunnelsValidator.validate(entry().copy(proxy = "")))
+    }
+
+    // --- model ---
+    @Test fun toBlock_omits_incomplete_entries() {
+        val cfg = TunnelsConfig(listOf(entry(), TunnelEntry(address = "127.0.0.1:1", target = "", proxy = "")))
+        val block = cfg.toTunnelsBlock()!!
+        assertEquals(1, block.size)
+        assertEquals("127.0.0.1:6553", block[0]["address"])
+        assertEquals(listOf("tcp", "udp"), block[0]["network"])
+    }
+
+    @Test fun empty_config_isEmpty() {
+        assertTrue(TunnelsConfig(emptyList()).isEmpty())
+    }
+
+    @Test fun from_snapshot_json_parses() {
+        val arr = Json.parseToJsonElement(
+            """[{"network":["tcp"],"address":"127.0.0.1:7777","target":"t.com:80","proxy":"P"}]""",
+        ) as JsonArray
+        val cfg = TunnelsConfig.from(arr)
+        assertEquals(1, cfg.entries.size)
+        assertEquals("127.0.0.1:7777", cfg.entries[0].address)
+        assertEquals(listOf("tcp"), cfg.entries[0].network)
+        // sanity: the parsed object is an object
+        assertTrue(arr[0].jsonObject.containsKey("proxy"))
+    }
+
+    // --- yaml round-trip ---
+    @Test fun render_adds_block_and_reparses() {
+        val base = "proxies:\n  - {name: G, type: socks5, server: 127.0.0.1, port: 1080}\nrules:\n  - MATCH,G\n"
+        val out = TunnelsYamlEdit.render(base, TunnelsConfig(listOf(entry())))
+        assertTrue(out.contains("tunnels:"), out)
+        // re-parse round-trips with the engine-aligned resolver
+        val root = YamlFormatting.parseRootMap(out)!!
+        @Suppress("UNCHECKED_CAST")
+        val tunnels = root["tunnels"] as List<Map<String, Any?>>
+        assertEquals("127.0.0.1:6553", tunnels[0]["address"])
+        assertEquals(listOf("tcp", "udp"), tunnels[0]["network"])
+    }
+
+    @Test fun render_empty_removes_block() {
+        val withBlock = "tunnels:\n  - {network: [tcp], address: 127.0.0.1:1, target: t, proxy: P}\nrules:\n  - MATCH,DIRECT\n"
+        val out = TunnelsYamlEdit.render(withBlock, TunnelsConfig(emptyList()))
+        assertTrue(!out.contains("tunnels:"), "tunnels block should be removed: $out")
+    }
+}


### PR DESCRIPTION
## Summary
Closes **#71 (item 4)** — visual, guard-railed editor for the kernel `tunnels:` block (static loopback port-forwards: protocol · listen · target · proxy).
Mirrors the shipped **DNS & Hosts** pattern: engine snapshot for READ, block-patcher for WRITE, per-profile **managed** flag + subscription-update preservation, experimental gate in App settings.
**What this is:** local `address` → `target` forwards through a chosen proxy/group — for apps that cannot use system proxy/VPN rules but can connect to `127.0.0.1:port`. Example: DNS forward `127.0.0.1:5353` → `1.1.1.1:53` via a proxy.
**What this is not:** domain routing (`2ip.io → Japan`). That stays in **Rules** (`DOMAIN,…`). Tunnels do not intercept normal browser traffic to a hostname.
- Go/Kotlin snapshot: `tunnels` normalized to `{network, address, target, proxy}`
- `TunnelsConfig` + `TunnelsValidator` (explicit loopback `host:port` only — bare `:port` rejected)
- `TunnelsYamlEdit` block-patch; empty config removes the block cleanly
- `ServiceStore` `tunnels_managed_<uuid>` + `SubscriptionUpdateMerge` preservation (replace fetched tunnels when managed)
- `IProfileManager`: `queryTunnelsConfigJson` / `previewSetTunnels` / managed toggle
- UI: `TunnelsSettingsActivity` + RecyclerView entry editor, proxy/group picker from snapshot, master toggle teardown, Settings card behind `UiStore.tunnelsEnabled` (default off)
- Strings: EN / RU / ZH
## Issue context
Part of [#71](https://github.com/Nemu-x/ClashFest/issues/71) (Hosting redirects and new ideas). This PR covers **only item 4** (visual tunnels). Items 1 (hosts redirect), 2 (geo-IP load balancing), and 3 (srs/JSON ACL) are out of scope — see `ROADMAP.md`.
## Test plan
- [x] `:app:assembleAlphaDebug` (JDK 21)
- [x] `:service:testAlphaDebugUnitTest` — `TunnelsConfigTest`, `SubscriptionUpdateMergeTest` (tunnels preservation)
- [x] Go `native/snapshot` tunnels test
- [x] Device: enable **Tunnels (experimental)** → add loopback tunnel → Save → works with VPN on
- [x] Master OFF → `tunnels:` block removed from profile YAML
- [x] Subscription update with managed ON → user tunnels preserved over fetched config
- [x] Validator rejects bare `:port` and non-loopback listen addresses