### PR TITLE
fix(subscription): one shared opaque-token heuristic for import + update (E-17)

### DIFF
--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
@@ -360,7 +360,7 @@ object SubscriptionNameGuesser {
             val uri = URL(urlString)
             val pathSeg = uri.path?.trim('/')?.split('/')?.filter { it.isNotBlank() }?.lastOrNull()
             val humanPath = pathSeg?.let { trimFileExtension(it) }
-                ?.takeIf { looksHumanReadable(it) && !looksLikeToken(it) }
+                ?.takeIf { looksHumanReadable(it) && !looksLikeOpaqueToken(it) }
             val byHost = uri.host?.let(::brandFromHost)
             // Prefer a readable path label, but fall back to the host brand when
             // the last segment is an opaque subscription token (gsU8_wQwF814_Eo).
@@ -398,7 +398,13 @@ object SubscriptionNameGuesser {
      * lower-case letters (e.g. `gsU8_wQwF814_Eo`). Plain word labels
      * (`premium`, `My-Plan`, `my_vpn`) are NOT flagged.
      */
-    private fun looksLikeToken(segment: String): Boolean {
+    /**
+     * True when a string looks like a random opaque token (mixed case + a digit, ≥8 core chars) —
+     * a subscription id / auth token, not a human name. Shared by import (URL-segment guessing) and
+     * update (ProfileManager decides whether to replace a stored name), so both agree on what a
+     * "token" is and the update path never overwrites a name that import deliberately kept. (E-17)
+     */
+    fun looksLikeOpaqueToken(segment: String): Boolean {
         val core = segment.replace(Regex("[_-]"), "")
         if (core.length < 8) return false
         return core.any { it.isDigit() } &&

--- a/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
+++ b/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
@@ -98,4 +98,22 @@ class SubscriptionNameGuesserTest {
     fun trailing_slash_url_uses_host_brand() {
         assertEquals("myvpn", SubscriptionNameGuesser.guessFast("https://myvpn.io/"))
     }
+
+    // --- looksLikeOpaqueToken: the ONE shared token predicate for import + update (E-17) ---
+
+    @Test
+    fun opaque_token_needs_mixed_case_and_digit() {
+        assertEquals(true, SubscriptionNameGuesser.looksLikeOpaqueToken("aB3xK9mQ2pLz"))
+        assertEquals(true, SubscriptionNameGuesser.looksLikeOpaqueToken("gsU8_wQwF814_Eo"))
+    }
+
+    @Test
+    fun opaque_token_rejects_human_names() {
+        // The E-17 divergence case: all-lowercase "premiumplan1" must NOT be treated as a token,
+        // so the update path never overwrites a name import kept.
+        assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("premiumplan1"))
+        assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("Premium Plan")) // no digit
+        assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("PREMIUM123"))   // no lowercase
+        assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("short1A"))      // core < 8
+    }
 }

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -523,10 +523,13 @@ class ProfileManager(private val context: Context) : IProfileManager,
 
     private fun looksLikeGeneratedTokenName(name: String): Boolean {
         val n = name.trim()
-        if (n.length < 12 || n.length > 48) return false
-        if (n.contains(' ')) return false
-        if (n.contains('.') || n.contains('/')) return false
-        return n.matches(Regex("^[A-Za-z0-9_-]{12,48}$"))
+        // Guard rails: only ever reconsider a medium-length single-word label — never rename a
+        // human name with spaces/dots or a very short/long one.
+        if (n.length !in 12..48) return false
+        if (n.contains(' ') || n.contains('.') || n.contains('/')) return false
+        // Shared predicate so import and update agree on what a token is (E-17): a name import
+        // deliberately kept (e.g. all-lowercase "premiumplan1") is no longer replaced on update.
+        return SubscriptionNameGuesser.looksLikeOpaqueToken(n)
     }
 
     override suspend fun commit(uuid: UUID, callback: IFetchObserver?) {


### PR DESCRIPTION
Import used looksLikeToken (mixed-case + digit) to reject opaque tokens as names, while update used a looser regex ([A-Za-z0-9_-]{12,48}) — so a name import deliberately kept (e.g. all-lowercase 'premiumplan1') could be flagged a token and OVERWRITTEN on update.

Extract SubscriptionNameGuesser.looksLikeOpaqueToken as the single predicate; both import and ProfileManager.looksLikeGeneratedTokenName use it. Update no longer second-guesses import. Tests cover the predicate + the divergence case + edges (no digit / no lowercase / too short).