### PR TITLE
fix(service): don't log normal VPN stop as a crash (O-01/O-02)

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/ClashService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashService.kt
@@ -57,6 +57,10 @@ class ClashService : BaseService() {
 
                 if (quit) break
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Normal VPN stop cancels the runtime scope — not a failure. Rethrow so it isn't logged
+            // as "Create clash runtime failed" on every stop, and structured cancellation works. (O-01)
+            throw e
         } catch (e: Exception) {
             Log.e("Create clash runtime failed", e)
 

--- a/service/src/main/java/com/github/kr328/clash/service/TunService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/TunService.kt
@@ -71,6 +71,10 @@ class TunService : VpnService(), CoroutineScope by CoroutineScope(Dispatchers.De
 
                 if (quit) break
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Normal VPN stop cancels the runtime scope — not a failure. Rethrow so it isn't logged
+            // as "Create clash runtime failed" on every stop, and structured cancellation works. (O-01)
+            throw e
         } catch (e: Exception) {
             Log.e("Create clash runtime failed", e)
 

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -167,6 +167,8 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                         Clash.load(profileDir).await()
                         applyPostLoad()
                         break
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e // normal stop cancelled the load — not a load failure (O-02)
                     } catch (e: Exception) {
                         loadFailures++
                         if (loadFailures > 48) {
@@ -211,6 +213,8 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                         }
                     }
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // normal stop — not a load failure (O-02)
             } catch (e: Exception) {
                 Log.e("Failed to load active profile, keeping runtime alive", e)
                 if (loaded == null) {


### PR DESCRIPTION
On stop the runtime scope is cancelled; the CancellationException fell into catch (Exception) and was logged as 'Create clash runtime failed' / bumped the config load-failure counter every time. Rethrow CancellationException before those handlers in TunService, ClashService and ConfigurationModule's load loop (mirrors the ClashRuntime install wrapper) so cancellation stays clean. Verified on device: no crash noise on stop.