### PR TITLE
perf(widget): cache widget presence instead of querying every tick (O-05)

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/SpeedWidgetModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/SpeedWidgetModule.kt
@@ -28,12 +28,26 @@ import java.util.concurrent.TimeUnit
 class SpeedWidgetModule(service: Service) : Module<Unit>(service) {
     private val widgetManager = AppWidgetManager.getInstance(service)
 
-    private fun hasWidgets(): Boolean = runCatching {
-        widgetManager.getAppWidgetIds(SpeedWidgetRenderer.provider(service)).isNotEmpty()
-    }.getOrDefault(false)
+    private var widgetsPresent = false
+    private var tickCounter = 0
+
+    /**
+     * Widgets are rarely added/removed, so re-check presence only every ~30 fast ticks (~30s)
+     * instead of an AppWidgetManager IPC every second — needless battery otherwise. A newly-added
+     * widget still renders immediately via the provider's onUpdate; live frames catch up here. (O-05)
+     */
+    private fun widgetsPresent(): Boolean {
+        if (tickCounter % 30 == 0) {
+            widgetsPresent = runCatching {
+                widgetManager.getAppWidgetIds(SpeedWidgetRenderer.provider(service)).isNotEmpty()
+            }.getOrDefault(false)
+        }
+        tickCounter++
+        return widgetsPresent
+    }
 
     private fun push(running: Boolean) {
-        if (!hasWidgets()) return
+        if (!widgetsPresent()) return
         val now = if (running) Clash.queryTrafficNow() else 0L
         SpeedWidgetRenderer.renderAll(
             service,


### PR DESCRIPTION
SpeedWidgetModule queried AppWidgetManager.getAppWidgetIds every 1s tick to decide whether to push. Widgets are rarely added/removed, so re-check presence only every ~30 ticks (~30s) and use the cached value between — dropping a per-second IPC while the VPN
+ widget are active. A newly-added widget still renders immediately via the provider's onUpdate; live frames catch up within one refresh.