### PR TITLE
fix(rules): classify sub rules by origin, exempt opaque types from validation, purge deleted manual rules

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -13,7 +13,9 @@ import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.remote.IFetchObserver
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.GeoUrlSanitizer
+import com.github.kr328.clash.service.util.MihomoConfigDocument
 import com.github.kr328.clash.service.util.RuleApplyService
+import com.github.kr328.clash.service.util.RuleMapper
 import com.github.kr328.clash.service.util.SubscriptionUpdateMerge
 import com.github.kr328.clash.service.util.FetchErrorClassifier
 import com.github.kr328.clash.service.util.MergeEngineVerdict
@@ -35,6 +37,16 @@ import okhttp3.Request
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
+
+/** `(type,value,policy)` keys of the `rules:` in a raw config text — for source reconcile. */
+private fun ruleKeysOf(configText: String): Set<String> = runCatching {
+    (MihomoConfigDocument.parseOrEmpty(configText).root["rules"] as? List<*>)
+        .orEmpty()
+        .mapNotNull { it as? String }
+        .mapIndexedNotNull { i, line -> RuleMapper.parseRuleLine(line, i) }
+        .map { "${it.type.uppercase()},${it.value.uppercase()},${it.policy.uppercase()}" }
+        .toSet()
+}.getOrDefault(emptySet())
 
 object ProfileProcessor {
     private val profileLock = Mutex()
@@ -281,8 +293,11 @@ object ProfileProcessor {
                 // if THIS merge breaks a config / drops an orphaned rule.
                 ServiceStore(context).setUpdateEngineWarning(snapshot.uuid, false)
                 ServiceStore(context).setOrphanedRulesDropped(snapshot.uuid, emptyList())
+                // Captured from the raw fetched config (pre-merge) for rule-source reconcile.
+                var fetchedSubRuleKeys: Set<String> = emptySet()
                 if (!preserved.isEmpty() && configFile.isFile) {
                     val fetchedText = configFile.readText()
+                    fetchedSubRuleKeys = ruleKeysOf(fetchedText)
                     val droppedOrphans = mutableListOf<String>()
                     val merged = SubscriptionUpdateMerge.mergeAfterFetch(
                         fetchedText,
@@ -340,7 +355,14 @@ object ProfileProcessor {
                 // RULE-SET / GEOSITE / MATCH entry was deleted in the new subscription.
                 val processingStateFile = File(context.processingDir, "rules_state.json")
                 if (configFile.isFile && processingStateFile.isFile) {
-                    RuleApplyService(context).reconcileWithStoredState(configFile, processingStateFile)
+                    // Rule keys from the freshly fetched subscription (pre-merge), so reconcile
+                    // classifies rules by ORIGIN (what's actually in the sub), not by rule type —
+                    // fixes plain DOMAIN/IP-CIDR sub rules mislabelled MANUAL + heals any already
+                    // stored wrong. If no merge happened, configFile IS the raw fetch.
+                    val subKeys = fetchedSubRuleKeys.ifEmpty { ruleKeysOf(configFile.readText()) }
+                    RuleApplyService(context).reconcileWithStoredState(
+                        configFile, processingStateFile, subKeys,
+                    )
                 }
 
                 GeoUrlSanitizer.sanitizeProfile(context.processingDir)

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleApplyService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleApplyService.kt
@@ -184,18 +184,25 @@ class RuleApplyService(
      * @return true if reconciliation rewrote the config; false on any failure (caller should
      *         leave whatever [SubscriptionUpdateMerge] produced alone in that case).
      */
-    fun reconcileWithStoredState(configFile: File, stateFile: File): Boolean {
+    fun reconcileWithStoredState(
+        configFile: File,
+        stateFile: File,
+        fetchedSubRuleKeys: Set<String> = emptySet(),
+    ): Boolean {
         if (!configFile.isFile) return false
         if (!stateFile.isFile) return false
         return runCatching {
             val configText = configFile.readText()
             val snapshot = Clash.parseProfileSnapshot(configFile.parentFile!!)
             val parsed = RuleMapper.parseStateFromSnapshot(snapshot)
+            val classifiedParsed = parsed.copy(
+                rules = reclassifyBySubscription(parsed.rules, fetchedSubRuleKeys),
+            )
             val stored = stateJsonForReconcile.decodeFromString(
                 RuleState.serializer(),
                 stateFile.readText(),
             )
-            val merged = syncStoredWithParsed(stored, parsed)
+            val merged = syncStoredWithParsed(stored, classifiedParsed)
             val normalized = merged.copy(rules = normalizeRuleOrder(merged.rules))
             val geoDataUrls = GeoDataSources.resolve(
                 preset = serviceStore.geoDataSourcePreset,
@@ -240,7 +247,12 @@ internal fun syncStoredWithParsed(stored: RuleState, incoming: RuleState): RuleS
     fun key(r: RuleItem) =
         "${r.type.uppercase()},${r.value.uppercase()},${r.policy.uppercase()}"
 
-    val byKey = stored.rules.associateBy(::key)
+    // A deleted MANUAL rule is gone for good (no upstream sub to restore from), so it must
+    // not survive a subscription refresh either. Drop these before matching/retention so they
+    // can't resurface or stamp deleted=true onto a later same-key re-add. Mirrors
+    // RuleRepository.syncProviderRules.
+    val storedRules = stored.rules.filterNot { it.deleted && it.source == RuleSource.MANUAL }
+    val byKey = storedRules.associateBy(::key)
     val mergedRules = incoming.rules.mapIndexed { index, rule ->
         val old = byKey[key(rule)]
         if (old != null) {
@@ -257,12 +269,29 @@ internal fun syncStoredWithParsed(stored: RuleState, incoming: RuleState): RuleS
     }.toMutableList()
 
     val incomingKeys = incoming.rules.map(::key).toSet()
-    val retained = stored.rules.filter { rule ->
+    val retained = storedRules.filter { rule ->
         key(rule) !in incomingKeys &&
             (rule.deleted || !rule.enabled || rule.source == RuleSource.MANUAL)
     }
     retained.forEach { mergedRules += it.copy(order = mergedRules.size) }
     return stored.copy(providers = incoming.providers, rules = mergedRules)
+}
+
+/**
+ * Reclassify rules by ORIGIN using the `(type,value,policy)` keys of the freshly fetched
+ * subscription: a rule whose key is in the fetch is PROVIDER (heals a wrongly-stored MANUAL
+ * back to subscription); one absent from the fetch is a genuine user MANUAL rule the merge
+ * preserved. Empty keys → leave as-is (caller had no fetch to compare). Pure → unit-testable.
+ */
+internal fun reclassifyBySubscription(
+    rules: List<RuleItem>,
+    fetchedSubRuleKeys: Set<String>,
+): List<RuleItem> {
+    if (fetchedSubRuleKeys.isEmpty()) return rules
+    return rules.map { r ->
+        val k = "${r.type.uppercase()},${r.value.uppercase()},${r.policy.uppercase()}"
+        r.copy(source = if (k in fetchedSubRuleKeys) RuleSource.PROVIDER else RuleSource.MANUAL)
+    }
 }
 
 /**

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
@@ -20,6 +20,15 @@ object RuleMapper {
     // the raw line as-is and never re-synthesise it from type/value/policy.
     private val OPAQUE_RULE_TYPES = setOf("AND", "OR", "NOT", "SUB-RULE", "SCRIPT")
 
+    /**
+     * Opaque/logical rule types carry their whole payload in [RuleItem.raw];
+     * their `value` and `policy` fields are legitimately empty (see
+     * [parseStateFromSnapshot]). Callers that validate value/policy must skip
+     * these (e.g. [RuleValidator]) — otherwise a single AND/OR/SUB-RULE rule
+     * from the subscription fails the whole save with "value is empty".
+     */
+    fun isOpaqueType(type: String): Boolean = type.trim().uppercase() in OPAQUE_RULE_TYPES
+
     // Rule types that only exist via subscription content - the UI does not
     // offer a form to add these manually. When we read them out of config.yaml
     // they are by definition PROVIDER-sourced. Marking them MANUAL caused
@@ -46,21 +55,14 @@ object RuleMapper {
             providerFromJson(name, body, source = RuleSource.PROVIDER)
         }
         val rules = snapshot.rules.mapIndexedNotNull { index, raw ->
-            parseRuleLine(raw, index)?.let { item ->
-                // Subscription-owned types (RULE-SET, GEOSITE, GEOIP, MATCH,
-                // SUB-RULE, AND, OR, NOT) cannot be entered through the UI
-                // add form, so when we see them in config.yaml they came
-                // from the subscription. Override the default MANUAL source
-                // so syncProviderRules drops them cleanly on a refresh that
-                // no longer contains them. User-typed types (DOMAIN, IP-CIDR,
-                // DOMAIN-SUFFIX, ...) keep the helper's MANUAL default - that
-                // is what lets manual entries survive subscription updates.
-                if (item.type.uppercase() in SUBSCRIPTION_OWNED_RULE_TYPES) {
-                    item.copy(source = RuleSource.PROVIDER)
-                } else {
-                    item
-                }
-            }
+            // Rules read out of config.yaml are PROVIDER-sourced by DEFAULT: they came
+            // from the (effective) subscription config, regardless of rule TYPE. The old
+            // heuristic assumed plain types (DOMAIN, IP-CIDR, ...) were user-MANUAL — but
+            // subscriptions routinely author plain DOMAIN/IP-CIDR rules, so that mislabelled
+            // subscription rules as MANUAL. Genuine MANUAL rules are only ever set by the
+            // editor (Add rule) and preserved via the stored state + the raw-fetch reconcile
+            // (reconcileWithStoredState reclassifies by what's actually in the fetched sub).
+            parseRuleLine(raw, index, defaultSource = RuleSource.PROVIDER)
         }
         return RuleState(providers = providers, rules = rules)
     }

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleRepository.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleRepository.kt
@@ -59,7 +59,15 @@ class RuleRepository(private val context: Context) {
     }
 
     private fun syncProviderRules(stored: RuleState, incoming: RuleState): RuleState {
-        val byKey = stored.rules.associateBy {
+        // A deleted MANUAL rule is gone for good: it has no upstream subscription to
+        // restore from (unlike a deleted PROVIDER rule, whose soft-delete guards against
+        // a sub refresh resurrecting it). Drop such entries up front so they neither
+        // resurface on the post-apply reload (the "delete does nothing" bug) nor poison a
+        // later same-key re-add by copying their stale deleted=true flag onto it.
+        val storedRules = stored.rules.filterNot {
+            it.deleted && it.source == RuleSource.MANUAL
+        }
+        val byKey = storedRules.associateBy {
             "${it.type.uppercase()},${it.value.uppercase()},${it.policy.uppercase()}"
         }
         val mergedRules = incoming.rules.mapIndexed { index, rule ->
@@ -68,6 +76,11 @@ class RuleRepository(private val context: Context) {
             if (old != null) {
                 rule.copy(
                     id = old.id,
+                    // Trust the STORED source (it's authoritative for MANUAL vs PROVIDER
+                    // after the last reconcile). The snapshot now defaults everything to
+                    // PROVIDER, so without this a genuine MANUAL rule present in config
+                    // would silently flip to PROVIDER on a plain editor open.
+                    source = old.source,
                     enabled = old.enabled,
                     deleted = old.deleted,
                     isRestorable = old.isRestorable || rule.isRestorable,
@@ -85,7 +98,7 @@ class RuleRepository(private val context: Context) {
         val incomingKeys = incoming.rules.map {
             "${it.type.uppercase()},${it.value.uppercase()},${it.policy.uppercase()}"
         }.toSet()
-        val retained = stored.rules.filter { rule ->
+        val retained = storedRules.filter { rule ->
             val k = "${rule.type.uppercase()},${rule.value.uppercase()},${rule.policy.uppercase()}"
             k !in incomingKeys &&
                 (

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleValidator.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleValidator.kt
@@ -22,6 +22,14 @@ object RuleValidator {
 
         state.rules.filter { it.enabled && !it.deleted }.forEach {
             require(it.type.isNotBlank()) { "Rule type is empty" }
+            // Opaque/logical types (AND/OR/NOT/SUB-RULE/SCRIPT) carry their whole
+            // payload in `raw`; value AND policy are legitimately empty for them.
+            // Validating those fields would reject a perfectly valid subscription
+            // rule and fail the entire save. Only their raw line must be present.
+            if (RuleMapper.isOpaqueType(it.type)) {
+                require(it.raw.isNotBlank()) { "Rule line is empty for type ${it.type}" }
+                return@forEach
+            }
             if (!it.type.equals("MATCH", true)) {
                 require(it.value.isNotBlank()) { "Rule value is empty for type ${it.type}" }
             }

--- a/service/src/test/java/com/github/kr328/clash/service/util/RuleMapperTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/RuleMapperTest.kt
@@ -111,10 +111,12 @@ class RuleMapperTest {
     }
 
     @Test
-    fun parseStateFromSnapshot_keepsManualTypesAsManual() {
-        // User-addable types stay MANUAL when read from config.yaml so
-        // subscription refresh does not wipe DOMAIN/IP-CIDR entries the
-        // user added through the UI.
+    fun parseStateFromSnapshot_classifiesConfigRulesAsProvider() {
+        // Rules read from config.yaml are PROVIDER by default — they came from the
+        // (effective) subscription, regardless of rule TYPE. Subscriptions routinely
+        // author plain DOMAIN/IP-CIDR rules, so the old "plain type => MANUAL" heuristic
+        // mislabelled them. MANUAL is set only by the editor + healed via the raw-fetch
+        // reconcile (see reconcileWithStoredState).
         val snapshot = snapshotWith(
             "DOMAIN,example.com,DIRECT",
             "DOMAIN-SUFFIX,corp.local,DIRECT",
@@ -126,8 +128,8 @@ class RuleMapperTest {
 
         state.rules.forEach { rule ->
             assertEquals(
-                "rule type=${rule.type} must keep MANUAL classification",
-                RuleSource.MANUAL,
+                "rule type=${rule.type} read from config must be PROVIDER, not MANUAL",
+                RuleSource.PROVIDER,
                 rule.source,
             )
         }

--- a/service/src/test/java/com/github/kr328/clash/service/util/RuleReconcileTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/RuleReconcileTest.kt
@@ -53,6 +53,49 @@ class RuleReconcileTest {
     }
 
     @Test
+    fun deletedManualRule_isPurged_notResurrected() {
+        // The user deleted their own MANUAL rule. It must NOT come back on the next
+        // load/refresh (the "delete does nothing" bug) — a manual rule has no upstream
+        // to restore from, unlike a deleted PROVIDER rule.
+        val stored = RuleState(rules = listOf(
+            RuleItem(id = "m", type = "DOMAIN", value = "gone.com", policy = "DIRECT",
+                source = RuleSource.MANUAL, deleted = true, enabled = false),
+        ))
+        val incoming = RuleState(rules = listOf(provider("RULE-SET", "ads", "REJECT", id = "f")))
+        val merged = syncStoredWithParsed(stored, incoming)
+        assertFalse(merged.rules.any { it.value == "gone.com" }, "deleted manual rule must be purged")
+    }
+
+    @Test
+    fun deletedProviderRule_isStillRetained() {
+        // Contrast: a deleted PROVIDER rule stays (soft-delete guards a sub refresh
+        // from resurrecting it + supports restore).
+        val stored = RuleState(rules = listOf(
+            provider("DOMAIN", "ad.com", "REJECT", id = "p", deleted = true, enabled = false),
+        ))
+        val incoming = RuleState(rules = listOf(provider("RULE-SET", "ads", "REJECT", id = "f")))
+        val merged = syncStoredWithParsed(stored, incoming)
+        assertTrue(merged.rules.any { it.value == "ad.com" && it.deleted }, "deleted provider rule retained")
+    }
+
+    @Test
+    fun reAddingDeletedManualKey_comesBackEnabled_notStuckDeleted() {
+        // After deleting DOMAIN,x,DIRECT the user re-adds the same rule. The stale
+        // deleted=true entry must not stamp itself onto the fresh re-add.
+        val stored = RuleState(rules = listOf(
+            RuleItem(id = "old", type = "DOMAIN", value = "x.com", policy = "DIRECT",
+                source = RuleSource.MANUAL, deleted = true, enabled = false),
+        ))
+        // re-added rule is present in the (merged) config => parsed PROVIDER, reclassified MANUAL
+        val incoming = RuleState(rules = listOf(
+            RuleItem(id = "new", type = "DOMAIN", value = "x.com", policy = "DIRECT", source = RuleSource.MANUAL),
+        ))
+        val merged = syncStoredWithParsed(stored, incoming)
+        val x = merged.rules.single { it.value == "x.com" }
+        assertTrue(x.enabled && !x.deleted, "re-added rule must be live, not inherit the old delete")
+    }
+
+    @Test
     fun freshProviderRule_defaultsEnabled() {
         val merged = syncStoredWithParsed(
             RuleState(),
@@ -84,5 +127,83 @@ class RuleReconcileTest {
             RuleItem(id = "rs", type = "RULE-SET", value = "ads", policy = "DIRECT", order = 2),
         )
         assertEquals(listOf("x", "r", "rs"), normalizeRuleOrder(rules).map { it.id })
+    }
+
+    @Test
+    fun reclassifyBySubscription_healsManualBackToSub_keepsGenuineManual() {
+        val rules = listOf(
+            // plain rule that IS in the fetched subscription (was wrongly stored MANUAL)
+            RuleItem(id = "a", type = "DOMAIN", value = "sub.com", policy = "DIRECT", source = RuleSource.MANUAL),
+            // genuine user rule, NOT present in the fetched subscription
+            RuleItem(id = "b", type = "DOMAIN", value = "mine.com", policy = "DIRECT", source = RuleSource.MANUAL),
+            // a subscription rule already classified PROVIDER
+            RuleItem(id = "c", type = "DOMAIN", value = "other.com", policy = "Proxy", source = RuleSource.PROVIDER),
+        )
+        val fetchedKeys = setOf("DOMAIN,SUB.COM,DIRECT", "DOMAIN,OTHER.COM,PROXY")
+
+        val out = reclassifyBySubscription(rules, fetchedKeys).associateBy { it.id }
+
+        assertEquals(RuleSource.PROVIDER, out.getValue("a").source) // healed: in sub -> PROVIDER
+        assertEquals(RuleSource.MANUAL, out.getValue("b").source)   // genuine manual stays MANUAL
+        assertEquals(RuleSource.PROVIDER, out.getValue("c").source) // provider unchanged
+    }
+
+    @Test
+    fun reclassifyBySubscription_emptyKeys_leavesUnchanged() {
+        val rules = listOf(
+            RuleItem(id = "m", type = "DOMAIN", value = "x", policy = "DIRECT", source = RuleSource.MANUAL),
+        )
+        assertEquals(RuleSource.MANUAL, reclassifyBySubscription(rules, emptySet()).single().source)
+    }
+
+    // --- full reconcile pipeline (regression: manual rule erased after sub update) ---
+    // Mirrors ProfileProcessor.update end-to-end on the PURE layer (everything except the
+    // native snapshot parse): merged config (post mergeAfterFetch) -> parsed-all-PROVIDER
+    // -> reclassify by raw-fetch keys -> syncStoredWithParsed -> mergeStateIntoConfig.
+    private val geoUrls = GeoDataUrls(geoIp = "", geoSite = "", mmdb = "", asn = "")
+
+    @Test
+    fun fullReconcile_manualRuleSurvivesSubscriptionUpdate() {
+        // The merged config (mergeAfterFetch output) the engine snapshot would read:
+        // the prefixed manual rule + the fresh subscription rules.
+        val mergedConfig = """
+            rules:
+              - DOMAIN,mine.com,DIRECT
+              - DOMAIN,sub.com,Proxy
+              - RULE-SET,ads,REJECT
+              - MATCH,Proxy
+        """.trimIndent()
+        // What parseStateFromSnapshot returns for that config: EVERY rule PROVIDER by default.
+        val parsed = RuleState(
+            rules = listOf(
+                provider("DOMAIN", "mine.com", "DIRECT", id = "p0"),
+                provider("DOMAIN", "sub.com", "Proxy", id = "p1"),
+                provider("RULE-SET", "ads", "REJECT", id = "p2"),
+                RuleItem(id = "p3", raw = "MATCH,Proxy", type = "MATCH", value = "", policy = "Proxy", source = RuleSource.PROVIDER),
+            ),
+        )
+        // Raw fetched subscription rule keys (mine.com is NOT in the sub — it's the user's).
+        val subKeys = setOf("DOMAIN,SUB.COM,PROXY", "RULE-SET,ADS,REJECT", "MATCH,,PROXY")
+        // rules_state.json carried over from before the update: the user's manual rule MANUAL.
+        val stored = RuleState(
+            rules = listOf(
+                RuleItem(id = "m", type = "DOMAIN", value = "mine.com", policy = "DIRECT", source = RuleSource.MANUAL),
+                provider("DOMAIN", "sub.com", "Proxy", id = "s1"),
+                provider("RULE-SET", "ads", "REJECT", id = "s2"),
+            ),
+        )
+
+        val classified = parsed.copy(rules = reclassifyBySubscription(parsed.rules, subKeys))
+        val merged = syncStoredWithParsed(stored, classified)
+        val normalized = merged.copy(rules = normalizeRuleOrder(merged.rules))
+
+        // 1. the manual rule kept its MANUAL source through reconcile
+        val mine = normalized.rules.single { it.value == "mine.com" }
+        assertEquals(RuleSource.MANUAL, mine.source)
+        assertTrue(mine.enabled && !mine.deleted, "manual rule stays active")
+
+        // 2. and it actually lands in the emitted config.yaml
+        val outYaml = RuleMapper.mergeStateIntoConfig(mergedConfig, normalized, geoUrls)
+        assertTrue(outYaml.contains("DOMAIN,mine.com,DIRECT"), "manual rule must survive into config:\n$outYaml")
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/RuleValidatorTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/RuleValidatorTest.kt
@@ -1,0 +1,44 @@
+package com.github.kr328.clash.service.util
+
+import com.github.kr328.clash.service.model.RuleItem
+import com.github.kr328.clash.service.model.RuleState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class RuleValidatorTest {
+    private fun rule(type: String, value: String, policy: String, raw: String = "", id: String = type) =
+        RuleItem(id = id, raw = raw, type = type, value = value, policy = policy)
+
+    @Test
+    fun opaqueRules_withEmptyValueAndPolicy_pass() {
+        // Regression: a single AND/OR/NOT/SUB-RULE rule from the subscription
+        // (value + policy empty, payload in `raw`) used to fail the WHOLE save
+        // with "Rule value is empty for type AND" — blocking the user from
+        // adding an unrelated DOMAIN-SUFFIX rule.
+        val state = RuleState(
+            rules = listOf(
+                rule("AND", "", "", raw = "AND,((NETWORK,UDP),(DST-PORT,53)),DIRECT"),
+                rule("OR", "", "", raw = "OR,((GEOIP,CN),(DOMAIN-SUFFIX,cn)),DIRECT"),
+                rule("SUB-RULE", "", "", raw = "SUB-RULE,((DOMAIN,foo.com)),GLOBAL"),
+                rule("DOMAIN-SUFFIX", "google.com", "DIRECT", raw = "DOMAIN-SUFFIX,google.com,DIRECT"),
+            ),
+        )
+        // must not throw
+        RuleValidator.validate(state)
+    }
+
+    @Test
+    fun opaqueRule_withBlankRaw_isRejected() {
+        val state = RuleState(rules = listOf(rule("AND", "", "", raw = "")))
+        val e = assertFailsWith<IllegalArgumentException> { RuleValidator.validate(state) }
+        assertEquals("Rule line is empty for type AND", e.message)
+    }
+
+    @Test
+    fun regularRule_withEmptyValue_stillRejected() {
+        val state = RuleState(rules = listOf(rule("DOMAIN", "", "DIRECT", raw = "DOMAIN,,DIRECT")))
+        val e = assertFailsWith<IllegalArgumentException> { RuleValidator.validate(state) }
+        assertEquals("Rule value is empty for type DOMAIN", e.message)
+    }
+}


### PR DESCRIPTION
Three rule-editor bugs: (1) plain DOMAIN/IP-CIDR sub rules mislabelled MANUAL by type heuristic - now PROVIDER by default + reconcile reclassifies by raw fetched sub. (2) RuleValidator demanded value/policy on opaque types (AND/OR/NOT/SUB-RULE/SCRIPT) that carry their payload in raw - one sub AND-rule failed every save. (3) deleting a MANUAL rule was soft-deleted then resurrected by the load/refresh retention - now purged for good (provider deletes still retained).