### PR TITLE
feat(dns): 'Block IPv6 (AAAA)' toggle in DNS & Hosts settings (#116)

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/DnsHostsSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/DnsHostsSettingsDesign.kt
@@ -38,6 +38,7 @@ class DnsHostsSettingsDesign(context: Context) : Design<DnsHostsSettingsDesign.R
     private val content: View = rootView.findViewById(R.id.content)
     private val masterToggle: MaterialSwitch = rootView.findViewById(R.id.master_toggle)
     private val dnsEnable: MaterialSwitch = rootView.findViewById(R.id.dns_enable)
+    private val blockIpv6: MaterialSwitch = rootView.findViewById(R.id.block_ipv6)
     private val modeGroup: MaterialButtonToggleGroup = rootView.findViewById(R.id.mode_group)
     private val cacheGroup: MaterialButtonToggleGroup = rootView.findViewById(R.id.cache_group)
     private val listenInput: TextInputEditText = rootView.findViewById(R.id.listen_input)
@@ -84,6 +85,7 @@ class DnsHostsSettingsDesign(context: Context) : Design<DnsHostsSettingsDesign.R
 
         masterToggle.isChecked = managed
         dnsEnable.isChecked = config.enable == true
+        blockIpv6.isChecked = config.ipv6 == false
         checkMode(config.enhancedMode)
         checkCache(config.cacheAlgorithm)
         listenInput.setText(config.listen.orEmpty())
@@ -99,6 +101,7 @@ class DnsHostsSettingsDesign(context: Context) : Design<DnsHostsSettingsDesign.R
     /** Reads the form into a model. */
     fun readModel(): DnsHostsConfig = DnsHostsConfig(
         enable = if (dnsEnable.isChecked) true else null,
+        ipv6 = if (blockIpv6.isChecked) false else null,
         enhancedMode = modeValue(),
         listen = listenInput.text?.toString()?.trim()?.takeIf { it.isNotEmpty() },
         cacheAlgorithm = cacheValue(),

--- a/design/src/main/res/layout/design_dns_hosts_settings.xml
+++ b/design/src/main/res/layout/design_dns_hosts_settings.xml
@@ -113,6 +113,21 @@
                     android:layout_marginTop="10dp"
                     android:text="@string/dns_hosts_enable_dns" />
 
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/block_ipv6"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/dns_hosts_block_ipv6" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/dns_hosts_block_ipv6_summary"
+                    android:textAppearance="@style/TextAppearance.App.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -295,6 +295,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="dns_hosts_master_summary">When on, your settings apply and survive subscription updates. Turning off reverts cleanly.</string>
     <string name="dns_hosts_section_dns">DNS</string>
     <string name="dns_hosts_enable_dns">Enable DNS</string>
+    <string name="dns_hosts_block_ipv6">Block IPv6 (AAAA)</string>
+    <string name="dns_hosts_block_ipv6_summary">Return no IPv6 addresses (drops AAAA DNS answers). Fixes stalls and slow loads on broken or high-latency IPv6.</string>
     <string name="dns_hosts_mode">Resolution mode</string>
     <string name="dns_hosts_mode_off">Off</string>
     <string name="dns_hosts_mode_redir">Redir-host</string>

--- a/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsConfig.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/DnsHostsConfig.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.jsonPrimitive
 @Serializable
 data class DnsHostsConfig(
     var enable: Boolean? = null,
+    var ipv6: Boolean? = null,
     var enhancedMode: String? = null,
     var listen: String? = null,
     var cacheAlgorithm: String? = null,
@@ -34,6 +35,7 @@ data class DnsHostsConfig(
     fun toDnsBlock(): Map<String, Any?>? {
         val m = LinkedHashMap<String, Any?>()
         enable?.let { m["enable"] = it }
+        ipv6?.let { m["ipv6"] = it }
         enhancedMode?.takeIf { it.isNotBlank() }?.let { m["enhanced-mode"] = it }
         listen?.takeIf { it.isNotBlank() }?.let { m["listen"] = it }
         cacheAlgorithm?.takeIf { it.isNotBlank() }?.let { m["cache-algorithm"] = it }
@@ -61,7 +63,7 @@ data class DnsHostsConfig(
     /**
      * Overlays the managed DNS fields onto an EXISTING `dns:` map, preserving
      * any keys this editor doesn't model (respect-rules, nameserver-policy,
-     * fake-ip-filter, ipv6, prefer-h3, use-hosts, …). A managed field that is
+     * fake-ip-filter, prefer-h3, use-hosts, …). A managed field that is
      * empty/cleared is removed from the map (so the user can drop it) without
      * touching unknown keys. This prevents Save from wiping the rest of a rich
      * provider `dns:` block.
@@ -71,6 +73,7 @@ data class DnsHostsConfig(
             if (value != null) existing[key] = value else existing.remove(key)
         }
         set("enable", enable)
+        set("ipv6", ipv6)
         set("enhanced-mode", enhancedMode?.takeIf { it.isNotBlank() })
         set("listen", listen?.takeIf { it.isNotBlank() })
         set("cache-algorithm", cacheAlgorithm?.takeIf { it.isNotBlank() })
@@ -95,6 +98,7 @@ data class DnsHostsConfig(
             val c = DnsHostsConfig()
             if (dns != null) {
                 c.enable = dns["enable"]?.jsonPrimitive?.booleanOrNull
+                c.ipv6 = dns["ipv6"]?.jsonPrimitive?.booleanOrNull
                 c.enhancedMode = dns.str("enhanced-mode")
                 c.listen = dns.str("listen")
                 c.cacheAlgorithm = dns.str("cache-algorithm")


### PR DESCRIPTION
mihomo-native answer to 'reject AAAA / disable IPv6 DNS': a plain switch that writes dns.ipv6:false into the per-profile user layer. Was only reachable via the buried Override → DNS → IPv6; now it's discoverable where users look for DNS settings.

- DnsHostsConfig models dns.ipv6 (parse + toDnsBlock + mergeIntoDns); it's no longer an opaque preserved key
- Switch + summary in DnsHostsSettingsDesign / design_dns_hosts_settings.xml
- Oracle-net round-trip test (DnsHostsConfigTest.ipv6_block_round_trips_and_overlays)
- We deliberately do NOT reimplement sing-box conditional DNS rules; dns.ipv6:false is the mihomo-native equivalent

Closes #116.