### PR TITLE
fix(subscription): correct display name on update; unify header resolver (E-16/E-19)

### DIFF
--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
@@ -92,6 +92,32 @@ object SubscriptionNameGuesser {
             fallbackName(requestUrl)
         }
 
+    /**
+     * Resolve a subscription display title from ALREADY-FETCHED response headers, using the SAME
+     * decoding chain as [guess] (explicit title headers → `Content-Disposition` filename* (RFC-5987)
+     * → `Subscription-Userinfo`), so the update path (`ProfileManager.updateFlow`) gets identical
+     * quality to import without a second network round-trip. Returns null when nothing usable. (E-19)
+     */
+    fun titleFromHeaders(get: (String) -> String?): String? {
+        listOf(
+            "Subscription-Title",
+            "Profile-Title",
+            "X-Subscription-Title",
+            "Display-Name",
+            "X-Display-Name",
+            "Subscription-Display-Name",
+        ).forEach { key ->
+            val raw = get(key)?.let(::normalizeHeaderValue)?.takeIf { it.isNotBlank() } ?: return@forEach
+            val name = sanitizeName(decodeMaybeEncodedName(raw) ?: raw)
+            if (!name.isNullOrBlank()) return name
+        }
+        get("Content-Disposition")?.let(::parseFilenameFromContentDisposition)
+            ?.let(::sanitizeName)?.takeIf { it.isNotBlank() }?.let { return it }
+        get("Subscription-Userinfo")?.let(::parseSubscriptionUserinfo)
+            ?.let(::sanitizeName)?.takeIf { it.isNotBlank() }?.let { return it }
+        return null
+    }
+
     /** First non-empty line starts with `mierus://` (QR / clipboard mierus share). */
     private fun isMierusLinkForSubscriptionTitle(trimmed: String): Boolean {
         val first = trimmed.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }

--- a/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
+++ b/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
@@ -25,4 +25,77 @@ class SubscriptionNameGuesserTest {
         // Percent-encoded spaces decode: "Home VPN", not "Home%20VPN".
         assertEquals("Home VPN", SubscriptionNameGuesser.guessFast("https://myvpn.io/x#Home%20VPN"))
     }
+
+    // --- titleFromHeaders: shared import/update resolver (E-19) ---
+
+    private fun title(headers: Map<String, String>): String? =
+        SubscriptionNameGuesser.titleFromHeaders { key -> headers[key] }
+
+    @Test
+    fun title_from_explicit_header() {
+        assertEquals("Premium Plan", title(mapOf("Subscription-Title" to "Premium Plan")))
+        assertEquals("Premium Plan", title(mapOf("X-Subscription-Title" to "\"Premium Plan\"")))
+    }
+
+    // Note: base64 title decoding relies on android.util.Base64 (device-only; stubbed to throw in
+    // plain JVM unit tests), so it's exercised on-device via the import path, not asserted here.
+
+    @Test
+    fun title_from_content_disposition_rfc5987() {
+        assertEquals(
+            "Home VPN",
+            title(mapOf("Content-Disposition" to "attachment; filename*=UTF-8''Home%20VPN")),
+        )
+    }
+
+    @Test
+    fun title_absent_returns_null() {
+        assertEquals(null, title(mapOf("Content-Type" to "text/plain")))
+        assertEquals(null, title(emptyMap()))
+    }
+
+    @Test
+    fun explicit_title_header_beats_content_disposition() {
+        // The account-id filename must never win over a real display title.
+        assertEquals(
+            "Real Name",
+            title(
+                mapOf(
+                    "Subscription-Title" to "Real Name",
+                    "Content-Disposition" to "attachment; filename*=UTF-8''BRIDGE_ACCOUNT_ID",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun blank_title_header_falls_through_to_next() {
+        assertEquals(
+            "Fallback",
+            title(mapOf("Subscription-Title" to "   ", "Profile-Title" to "Fallback")),
+        )
+    }
+
+    @Test
+    fun title_header_is_unquoted_and_trimmed() {
+        assertEquals("Premium", title(mapOf("Display-Name" to "  \"Premium\"  ")))
+    }
+
+    @Test
+    fun content_disposition_plain_filename() {
+        assertEquals(
+            "MyPlan",
+            title(mapOf("Content-Disposition" to "attachment; filename=\"MyPlan\"")),
+        )
+    }
+
+    @Test
+    fun url_name_param_fragment_decodes() {
+        assertEquals("My VPN", SubscriptionNameGuesser.guessFast("https://myvpn.io/x#name=My%20VPN"))
+    }
+
+    @Test
+    fun trailing_slash_url_uses_host_brand() {
+        assertEquals("myvpn", SubscriptionNameGuesser.guessFast("https://myvpn.io/"))
+    }
 }

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -2,7 +2,7 @@ package com.github.kr328.clash.service
 
 import android.content.Context
 import com.github.kr328.clash.common.log.Log
-import com.github.kr328.clash.common.util.MaybeBase64
+import com.github.kr328.clash.common.util.SubscriptionNameGuesser
 import com.github.kr328.clash.common.util.SubscriptionOverrides
 import com.github.kr328.clash.common.util.SubscriptionRequestHeaders
 import com.github.kr328.clash.common.util.SubscriptionUsage
@@ -473,13 +473,12 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 // (not a transient failure) and feeds the debounced auto-clear.
                 BrandRefresh.apply(context, old.uuid, brand, confirmedResponse = true)
 
-                if (response.headers["subscription-userinfo"] == null) return
-
+                // Re-derive the display name on EVERY update — not only when the panel sends
+                // subscription-userinfo. Tying the rename to the quota header meant subscriptions
+                // that don't send it never had their name corrected on update (the "белиберда /
+                // URL-tail" name bug). Usage/expiry still come from subscription-userinfo when
+                // present, but its absence must not skip the rename. (E-16)
                 val usage = SubscriptionUsage.parse(response.headers["subscription-userinfo"])
-                val upload = usage?.upload ?: 0L
-                val download = usage?.download ?: 0L
-                val total = usage?.total ?: 0L
-                val expire = usage?.expireAt?.times(1000L) ?: 0L
                 val renamed = deriveTitleFromHeaders(response.headers)
                 val effectiveName = if (looksLikeGeneratedTokenName(old.name) && !renamed.isNullOrBlank()) {
                     renamed
@@ -487,24 +486,27 @@ class ProfileManager(private val context: Context) : IProfileManager,
                     old.name
                 }
 
+                // Keep the previous quota/expiry when the panel didn't send subscription-userinfo
+                // this time, instead of zeroing them.
                 val new = Imported(
                     old.uuid,
                     effectiveName,
                     old.type,
                     old.source,
                     old.interval,
-                    upload,
-                    download,
-                    total,
-                    expire,
+                    usage?.upload ?: old.upload,
+                    usage?.download ?: old.download,
+                    usage?.total ?: old.total,
+                    usage?.expireAt?.times(1000L) ?: old.expire,
                     old.createdAt,
                     old.profileOrder,
                 )
 
-                ImportedDao().update(new)
-
-                PendingDao().remove(new.uuid)
-                context.sendProfileChanged(new.uuid)
+                if (new != old) {
+                    ImportedDao().update(new)
+                    PendingDao().remove(new.uuid)
+                    context.sendProfileChanged(new.uuid)
+                }
             }
 
         } catch (e: Exception) {
@@ -512,23 +514,12 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
-    private fun deriveTitleFromHeaders(headers: okhttp3.Headers): String? {
-        val raw = listOf(
-            "Subscription-Title",
-            "Profile-Title",
-            "X-Subscription-Title",
-            "Display-Name",
-            "X-Display-Name",
-            "Subscription-Display-Name",
-        ).firstNotNullOfOrNull { key ->
-            headers[key]?.trim()?.trim('"', '\'')
-        } ?: return null
-
-        val decoded = MaybeBase64.decode(raw).trim()
-        if (decoded.isBlank()) return null
-        if (decoded.length > 64) return decoded.take(64)
-        return decoded
-    }
+    // Delegate to the shared resolver so import and update decode headers identically (E-19):
+    // title headers → Content-Disposition filename* (RFC-5987) → Subscription-Userinfo. Keep the
+    // 64-char safety cap.
+    private fun deriveTitleFromHeaders(headers: okhttp3.Headers): String? =
+        SubscriptionNameGuesser.titleFromHeaders { key -> headers[key] }
+            ?.let { if (it.length > 64) it.take(64) else it }
 
     private fun looksLikeGeneratedTokenName(name: String): Boolean {
         val n = name.trim()


### PR DESCRIPTION
E-16: updateFlow re-derived the name only when the panel sent subscription-userinfo, so subs without that header never had their name fixed on update (the белиберда/URL-tail bug). Move the rename out of the early-return; keep old quota/expiry when the header is absent; only write when something changed.

E-19: add SubscriptionNameGuesser.titleFromHeaders — the SAME decode chain as import (title headers -> Content-Disposition filename* RFC-5987 -> subscription-userinfo). updateFlow now delegates to it, so import and update decode identically without a second network fetch.

Tests: 9 titleFromHeaders/guessFast fixtures (priority, blank-skip, unquote, RFC-5987 + plain Content-Disposition, #name= fragment, host fallback). base64 decoding is device-only (android.util.Base64), exercised via the import path.