### PR TITLE
fix(notification): no launcher badge on the persistent VPN notification

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/StaticNotificationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/StaticNotificationModule.kt
@@ -59,14 +59,25 @@ class StaticNotificationModule(service: Service) : Module<Unit>(service) {
     }
 
     companion object {
-        const val CHANNEL_ID = "clash_status_channel"
+        // Bumped from the original "clash_status_channel": a channel's showBadge can't be changed
+        // after creation (Android ignores in-place updates), so the no-badge fix only reaches
+        // existing installs by recreating the channel under a new id (+ deleting the old one).
+        const val CHANNEL_ID = "clash_status_channel_v2"
+        private const val LEGACY_CHANNEL_ID = "clash_status_channel"
 
         fun createNotificationChannel(service: Service) {
-            NotificationManagerCompat.from(service).createNotificationChannel(
+            val manager = NotificationManagerCompat.from(service)
+            manager.deleteNotificationChannel(LEGACY_CHANNEL_ID)
+            manager.createNotificationChannel(
                 NotificationChannelCompat.Builder(
                     CHANNEL_ID,
                     NotificationManagerCompat.IMPORTANCE_LOW
-                ).setName(service.getText(R.string.clash_service_status_channel)).build()
+                )
+                    .setName(service.getText(R.string.clash_service_status_channel))
+                    // The persistent VPN-foreground notification must not put a "1" badge on the
+                    // launcher icon — users read it as an unread alert and can't swipe it away.
+                    .setShowBadge(false)
+                    .build()
             )
         }
 


### PR DESCRIPTION
The ongoing VPN-foreground notification put a '1' badge on the launcher icon that users read as an unread alert and couldn't swipe away. setShowBadge(false) on the status channel. Channel settings can't change in place after creation, so the channel id is bumped (clash_status_channel -> _v2) and the legacy channel deleted — the fix reaches existing installs too.