### PR TITLE
refactor(overlay): Stage C — user layer is the source of truth on update; AGENTS engine-oracle policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,20 @@ fastly.jsdelivr.net
 - Кнопка «О приложении» **только** внутри Settings (`SettingsDesign.Request.StartAbout`), не на главном экране.
 - Per-app routing: один экран со списком приложений (иконка+имя+чекбокс), вверху сегментированный переключатель Allow-list / Block-list / All, поиск, сортировка, кнопка «Сбросить». Доступ — через «Правила» → «По приложениям» (а также через Settings → Network → Access Control Packages для совместимости).
 
-## 6. Изменения в YAML/конфигах
+## 6. Изменения в YAML/конфигах (config-overlay-architecture)
 
-- Источник истины — текст профиля на диске. «Hardening»-логика применяется как пост-процессинг при сохранении/обновлении профиля (`YamlHardener.hardenProfile`).
-- Оригинальный пользовательский YAML сохраняется рядом как `config.original.yaml` (создаётся при первой правке, далее не перезаписывается) для возможности восстановления.
+Модель конфига — **overlay**, а не переписывание подписки:
+
+- **Подписка неприкосновенна.** Полученный конфиг сохраняется как есть в `subscription.yaml` (база) и НЕ переписывается/не мержится/не GC-ится. Правки пользователя живут отдельным **user-layer** (`user_layer.json`, `UserLayerStore`) как intent/delta: rules / dns / hosts / tunnels / rule-providers / proxy-providers / proxy-chain. Итоговый `config.yaml`, который получает движок, **композируется** at apply time: `ConfigComposer.compose(subscription.yaml + user_layer)` (на VPN-старте и на обновлении подписки).
+- **Только non-reconciling операции.** Композиция использует ТОЛЬКО: wholesale-replace верхнеуровневых ключей (dns/hosts/tunnels), list-prepend (правила юзера идут первыми, побеждают), map-union (rule-/proxy-providers, **без GC**), replay-intent (auto-select группа перегенерируется на свежем конфиге). **Никакого identity-reconciliation, orphan-detection, garbage-collection** — это источник дивергенции с семантикой mihomo (класс багов «not found rule-set: …»).
+- **Hard engine-gate.** Перед применением любого композированного/обновлённого конфига — валидировать реальным движком (`Clash.validateProfileBytes`). Если композиция сломала иначе-валидную подписку — применить чистую подписку (обновление всё равно работает) и сообщить, какая правка не легла (`MergeEngineVerdict`). НИКОГДА не отдавать движку конфиг, который он отвергает.
+- **Store — единственный источник истины для правок**, когда overlay активен (`ProfileMigration.isMigrated` = есть `subscription.yaml`). Редакторы (`*YamlEdit`) пишут store напрямую; **не переизвлекать** layer из `config.yaml` (string-extraction = тот самый reconciling-путь). Легаси-инсталлы мигрируются один раз (`ProfileMigration.migrateIfNeeded`), без потери правок.
+- **ПОЛИТИКА (обязательно): никаких config-переписывающих/мержащих трансформов без engine-oracle теста.** Любой новый трансформ, который парсит/мержит/переписывает конфиг, обязан иметь тест, сверяющий результат с реальным движком mihomo (`ValidateBytes`) — образцы: `ConfigCompositionFidelityTest`, `MergeEngineVerdictTest`, `WritePipelineOracleFixtureTest`. **Предпочитай делегировать движку** (query snapshot / API — Path-B), а не реимплементировать его семантику: read-only превью групп/транспорта берутся из snapshot движка (`ProxyGroupsYamlPreview`/…), YAML-парсинг — только для offline-случая.
+
+Пост-процессинг и бэкап (ортогонально overlay):
+
+- «Hardening»-логика применяется как пост-процессинг к композированному `config.yaml` при сохранении/обновлении (`YamlHardener.hardenProfile` + рантайм `ProxyHardener`).
+- Оригинальный пользовательский YAML сохраняется рядом как `config.original.yaml` (создаётся при первой hardening-правке, далее не перезаписывается) для возможности восстановления.
 
 ## 7. Git / Workflow
 
@@ -124,4 +134,4 @@ fastly.jsdelivr.net
 
 ---
 
-Файл версии: 2. Любые изменения этих правил — отдельным PR с явным согласованием.
+Файл версии: 3. Любые изменения этих правил — отдельным PR с явным согласованием.

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -234,10 +234,19 @@ object ProfileProcessor {
                 val serviceStore = ServiceStore(context)
                 val dnsHostsManaged = serviceStore.isDnsHostsManaged(snapshot.uuid)
                 val tunnelsManaged = serviceStore.isTunnelsManaged(snapshot.uuid)
-                // Overlay (config-overlay-architecture): capture the user's edit layer from the
-                // CURRENT (pre-fetch) config — before the fetch overwrites it — so it can be composed
-                // onto the freshly fetched subscription below. Replaces SubscriptionUpdateMerge.
-                val capturedLayer = if (configFile.isFile) {
+                // Overlay (config-overlay-architecture): the user's edit layer is composed onto the
+                // freshly fetched subscription below. Stage C — the user_layer store is the single
+                // source of truth once the overlay is active, so we no longer re-extract it from the
+                // (composed) config.yaml on every update: that string-extraction was the last
+                // reconciling path, exactly the divergence class this epic removes.
+                val capturedLayer = if (ProfileMigration.isMigrated(context.processingDir)) {
+                    // Overlay active: carry the store as-is. Every editor writes it directly, so it
+                    // already holds the authoritative intent; re-deriving from config.yaml could only
+                    // diverge.
+                    UserLayerStore.loadAt(context.processingDir)
+                } else if (configFile.isFile) {
+                    // Legacy install updating before its first post-upgrade VPN-start migration: one
+                    // time, extract the edits baked into the current config.yaml so nothing is lost.
                     ProfileMigration.buildLayerFromConfig(
                         profileDir = context.processingDir,
                         rulesStateJson = File(context.processingDir, "rules_state.json").takeIf { it.isFile }

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -41,8 +41,8 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
     }
 
     /**
-     * [outboundgroup.getProxies]/getProviders — stale member names in merged `proxy-groups` after
-     * subscription update ([SubscriptionUpdateMerge]).
+     * [outboundgroup.getProxies]/getProviders — stale member names in composed `proxy-groups`
+     * after a subscription update (overlay composition).
      */
     private fun extractQuotedNotFoundName(e: Throwable): String? {
         val re = Regex("'([^']*)'\\s+not\\s+found", RegexOption.IGNORE_CASE)

--- a/service/src/main/java/com/github/kr328/clash/service/util/JsonElementToYaml.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/JsonElementToYaml.kt
@@ -11,8 +11,8 @@ import kotlinx.serialization.json.JsonPrimitive
  * `Clash.parseProfileSnapshot`) into plain Kotlin Map/List/scalar trees
  * that SnakeYAML can dump back to YAML without surprises.
  *
- * The WRITE helpers in [MihomoConfigDocument] and SubscriptionUpdateMerge
- * still operate on raw Map/List/Any? because they need to feed SnakeYAML;
+ * The WRITE helpers in [MihomoConfigDocument] still operate on raw Map/List/Any?
+ * because they need to feed SnakeYAML;
  * READ now comes from the engine as JsonElement. This bridge lets the two
  * worlds coexist while we migrate read helpers piecewise.
  */

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleApplyService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleApplyService.kt
@@ -188,15 +188,15 @@ class RuleApplyService(
     /**
      * Reconcile after a subscription refresh. Reads MANUAL rules from the saved state file
      * (anything the user added through the UI), reads PROVIDER rules from the freshly fetched
-     * config, and re-applies them through the same merge code path used by applyState. This
-     * is the structured complement to [SubscriptionUpdateMerge]'s string-based merge: if a
-     * state file exists, MANUAL vs PROVIDER classification beats heuristic line matching.
+     * config, and re-applies them through the same merge code path used by applyState. It relies
+     * on structured MANUAL-vs-PROVIDER classification from the saved state file rather than
+     * heuristic line matching.
      *
      * Files are passed in explicitly because the caller runs against `processingDir`, not the
      * usual `importedDir/<uuid>`.
      *
      * @return true if reconciliation rewrote the config; false on any failure (caller should
-     *         leave whatever [SubscriptionUpdateMerge] produced alone in that case).
+     *         leave the freshly fetched config alone in that case).
      */
     fun reconcileWithStoredState(
         configFile: File,

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
@@ -36,9 +36,9 @@ object RuleMapper {
     // that no longer contained them (e.g. GEOSITE,category-ads-all,REJECT
     // surviving across an update that deleted it).
     //
-    // Kept in sync with SubscriptionUpdateMerge.SUBSCRIPTION_OWNED_RULE_TYPES
-    // by intent: those are the same types the merge step drops from preserved
-    // overlays. Both files own a copy to keep the dependency direction clean.
+    // These are the rule types the overlay composition treats as subscription-owned: the
+    // user's MANUAL rules are list-prepended and win, while these PROVIDER-sourced types come
+    // fresh from subscription.yaml on every update and are never frozen into the user layer.
     private val SUBSCRIPTION_OWNED_RULE_TYPES = setOf(
         "RULE-SET", "GEOSITE", "GEOIP", "MATCH",
         "SUB-RULE", "AND", "OR", "NOT",


### PR DESCRIPTION
- ProfileProcessor: on subscription update, gate on ProfileMigration.isMigrated — when the overlay is active, carry the user_layer store as-is instead of re-extracting it from the composed config.yaml (that string-extraction was the last reconciling path). Legacy installs still migrate once. Removes the final config->layer divergence surface.
- AGENTS.md: document the overlay config model (subscription.yaml base + user_layer intent + compose-time non-reconciling ops + hard engine-gate) and the policy: no config-rewriting transform without an engine-oracle test; prefer delegating to the engine. Bump to version 3.
- drop 4 stale doc references to the deleted SubscriptionUpdateMerge.