### PR TITLE
feat(config): hard engine gate — never apply a config the engine rejects

### DIFF
--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -56,7 +56,7 @@
     <string name="home_import_file_row">Из файла</string>
     <string name="home_import_file_sub">Выберите локальный конфиг (.yaml) и импортируйте как профиль.</string>
     <string name="profiles_update_all_failed">Не удалось обновить подписок: %1$d.</string>
-    <string name="profiles_update_engine_warning">Обновление сохранено, но движок забраковал собранный конфиг. Проверь профиль.</string>
+    <string name="profiles_update_engine_warning">Подписка обновлена, но твои локальные правки не подошли к новому конфигу и в этот раз не применились. Проверь их.</string>
     <string name="profiles_orphaned_rules_dropped">Отключено правил: %1$d — их прокси/группы больше нет в новой подписке.</string>
 
     <!-- DNS & Hosts -->

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -429,7 +429,7 @@
     <string name="home_import_file_row">从文件</string>
     <string name="home_import_file_sub">选择本地配置文件 (.yaml) 并作为配置导入。</string>
     <string name="profiles_update_all_failed">%1$d 个订阅更新失败。</string>
-    <string name="profiles_update_engine_warning">更新已保存，但内核判定合并后的配置无效，请检查该配置。</string>
+    <string name="profiles_update_engine_warning">订阅已更新，但你的本地修改不适配新配置，本次未应用。请检查。</string>
     <string name="profiles_orphaned_rules_dropped">已禁用 %1$d 条规则：其代理/策略组在新订阅中已不存在。</string>
 
     <!-- DNS & Hosts -->

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -248,7 +248,7 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="home_import_file_row">From file</string>
     <string name="home_import_file_sub">Pick a local config file (.yaml) and import it as a profile.</string>
     <string name="profiles_update_all_failed">Couldn\'t update %1$d subscription(s).</string>
-    <string name="profiles_update_engine_warning">Update saved, but the engine flagged the merged config. Check the profile.</string>
+    <string name="profiles_update_engine_warning">Subscription updated, but your local edits didn't fit the new config and weren't applied this time. Review them.</string>
     <string name="profiles_orphaned_rules_dropped">Disabled %1$d rule(s): their proxy/group no longer exists in the new subscription.</string>
 
     <!-- Rule editor: friendly type catalog (RuleTypeCatalog) -->

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -319,16 +319,21 @@ object ProfileProcessor {
                     } else {
                         MergeEngineVerdict.classify(Clash.validateProfileBytes(fetchedText), mergedError)
                     }
+                    // Runtime engine gate (§config-engine-gate): NEVER apply a config the engine
+                    // rejects. When our overlay broke an otherwise-valid subscription, fall back to
+                    // the clean fetched subscription so the update still works, and surface that the
+                    // local edits could not be applied. PreexistingBroken also uses the fetched body
+                    // as-is (the breakage is the subscription's own, not our merge's).
                     when (verdict) {
                         MergeEngineVerdict.MergeIntroduced -> {
-                            Log.w("Merge BROKE an otherwise-valid subscription for ${snapshot.uuid}: $mergedError")
+                            Log.w("Overlay broke a valid subscription for ${snapshot.uuid}; applying clean fetched instead. $mergedError")
                             ServiceStore(context).setUpdateEngineWarning(snapshot.uuid, true)
                         }
                         MergeEngineVerdict.PreexistingBroken ->
-                            Log.w("Merged config invalid for ${snapshot.uuid}, but fetched was already invalid (continuing): $mergedError")
+                            Log.w("Merged invalid for ${snapshot.uuid}, but fetched was already invalid (using fetched): $mergedError")
                         MergeEngineVerdict.Ok -> Unit
                     }
-                    configFile.writeText(merged)
+                    configFile.writeText(if (verdict.appliesMergedConfig()) merged else fetchedText)
                     Log.d("Subscription merge preserved local overlays: rules/rule-providers/proxy-providers reapplied for ${snapshot.uuid}")
 
                     // Subscription providers are already on disk from the fetch above;

--- a/service/src/main/java/com/github/kr328/clash/service/util/MergeEngineVerdict.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/MergeEngineVerdict.kt
@@ -16,6 +16,15 @@ enum class MergeEngineVerdict {
     /** Fetched config was already invalid; the merge is not at fault. */
     PreexistingBroken;
 
+    /**
+     * The runtime engine gate (§config-engine-gate): whether the merged/composed config may be
+     * handed to the engine. We NEVER apply a config the engine rejects — when our overlay broke an
+     * otherwise-valid subscription ([MergeIntroduced]) the caller falls back to the clean fetched
+     * subscription so the update still succeeds. [PreexistingBroken] is likewise not applied as
+     * "merged" (the fetched body is used as-is; the breakage is the subscription's own).
+     */
+    fun appliesMergedConfig(): Boolean = this == Ok
+
     companion object {
         /**
          * @param fetchedError engine error for the freshly fetched config, or null if valid

--- a/service/src/test/java/com/github/kr328/clash/service/util/MergeEngineVerdictTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/MergeEngineVerdictTest.kt
@@ -16,4 +16,19 @@ class MergeEngineVerdictTest {
     @Test fun preexisting_when_both_bad() {
         assertEquals(MergeEngineVerdict.PreexistingBroken, MergeEngineVerdict.classify("already bad", "boom"))
     }
+
+    // The runtime engine gate: only an engine-valid merge may be applied; a merge that broke an
+    // otherwise-valid subscription must NOT be applied (caller falls back to clean fetched).
+    @Test fun gate_applies_merged_only_when_ok() {
+        assertEquals(true, MergeEngineVerdict.Ok.appliesMergedConfig())
+        assertEquals(false, MergeEngineVerdict.MergeIntroduced.appliesMergedConfig())
+        assertEquals(false, MergeEngineVerdict.PreexistingBroken.appliesMergedConfig())
+    }
+
+    @Test fun gate_broken_merge_of_valid_subscription_is_not_applied() {
+        // Real shape of the bug class: fetched valid, our overlay produced an invalid config.
+        val verdict = MergeEngineVerdict.classify(fetchedError = null, mergedError = "not found rule-set: ip-check")
+        assertEquals(MergeEngineVerdict.MergeIntroduced, verdict)
+        assertEquals(false, verdict.appliesMergedConfig()) // → caller applies clean fetched
+    }
 }


### PR DESCRIPTION
Before applying a merged subscription config, validate it with the real mihomo engine (Clash.validateProfileBytes). If our overlay broke an otherwise-valid subscription (MergeEngineVerdict.MergeIntroduced) apply the clean fetched subscription instead of the broken merged config, so the update still works, and surface that local edits couldn't be applied. Upgrades MergeEngineVerdict from advisory toast to a blocking decision (appliesMergedConfig). First/safety-floor step of config-overlay-architecture.