### PR TITLE
polish(ui): obsidian canvas on 5 screens that showed flat window bg (F-02)

### DIFF
--- a/design/src/main/res/layout/design_access_control.xml
+++ b/design/src/main/res/layout/design_access_control.xml
@@ -11,6 +11,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@drawable/bg_home_canvas"
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 

--- a/design/src/main/res/layout/design_files.xml
+++ b/design/src/main/res/layout/design_files.xml
@@ -18,6 +18,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@drawable/bg_home_canvas"
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 

--- a/design/src/main/res/layout/design_new_profile.xml
+++ b/design/src/main/res/layout/design_new_profile.xml
@@ -10,6 +10,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@drawable/bg_home_canvas"
         android:paddingStart="@{self.surface.insets.start}"
         android:paddingEnd="@{self.surface.insets.end}">
 

--- a/design/src/main/res/layout/design_proxy_provider_merged_group.xml
+++ b/design/src/main/res/layout/design_proxy_provider_merged_group.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/bg_home_canvas"
     android:orientation="vertical">
 
     <TextView

--- a/design/src/main/res/layout/design_rule_providers_editor.xml
+++ b/design/src/main/res/layout/design_rule_providers_editor.xml
@@ -5,6 +5,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@drawable/bg_home_canvas"
         android:orientation="vertical"
         android:fitsSystemWindows="true">
 


### PR DESCRIPTION
new-profile, access-control, files, proxy-provider-merged-group, rule-providers-editor had no root background, so they rendered the flat tech_bg instead of the Lumen bg_home_canvas (obsidian + ambient glow). Add the canvas to their roots. No behavior change; TrueBlack unaffected.