### PR TITLE
ci(release): drop version from APK filenames for stable latest-download links (#85)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Collect APKs
         run: |
           mkdir -p release-artifacts
-          VERSION_TAG="${GITHUB_REF_NAME}"
           find app/build/outputs/apk -name "*.apk" | while read -r apk; do
             base="$(basename "$apk")"
             abi="universal"
@@ -75,7 +74,10 @@ jobs:
             flavor="alpha"
             if [[ "$base" == *"meta"* ]]; then flavor="meta"; fi
 
-            out="clashfest-${VERSION_TAG}-${flavor}-${abi}.apk"
+            # Version-less, stable filename so the GitHub "latest release"
+            # direct link works: releases/latest/download/clashfest-<flavor>-<abi>.apk
+            # (the version stays on the release page/tag, #85).
+            out="clashfest-${flavor}-${abi}.apk"
             cp "$apk" "release-artifacts/$out"
           done
           ls -la release-artifacts


### PR DESCRIPTION
Closes #85.

The release APK filename included the version tag
(`clashfest-v0.7.0-alpha-universal.apk`), which broke a permanent
`releases/latest/download/...` link since the name changed every release.

This makes the filename version-less and stable, so a direct latest link works:

```
https://github.com/Nemu-x/ClashFest/releases/latest/download/clashfest-alpha-universal.apk
```

- `release.yml` only — no gradle/app changes.
- No duplicate assets; the version stays on the release page/tag.
- In-app updater is unaffected (it matches assets by flavor/arch substrings,
  not by the version in the name).

Note: takes effect from the next tagged release; existing release assets keep
their old names.
