### PR TITLE
feat(geo): manual GeoIP/GeoSite database update (#70)

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/GeoDataSourceSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/GeoDataSourceSettingsActivity.kt
@@ -2,15 +2,20 @@ package com.github.kr328.clash
 
 import androidx.activity.result.contract.ActivityResultContracts
 import com.github.kr328.clash.design.GeoDataSourceSettingsDesign
+import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.dialog.withModelProgressBar
+import com.github.kr328.clash.design.ui.ToastDuration
+import com.github.kr328.clash.design.util.showExceptionToast
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.util.GeoDatabaseImportKind
 import com.github.kr328.clash.util.GeoDatabaseImportResult
 import com.github.kr328.clash.util.geoDatabaseImportAcceptedExtensionsLabel
 import com.github.kr328.clash.util.importGeoDatabaseFromUri
+import com.github.kr328.clash.util.withClash
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
-import com.github.kr328.clash.design.R
 
 class GeoDataSourceSettingsActivity : BaseActivity<GeoDataSourceSettingsDesign>() {
     override suspend fun main() {
@@ -40,36 +45,70 @@ class GeoDataSourceSettingsActivity : BaseActivity<GeoDataSourceSettingsDesign>(
                     // no-op
                 }
                 design.requests.onReceive {
-                    val kind = when (it) {
-                        GeoDataSourceSettingsDesign.Request.ImportGeoIp ->
-                            GeoDatabaseImportKind.GeoIp
-                        GeoDataSourceSettingsDesign.Request.ImportGeoSite ->
-                            GeoDatabaseImportKind.GeoSite
-                        GeoDataSourceSettingsDesign.Request.ImportCountryMmdb ->
-                            GeoDatabaseImportKind.CountryMmdb
-                        GeoDataSourceSettingsDesign.Request.ImportAsnMmdb ->
-                            GeoDatabaseImportKind.AsnMmdb
-                    }
-                    val uri = startActivityForResult(
-                        ActivityResultContracts.GetContent(),
-                        "*/*",
-                    )
-                    when (importGeoDatabaseFromUri(uri, kind)) {
-                        GeoDatabaseImportResult.BadExtension ->
-                            MaterialAlertDialogBuilder(this@GeoDataSourceSettingsActivity)
-                                .setTitle(R.string.geofile_unknown_db_format)
-                                .setMessage(
-                                    getString(
-                                        R.string.geofile_unknown_db_format_message,
-                                        geoDatabaseImportAcceptedExtensionsLabel(),
-                                    ),
-                                )
-                                .setPositiveButton(android.R.string.ok, null)
-                                .show()
-                        else -> Unit
+                    when (it) {
+                        GeoDataSourceSettingsDesign.Request.UpdateGeoDatabases ->
+                            launch { updateGeoDatabases(design) }
+                        else -> handleGeoImport(it)
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun updateGeoDatabases(design: GeoDataSourceSettingsDesign) {
+        design.setGeoUpdateBusy(true)
+        try {
+            var error: String? = null
+            withModelProgressBar {
+                configure {
+                    isIndeterminate = true
+                    text = getString(R.string.geo_update_progress)
+                }
+                error = withClash { updateGeoDatabases() }
+            }
+            val message = error
+            if (message == null) {
+                design.showToast(R.string.geo_update_success, ToastDuration.Long)
+            } else {
+                design.showToast(message, ToastDuration.Long)
+            }
+        } catch (e: Exception) {
+            design.showExceptionToast(e)
+        } finally {
+            design.setGeoUpdateBusy(false)
+        }
+    }
+
+    private suspend fun handleGeoImport(request: GeoDataSourceSettingsDesign.Request) {
+        val kind = when (request) {
+            GeoDataSourceSettingsDesign.Request.ImportGeoIp ->
+                GeoDatabaseImportKind.GeoIp
+            GeoDataSourceSettingsDesign.Request.ImportGeoSite ->
+                GeoDatabaseImportKind.GeoSite
+            GeoDataSourceSettingsDesign.Request.ImportCountryMmdb ->
+                GeoDatabaseImportKind.CountryMmdb
+            GeoDataSourceSettingsDesign.Request.ImportAsnMmdb ->
+                GeoDatabaseImportKind.AsnMmdb
+            GeoDataSourceSettingsDesign.Request.UpdateGeoDatabases ->
+                return
+        }
+        val uri = startActivityForResult(
+            ActivityResultContracts.GetContent(),
+            "*/*",
+        )
+        when (importGeoDatabaseFromUri(uri, kind)) {
+            GeoDatabaseImportResult.BadExtension ->
+                MaterialAlertDialogBuilder(this@GeoDataSourceSettingsActivity)
+                    .setTitle(R.string.geofile_unknown_db_format)
+                    .setMessage(
+                        getString(
+                            R.string.geofile_unknown_db_format_message,
+                            geoDatabaseImportAcceptedExtensionsLabel(),
+                        ),
+                    )
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show()
+            else -> Unit
         }
     }
 }

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -57,6 +57,15 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeQueryTunnelState(JNIEnv *en
     return new_string(response);
 }
 
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeUpdateGeoDatabases(JNIEnv *env, jobject thiz) {
+    TRACE_METHOD();
+
+    scoped_string response = updateGeoDatabases();
+
+    return new_string(response);
+}
+
 JNIEXPORT jlong JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeQueryTrafficNow(JNIEnv *env, jobject thiz) {
     TRACE_METHOD();

--- a/core/src/main/golang/native/geo.go
+++ b/core/src/main/golang/native/geo.go
@@ -1,0 +1,21 @@
+package main
+
+//#include "bridge.h"
+import "C"
+
+import (
+	"github.com/metacubex/mihomo/component/updater"
+)
+
+// updateGeoDatabases downloads fresh GeoIP/GeoSite databases from the configured
+// geox-url into the data dir (mihomo's own UpdateGeoDatabases). Returns an empty
+// string on success, or the error message on failure.
+//
+//export updateGeoDatabases
+func updateGeoDatabases() *C.char {
+	defer guard("updateGeoDatabases")()
+	if err := updater.UpdateGeoDatabases(); err != nil {
+		return marshalString(err.Error())
+	}
+	return marshalString("")
+}

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -32,6 +32,10 @@ object Clash {
         Bridge.nativeForceGc()
     }
 
+    /** Download fresh GeoIP/GeoSite databases. Returns null on success, or the engine error. */
+    fun updateGeoDatabases(): String? =
+        Bridge.nativeUpdateGeoDatabases()?.takeIf { it.isNotBlank() }
+
     fun suspendCore(suspended: Boolean) {
         Bridge.nativeSuspend(suspended)
     }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -12,6 +12,7 @@ import java.io.File
 object Bridge {
     external fun nativeReset()
     external fun nativeForceGc()
+    external fun nativeUpdateGeoDatabases(): String?
     external fun nativeSuspend(suspend: Boolean)
     external fun nativeQueryTunnelState(): String
     external fun nativeQueryTrafficNow(): Long

--- a/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
@@ -78,7 +78,9 @@ class GeoDataSourceSettingsDesign(
             ) {
                 listener = OnChangedListener {
                     val isCustom = config.preset == GeoDataSourcePreset.Custom
-                    customDependencies.forEach { it.enabled = isCustom }
+                    // Hide the custom URL fields unless the Custom preset is picked —
+                    // no clutter of greyed-out rows for the 95% on a preset.
+                    customDependencies.forEach { it.visible = isCustom }
                     mirrorTips?.text = mirrorSummaryText()
                 }
             }

--- a/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/GeoDataSourceSettingsDesign.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import com.github.kr328.clash.design.databinding.DesignSettingsCommonBinding
+import com.github.kr328.clash.design.preference.ClickablePreference
 import com.github.kr328.clash.design.preference.*
 import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.design.util.root
@@ -24,11 +25,14 @@ class GeoDataSourceSettingsDesign(
     )
 
     enum class Request {
+        UpdateGeoDatabases,
         ImportGeoIp,
         ImportGeoSite,
         ImportCountryMmdb,
         ImportAsnMmdb,
     }
+
+    private var updateGeoClickable: ClickablePreference? = null
 
     private val binding = DesignSettingsCommonBinding
         .inflate(context.layoutInflater, context.root, false)
@@ -115,6 +119,15 @@ class GeoDataSourceSettingsDesign(
                 configure = customDependencies::add,
             )
 
+            category(R.string.geo_update_online)
+
+            updateGeoClickable = clickable(
+                title = R.string.geo_update_action,
+                icon = R.drawable.ic_baseline_cloud_download,
+            ) {
+                clicked { requests.trySend(Request.UpdateGeoDatabases) }
+            }
+
             category(R.string.import_local_geo_databases)
 
             clickable(title = R.string.import_geoip_file) {
@@ -134,5 +147,12 @@ class GeoDataSourceSettingsDesign(
         }
 
         binding.content.addView(screen.root)
+    }
+
+    fun setGeoUpdateBusy(busy: Boolean) {
+        updateGeoClickable?.apply {
+            enabled = !busy
+            summary = if (busy) context.getString(R.string.geo_update_progress) else null
+        }
     }
 }

--- a/design/src/main/java/com/github/kr328/clash/design/preference/Preference.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/preference/Preference.kt
@@ -17,4 +17,11 @@ interface Preference {
             view.isFocusable = value
             view.alpha = if (value) 1.0f else 0.33f
         }
+
+    /** Show/hide the row entirely (GONE), so dependent options don't clutter as disabled rows. */
+    var visible: Boolean
+        get() = view.visibility == View.VISIBLE
+        set(value) {
+            view.visibility = if (value) View.VISIBLE else View.GONE
+        }
 }

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -152,6 +152,10 @@
     <string name="geo_preset_custom">Свои URL</string>
     <string name="geo_preset_mirrors_title">URL для этого пресета:</string>
     <string name="geo_preset_mirrors_custom">Свой пресет: поля выше; пусто — встроенный URL для слота.</string>
+    <string name="geo_update_online">Онлайн-обновление</string>
+    <string name="geo_update_action">Обновить GeoIP/GeoSite</string>
+    <string name="geo_update_progress">Загрузка GeoIP и GeoSite…</string>
+    <string name="geo_update_success">GeoIP/GeoSite обновлены</string>
     <string name="import_local_geo_databases">Локальный импорт геобаз</string>
     <string name="advanced_settings">Расширенные</string>
     <string name="help">Помощь</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -121,6 +121,10 @@
     <string name="geo_preset_custom">自定义 URL</string>
     <string name="geo_preset_mirrors_title">此预设的 URL：</string>
     <string name="geo_preset_mirrors_custom">自定义：用上方字段；留空则用该槽位内置默认。</string>
+    <string name="geo_update_online">在线更新</string>
+    <string name="geo_update_action">更新 GeoIP/GeoSite</string>
+    <string name="geo_update_progress">正在下载 GeoIP 和 GeoSite…</string>
+    <string name="geo_update_success">GeoIP/GeoSite 已更新</string>
     <string name="import_local_geo_databases">导入本地地理库</string>
     <string name="advanced_settings">高级</string>
     <string name="show_traffic">显示流量</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -67,6 +67,10 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="geo_preset_mirrors_title">URLs for this preset:</string>
     <string name="geo_preset_mirrors_custom">Custom: use the fields above; empty = built-in default for that slot.</string>
     <string name="geox_asn">ASN URL</string>
+    <string name="geo_update_online">Online update</string>
+    <string name="geo_update_action">Update GeoIP/GeoSite</string>
+    <string name="geo_update_progress">Downloading GeoIP and GeoSite…</string>
+    <string name="geo_update_success">GeoIP/GeoSite updated</string>
     <string name="import_local_geo_databases">Import local geo databases</string>
     <string name="advanced_settings">Advanced</string>
     <string name="help">Help</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -197,6 +197,9 @@ class ClashManager(private val context: Context) : IClashManager,
         return Clash.updateProvider(type, name).await()
     }
 
+    override suspend fun updateGeoDatabases(): String? =
+        withContext(Dispatchers.IO) { Clash.updateGeoDatabases() }
+
     override fun setLogObserver(observer: ILogObserver?) {
         synchronized(this) {
             logReceiver?.apply {

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
@@ -31,6 +31,9 @@ interface IClashManager {
     fun healthCheckAll()
     suspend fun updateProvider(type: Provider.Type, name: String)
 
+    /** Download fresh GeoIP/GeoSite databases. Returns null on success, or the engine error. */
+    suspend fun updateGeoDatabases(): String?
+
     fun queryOverride(slot: Clash.OverrideSlot): ConfigurationOverride
     fun patchOverride(slot: Clash.OverrideSlot, configuration: ConfigurationOverride)
     fun clearOverride(slot: Clash.OverrideSlot)


### PR DESCRIPTION
Closes the last item of #70 — manual update of the GeoIP/GeoSite databases.

### What
- A **"Update GeoIP/GeoSite"** action in **Settings → Geo data source** that
  downloads fresh databases on demand (with a progress state and a success/error
  toast). Downloads from the configured geox-url.

### Backend
- New native bridge `updateGeoDatabases()` → mihomo's `updater.UpdateGeoDatabases()`
  (Go export + JNI glue + `Bridge`/`Clash.updateGeoDatabases()`), returning `null`
  on success or the engine error message.
- `IClashManager.updateGeoDatabases()` binder (runs the blocking download on IO).

### Settings polish (bonus, reusable)
- Added `Preference.visible` to the settings DSL (alongside `enabled`), so screens
  can hide dependent rows instead of greying them out.
- Geo screen now **hides the custom GeoIP/GeoSite/MMDB/ASN URL fields unless the
  Custom preset is selected** — no more four greyed-out rows for users on a preset.

### Notes
- No engine/submodule changes. Native rebuild required (cgo/JNI).
