### PR TITLE
feat(settings): advanced-settings overhaul - Expert features gate

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MetaFeatureSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MetaFeatureSettingsActivity.kt
@@ -1,19 +1,10 @@
 package com.github.kr328.clash
 
-import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContracts
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.design.MetaFeatureSettingsDesign
-import com.github.kr328.clash.util.GeoDatabaseImportKind
-import com.github.kr328.clash.util.GeoDatabaseImportResult
-import com.github.kr328.clash.util.importGeoDatabaseFromUri
-import com.github.kr328.clash.util.geoDatabaseImportAcceptedExtensionsLabel
 import com.github.kr328.clash.util.withClash
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.selects.select
-import com.github.kr328.clash.design.R
-
 
 class MetaFeatureSettingsActivity : BaseActivity<MetaFeatureSettingsDesign>() {
     override suspend fun main() {
@@ -49,50 +40,9 @@ class MetaFeatureSettingsActivity : BaseActivity<MetaFeatureSettingsDesign>() {
                                 finish()
                             }
                         }
-                        MetaFeatureSettingsDesign.Request.ImportGeoIp -> {
-                            val uri = startActivityForResult(
-                                ActivityResultContracts.GetContent(),
-                                "*/*")
-                            importGeoFile(uri, GeoDatabaseImportKind.GeoIp)
-                        }
-                        MetaFeatureSettingsDesign.Request.ImportGeoSite -> {
-                            val uri = startActivityForResult(
-                                ActivityResultContracts.GetContent(),
-                                "*/*")
-                            importGeoFile(uri, GeoDatabaseImportKind.GeoSite)
-                        }
-                        MetaFeatureSettingsDesign.Request.ImportCountry -> {
-                            val uri = startActivityForResult(
-                                ActivityResultContracts.GetContent(),
-                                "*/*")
-                            importGeoFile(uri, GeoDatabaseImportKind.CountryMmdb)
-                        }
-                        MetaFeatureSettingsDesign.Request.ImportASN -> {
-                            val uri = startActivityForResult(
-                                ActivityResultContracts.GetContent(),
-                                "*/*")
-                            importGeoFile(uri, GeoDatabaseImportKind.AsnMmdb)
-                        }
                     }
                 }
             }
-        }
-    }
-
-    private suspend fun importGeoFile(uri: Uri?, kind: GeoDatabaseImportKind) {
-        when (importGeoDatabaseFromUri(uri, kind)) {
-            GeoDatabaseImportResult.BadExtension ->
-                MaterialAlertDialogBuilder(this)
-                    .setTitle(R.string.geofile_unknown_db_format)
-                    .setMessage(
-                        getString(
-                            R.string.geofile_unknown_db_format_message,
-                            geoDatabaseImportAcceptedExtensionsLabel(),
-                        ),
-                    )
-                    .setPositiveButton(android.R.string.ok, null)
-                    .show()
-            else -> Unit
         }
     }
 }

--- a/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/SettingsActivity.kt
@@ -14,7 +14,9 @@ class SettingsActivity : BaseActivity<SettingsDesign>() {
         while (isActive) {
             select<Unit> {
                 events.onReceive {
-
+                    // Re-evaluate experimental/expert gates when returning to this
+                    // screen (e.g. after toggling them in App settings).
+                    if (it == Event.ActivityStart) design.applyExperimentalVisibility()
                 }
                 design.requests.onReceive {
                     when (it) {
@@ -30,6 +32,8 @@ class SettingsActivity : BaseActivity<SettingsDesign>() {
                             startActivity(DnsHostsSettingsActivity::class.intent)
                         SettingsDesign.Request.StartTunnels ->
                             startActivity(TunnelsSettingsActivity::class.intent)
+                        SettingsDesign.Request.StartOverride ->
+                            startActivity(OverrideSettingsActivity::class.intent)
                     }
                 }
             }

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -101,6 +101,13 @@ class AppSettingsDesign(
                 summary = R.string.tunnels_experimental_summary,
             )
 
+            switch(
+                value = uiStore::expertEnabled,
+                icon = R.drawable.ic_baseline_bolt,
+                title = R.string.expert_features_title,
+                summary = R.string.expert_features_summary,
+            )
+
             category(R.string.service)
 
             switch(

--- a/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.github.kr328.clash.core.model.ConfigurationOverride
 import com.github.kr328.clash.design.databinding.DesignSettingsMetaFeatureBinding
 import com.github.kr328.clash.design.preference.*
+import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.util.*
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -16,7 +17,7 @@ class MetaFeatureSettingsDesign(
     configuration: ConfigurationOverride
 ) : Design<MetaFeatureSettingsDesign.Request>(context) {
     enum class Request {
-        ResetOverride, ImportGeoIp, ImportGeoSite, ImportCountry, ImportASN
+        ResetOverride
     }
 
     private val binding = DesignSettingsMetaFeatureBinding
@@ -49,6 +50,8 @@ class MetaFeatureSettingsDesign(
         binding.self = this
 
         binding.header.screenTitle.text = context.getString(R.string.meta_features)
+
+        val ui = UiStore(context)
 
         val booleanValues: Array<Boolean?> = arrayOf(
             null,
@@ -85,6 +88,8 @@ class MetaFeatureSettingsDesign(
                 title = R.string.tcp_concurrent,
             )
 
+            // find-process-mode is a power-user knob (and a footgun for bad
+            // subscription values) — only show it when Expert features is on.
             selectableList(
                 value = configuration::findProcessMode,
                 values = arrayOf(
@@ -101,7 +106,7 @@ class MetaFeatureSettingsDesign(
                 ),
                 title = R.string.find_process_mode,
             ) {
-
+                visible = ui.expertEnabled
             }
 
             category(R.string.sniffer_setting)
@@ -240,77 +245,6 @@ class MetaFeatureSettingsDesign(
             )
 
             sniffer.listener?.onChanged()
-
-            /*
-            category(R.string.geox_url_setting)
-
-            val geoxUrlDependencies: MutableList<Preference> = mutableListOf()
-
-            editableText(
-                value = configuration.geoxurl::geoip,
-                adapter = NullableTextAdapter.String,
-                title = R.string.geox_geoip,
-                placeholder = R.string.dont_modify,
-                empty = R.string.geoip_url,
-                configure = geoxUrlDependencies::add,
-            )
-
-            editableText(
-                value = configuration.geoxurl::mmdb,
-                adapter = NullableTextAdapter.String,
-                title = R.string.geox_mmdb,
-                placeholder = R.string.dont_modify,
-                empty = R.string.mmdb_url,
-                configure = geoxUrlDependencies::add,
-            )
-
-            editableText(
-                value = configuration.geoxurl::geosite,
-                adapter = NullableTextAdapter.String,
-                title = R.string.geox_geosite,
-                placeholder = R.string.dont_modify,
-                empty = R.string.geosite_url,
-                configure = geoxUrlDependencies::add,
-            )
-            */
-
-            category(R.string.geox_files)
-
-            clickable (
-                title = R.string.import_geoip_file,
-                summary = R.string.press_to_import,
-            ){
-                clicked {
-                    requests.trySend(Request.ImportGeoIp)
-                }
-            }
-
-            clickable (
-                title = R.string.import_geosite_file,
-                summary = R.string.press_to_import,
-            ){
-                clicked {
-                    requests.trySend(Request.ImportGeoSite)
-                }
-            }
-
-            clickable (
-                title = R.string.import_country_file,
-                summary = R.string.press_to_import,
-            ){
-                clicked {
-                    requests.trySend(Request.ImportCountry)
-                }
-            }
-            
-            clickable (
-                title = R.string.import_asn_file,
-                summary = R.string.press_to_import,
-            ){
-                clicked {
-                    requests.trySend(Request.ImportASN)
-                }
-            }
         }
 
         binding.content.addView(screen.root)

--- a/design/src/main/java/com/github/kr328/clash/design/OverrideSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/OverrideSettingsDesign.kt
@@ -1,11 +1,12 @@
 package com.github.kr328.clash.design
 
+import android.app.Activity
 import android.content.Context
 import android.view.View
 import com.github.kr328.clash.core.model.ConfigurationOverride
 import com.github.kr328.clash.core.model.LogMessage
 import com.github.kr328.clash.core.model.TunnelState
-import com.github.kr328.clash.design.databinding.DesignSettingsOverideBinding
+import com.github.kr328.clash.design.databinding.DesignSettingsCommonBinding
 import com.github.kr328.clash.design.databinding.DialogPreferenceListBinding
 import com.github.kr328.clash.design.dialog.FullScreenDialog
 import com.github.kr328.clash.design.model.AppInfo
@@ -25,7 +26,7 @@ class OverrideSettingsDesign(
         ResetOverride
     }
 
-    private val binding = DesignSettingsOverideBinding
+    private val binding = DesignSettingsCommonBinding
         .inflate(context.layoutInflater, context.root, false)
 
     override val root: View
@@ -52,11 +53,10 @@ class OverrideSettingsDesign(
     }
 
     init {
-        binding.self = this
+        binding.surface = surface
 
-        binding.activityBarLayout.applyFrom(context)
-
-        binding.scrollRoot.bindAppBarElevation(binding.activityBarLayout)
+        binding.header.screenTitle.text =
+            (context as? Activity)?.title?.toString().orEmpty()
 
         val booleanValues: Array<Boolean?> = arrayOf(
             null,
@@ -70,7 +70,7 @@ class OverrideSettingsDesign(
         )
 
         val screen = preferenceScreen(context) {
-            category(R.string.general)
+            category(R.string.override_cat_listeners)
 
             editableText(
                 value = configuration::httpPort,
@@ -84,22 +84,6 @@ class OverrideSettingsDesign(
                 value = configuration::socksPort,
                 adapter = NullableTextAdapter.Port,
                 title = R.string.socks_port,
-                placeholder = R.string.dont_modify,
-                empty = R.string.disabled,
-            )
-
-            editableText(
-                value = configuration::redirectPort,
-                adapter = NullableTextAdapter.Port,
-                title = R.string.redirect_port,
-                placeholder = R.string.dont_modify,
-                empty = R.string.disabled,
-            )
-
-            editableText(
-                value = configuration::tproxyPort,
-                adapter = NullableTextAdapter.Port,
-                title = R.string.tproxy_port,
                 placeholder = R.string.dont_modify,
                 empty = R.string.disabled,
             )
@@ -141,6 +125,8 @@ class OverrideSettingsDesign(
                 empty = R.string.default_
             )
 
+            category(R.string.external_controller)
+
             editableText(
                 value = configuration::externalController,
                 adapter = NullableTextAdapter.String,
@@ -178,6 +164,8 @@ class OverrideSettingsDesign(
                 placeholder = R.string.dont_modify,
                 empty = R.string.default_
             )
+
+            category(R.string.general)
 
             selectableList(
                 value = configuration::mode,
@@ -315,6 +303,8 @@ class OverrideSettingsDesign(
                 configure = dnsDependencies::add,
             )
 
+            category(R.string.name_server)
+
             editableTextList(
                 value = configuration.dns::nameServer,
                 adapter = TextAdapter.String,
@@ -339,6 +329,17 @@ class OverrideSettingsDesign(
                 configure = dnsDependencies::add,
             )
 
+            editableTextMap(
+                value = configuration.dns::nameserverPolicy,
+                keyAdapter = TextAdapter.String,
+                valueAdapter = TextAdapter.String,
+                title = R.string.name_server_policy,
+                placeholder = R.string.dont_modify,
+                configure = dnsDependencies::add,
+            )
+
+            category(R.string.fakeip)
+
             editableTextList(
                 value = configuration.dns::fakeIpFilter,
                 adapter = TextAdapter.String,
@@ -362,6 +363,8 @@ class OverrideSettingsDesign(
                 title = R.string.fakeip_filter_mode,
                 configure = dnsDependencies::add,
             )
+
+            category(R.string.override_cat_fallback_filter)
 
             selectableList(
                 value = configuration.dns.fallbackFilter::geoIp,
@@ -396,14 +399,15 @@ class OverrideSettingsDesign(
                 configure = dnsDependencies::add,
             )
 
-            editableTextMap(
-                value = configuration.dns::nameserverPolicy,
-                keyAdapter = TextAdapter.String,
-                valueAdapter = TextAdapter.String,
-                title = R.string.name_server_policy,
-                placeholder = R.string.dont_modify,
-                configure = dnsDependencies::add,
-            )
+            category(R.string.reset_override_settings)
+
+            clickable(
+                title = R.string.reset_override_settings,
+                summary = R.string.reset_override_settings_message,
+                icon = R.drawable.ic_baseline_restore,
+            ) {
+                clicked { requestClear() }
+            }
 
             dns.listener?.onChanged()
         }

--- a/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/SettingsDesign.kt
@@ -16,6 +16,7 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
         StartMetaFeatures,
         StartDnsHosts,
         StartTunnels,
+        StartOverride,
     }
 
     private val binding = DesignSettingsBinding
@@ -24,15 +25,26 @@ class SettingsDesign(context: Context) : Design<SettingsDesign.Request>(context)
     override val root: View
         get() = binding.root
 
+    private val ui = UiStore(context)
+
     init {
         binding.self = this
         binding.header.screenTitle.text = context.getString(R.string.main_advanced_settings)
-        val ui = UiStore(context)
-        // Experimental entries are hidden until opted in (AppSettings).
+        applyExperimentalVisibility()
+    }
+
+    /**
+     * Re-read the experimental/expert gates and show/hide their entries. Called on
+     * init AND whenever the screen returns to the foreground, so toggling a switch in
+     * App settings reflects here without leaving and re-entering Advanced.
+     */
+    fun applyExperimentalVisibility() {
         binding.cardDnsHosts.visibility =
             if (ui.dnsHostsEnabled) View.VISIBLE else View.GONE
         binding.cardTunnels.visibility =
             if (ui.tunnelsEnabled) View.VISIBLE else View.GONE
+        binding.cardOverride.visibility =
+            if (ui.expertEnabled) View.VISIBLE else View.GONE
     }
 
     fun request(request: Request) {

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -87,6 +87,16 @@ class UiStore(context: Context) {
         defaultValue = false,
     )
 
+    /**
+     * Master gate for expert-tier raw config (OFF by default): unlocks the raw
+     * Config-override screen and other power-user knobs (e.g. find-process-mode).
+     * These interact with the security hardening mode — kept hidden from normal users.
+     */
+    var expertEnabled: Boolean by store.boolean(
+        key = "expert_features_enabled",
+        defaultValue = false,
+    )
+
     var proxyExcludeNotSelectable by store.boolean(
         key = "proxy_exclude_not_selectable",
         defaultValue = false,

--- a/design/src/main/res/layout/design_settings.xml
+++ b/design/src/main/res/layout/design_settings.xml
@@ -366,6 +366,61 @@
                         </LinearLayout>
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/card_override"
+                    style="@style/AppCard.Filled"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:onClick="@{() -> self.request(Request.StartOverride)}"
+                    android:visibility="gone"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer"
+                    app:cardCornerRadius="22dp"
+                    app:cardElevation="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:padding="16dp">
+
+                        <ImageView
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:contentDescription="@string/config_override"
+                            android:src="@drawable/ic_baseline_bolt"
+                            app:tint="?attr/colorPrimary" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="14dp"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/config_override"
+                                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                                android:textColor="?attr/colorOnSurface"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="3dp"
+                                android:text="@string/config_override_summary"
+                                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
         </com.github.kr328.clash.design.view.ObservableScrollView>
 

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -97,6 +97,12 @@
     <string name="tunnels_entry_summary">Статические форварды по профилю: loopback listen → target через прокси или группу.</string>
     <string name="tunnels_experimental_title">Туннели (эксперимент)</string>
     <string name="tunnels_experimental_summary">Показывать редактор туннелей по профилю в настройках.</string>
+    <string name="expert_features_title">Экспертные функции</string>
+    <string name="expert_features_summary">Открыть сырой config override и другие ручки для опытных. Зависят от режима защиты (hardening).</string>
+    <string name="config_override">Config override</string>
+    <string name="config_override_summary">Сырой оверрайд конфига clash (порты, listeners, DNS, hosts, режим).</string>
+    <string name="override_cat_listeners">Listeners и порты</string>
+    <string name="override_cat_fallback_filter">DNS fallback-фильтр</string>
     <string name="tunnels_no_active_profile">Активируйте профиль, чтобы править его туннели.</string>
     <string name="tunnels_master_title">Управлять туннелями для этого профиля</string>
     <string name="tunnels_master_summary">Включено — туннели применяются и переживают обновление подписки. Выключение откатывает чисто.</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -470,6 +470,12 @@
     <string name="tunnels_entry_summary">按配置的静态转发：回环监听 → 经代理或组转发到目标。</string>
     <string name="tunnels_experimental_title">隧道（实验）</string>
     <string name="tunnels_experimental_summary">在设置中显示按配置的隧道编辑器。</string>
+    <string name="expert_features_title">专家功能</string>
+    <string name="expert_features_summary">解锁原始配置覆盖和其他高级选项。这些设置与安全加固模式相关。</string>
+    <string name="config_override">配置覆盖</string>
+    <string name="config_override_summary">原始 clash 配置覆盖（端口、监听、DNS、hosts、模式）。</string>
+    <string name="override_cat_listeners">监听与端口</string>
+    <string name="override_cat_fallback_filter">DNS 回退过滤</string>
     <string name="tunnels_no_active_profile">请先激活一个配置以编辑其隧道。</string>
     <string name="tunnels_master_title">为此配置管理隧道</string>
     <string name="tunnels_master_summary">开启后隧道生效并在订阅更新后保留；关闭将干净还原。</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -324,6 +324,12 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="tunnels_experimental_title">Tunnels (experimental)</string>
     <string name="tunnels_experimental_summary">Show the per-profile Tunnels editor in Settings.</string>
     <string name="tunnels_no_active_profile">Activate a profile to edit its tunnels.</string>
+    <string name="expert_features_title">Expert features</string>
+    <string name="expert_features_summary">Unlock raw config override and other power-user knobs. These interact with the security hardening mode.</string>
+    <string name="config_override">Config override</string>
+    <string name="config_override_summary">Raw clash config override (ports, listeners, DNS, hosts, mode).</string>
+    <string name="override_cat_listeners">Listeners &amp; ports</string>
+    <string name="override_cat_fallback_filter">DNS fallback filter</string>
     <string name="tunnels_master_title">Manage tunnels for this profile</string>
     <string name="tunnels_master_summary">When on, your tunnels apply and survive subscription updates. Turning off reverts cleanly.</string>
     <string name="tunnels_section_entries">Tunnel entries</string>


### PR DESCRIPTION
Remove dead/duplicate advanced options (Linux-only redirect/tproxy ports, dead geox-url block, geo-import dup covered by Geo Data Source).

Add an Expert features master toggle gating power-user knobs; resurrect the orphaned Config-override screen behind it and gate find-process-mode.

Modernize Config override (common-binding header, labeled sections, reset as bottom card); re-evaluate gates on resume so toggles reflect without re-entering Advanced.