### PR TITLE
fix(merge): keep rule-providers referenced only by DNS config

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/SubscriptionUpdateMerge.kt
@@ -202,7 +202,7 @@ object SubscriptionUpdateMerge {
     private fun gcUnusedRuleProviders(root: MutableMap<String, Any?>) {
         val providers = root["rule-providers"] as? Map<*, *> ?: return
         if (providers.isEmpty()) return
-        val referenced = collectRuleSetTargets(root["rules"])
+        val referenced = collectAllRuleSetRefs(root)
         val kept = LinkedHashMap<String, Any?>()
         for ((k, v) in providers) {
             val name = k?.toString() ?: continue
@@ -243,6 +243,9 @@ object SubscriptionUpdateMerge {
      */
     private val ruleSetRef = Regex("RULE-SET\\s*,\\s*([^,()]+)", RegexOption.IGNORE_CASE)
 
+    /** Prefix on `dns.nameserver-policy` keys / `dns.fake-ip-filter` entries that name a rule-set. */
+    private val RULE_SET_PREFIX = "rule-set:"
+
     private fun collectRuleSetTargets(rulesNode: Any?): Set<String> {
         val list = rulesNode as? List<*> ?: return emptySet()
         val out = HashSet<String>()
@@ -257,6 +260,37 @@ object SubscriptionUpdateMerge {
             }
         }
         return out
+    }
+
+    /**
+     * Every rule-provider a config references — NOT just `rules:`. A provider can be used by:
+     *  - `rules:` and `sub-rules:` (via `RULE-SET,<name>`),
+     *  - `dns.nameserver-policy` keys (`rule-set:a,b,c:` — comma-separated, `rule-set:` prefix),
+     *  - `dns.fake-ip-filter` entries (`rule-set:<name>`).
+     * Missing the DNS sources GC'd a provider used only by DNS (e.g. `ip-check` referenced solely
+     * in nameserver-policy), which then failed the next update with `not found rule-set: <name>`.
+     */
+    private fun collectAllRuleSetRefs(root: Map<String, Any?>): Set<String> {
+        val out = HashSet<String>()
+        out += collectRuleSetTargets(root["rules"])
+        // sub-rules: map of <name> -> list of rule lines.
+        (root["sub-rules"] as? Map<*, *>)?.values?.forEach { out += collectRuleSetTargets(it) }
+
+        val dns = root["dns"] as? Map<*, *>
+        if (dns != null) {
+            (dns["nameserver-policy"] as? Map<*, *>)?.keys?.forEach { addRuleSetPrefixed(it?.toString(), out) }
+            (dns["fake-ip-filter"] as? List<*>)?.forEach { addRuleSetPrefixed(it?.toString(), out) }
+        }
+        return out
+    }
+
+    /** Parse a `rule-set:a,b,c` token (DNS sections) into provider names. No-op otherwise. */
+    private fun addRuleSetPrefixed(value: String?, out: MutableSet<String>) {
+        val v = value?.trim() ?: return
+        if (!v.startsWith(RULE_SET_PREFIX, ignoreCase = true)) return
+        v.substring(RULE_SET_PREFIX.length).split(',').forEach { name ->
+            name.trim().takeIf { it.isNotEmpty() }?.let { out.add(it) }
+        }
     }
 
     private fun collectProxyProviderUsage(groupsNode: Any?): Pair<Set<String>, Boolean> {

--- a/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/SubscriptionUpdateMergeTest.kt
@@ -221,6 +221,46 @@ class SubscriptionUpdateMergeTest {
     }
 
     @Test
+    fun gc_keepsRuleProvidersReferencedOnlyInDns() {
+        // A rule-provider can be used by DNS config, not only `rules:` — `dns.nameserver-policy`
+        // keys (`rule-set:a,b,c:`) and `dns.fake-ip-filter` entries (`rule-set:x`). Real-world
+        // break: `ip-check` was referenced solely in nameserver-policy (its `rules:` line was
+        // commented out), so the GC dropped it and the next update failed with
+        // `not found rule-set: ip-check`.
+        val fetched = """
+            proxies:
+              - {name: p1, type: socks5, server: 127.0.0.1, port: 1080}
+            rule-providers:
+              ip-check:    {type: http, behavior: domain, format: mrs, url: https://e/x.mrs, path: ./ip.mrs}
+              geo-private: {type: http, behavior: domain, format: mrs, url: https://e/x.mrs, path: ./gp.mrs}
+              ru-inline:   {type: http, behavior: classical, url: https://e/x.yaml, path: ./ru.yaml}
+              setUnused:   {type: http, behavior: domain, format: mrs, url: https://e/x.mrs, path: ./z.mrs}
+            dns:
+              enhanced-mode: fake-ip
+              fake-ip-filter:
+                - rule-set:geo-private
+                - "*.lan"
+              nameserver-policy:
+                rule-set:ru-inline,ip-check:
+                  - https://8.8.8.8/dns-query
+                raw.githubusercontent.com:
+                  - https://1.1.1.1/dns-query
+            rules:
+              - MATCH,p1
+        """.trimIndent() + "\n"
+
+        val preserved = SubscriptionUpdateMerge.extractPreserved(
+            snapshot(rules = listOf("DOMAIN,kept.local,DIRECT")),
+        )
+        val merged = SubscriptionUpdateMerge.mergeAfterFetch(fetched, preserved)
+
+        for (name in listOf("ip-check", "geo-private", "ru-inline")) {
+            assertTrue("$name (referenced only in DNS) must survive GC", merged.contains(name))
+        }
+        assertFalse("setUnused (unreferenced) should be dropped", merged.contains("setUnused"))
+    }
+
+    @Test
     fun gc_keepsRuleProviderWhoseNameContainsSpaces() {
         // Regression: rule-provider names may contain spaces (valid in mihomo).
         // The reference regex stopped at the first whitespace, so `RULE-SET,Ad Block`


### PR DESCRIPTION
gcUnusedRuleProviders collected RULE-SET refs only from rules:, so a provider used solely in dns.nameserver-policy (rule-set:a,b,c) or dns.fake-ip-filter (rule-set:x) was GC'd, then the next subscription update failed with 'not found rule-set: <name>' (real case: ip-check referenced only in nameserver-policy, its rules line commented). collectAllRuleSetRefs now also scans sub-rules and the DNS sections. Adds an engine-fidelity test (gc_keepsRuleProvidersReferencedOnlyInDns).