### PR TITLE
i18n: fill RU/ZH drift — DNS block-ipv6 (#116) + ZH about-telegram

### DIFF
--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -91,6 +91,8 @@
     <string name="dns_hosts_disabled">DNS и Hosts откатаны для этого профиля.</string>
     <string name="dns_hosts_err_listen">Адрес DNS listen: loopback (127.0.0.1:порт), форма по умолчанию (:порт) или пусто.</string>
     <string name="dns_hosts_err_invalid">Движок отклонил эту конфигурацию.</string>
+    <string name="dns_hosts_block_ipv6">Блокировать IPv6 (AAAA)</string>
+    <string name="dns_hosts_block_ipv6_summary">Не возвращать IPv6-адреса (отбрасывает AAAA-ответы DNS). Устраняет зависания и медленную загрузку при неработающем или высоколатентном IPv6.</string>
 
     <!-- Tunnels -->
     <string name="tunnels_title">Туннели</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -464,6 +464,8 @@
     <string name="dns_hosts_disabled">已为此配置还原 DNS 与 Hosts。</string>
     <string name="dns_hosts_err_listen">DNS 监听需为回环 (127.0.0.1:端口)、默认形式 (:端口) 或留空。</string>
     <string name="dns_hosts_err_invalid">引擎拒绝了此配置。</string>
+    <string name="dns_hosts_block_ipv6">屏蔽 IPv6 (AAAA)</string>
+    <string name="dns_hosts_block_ipv6_summary">不返回 IPv6 地址（丢弃 AAAA DNS 应答）。修复 IPv6 故障或高延迟导致的卡顿与加载缓慢。</string>
 
     <!-- Tunnels -->
     <string name="tunnels_title">隧道</string>
@@ -737,6 +739,7 @@
     <string name="headers_desc_brand_hide_routing">与 Show-Operator-Tab=true 配对:用运营商标签替换路由标签。单独使用无效。</string>
     <!-- I18N-R2: zh backfill (design) — first pass, pending native review -->
     <string name="about_github_repo">ClashFest 在 GitHub</string>
+    <string name="about_telegram_community">ClashFest 的 Telegram — 问题反馈与讨论</string>
     <string name="about_support">联系支持</string>
     <string name="add">添加</string>
     <string name="allow_all_apps_description">所有应用都使用 VPN</string>


### PR DESCRIPTION
- RU/ZH: dns_hosts_block_ipv6 + summary (were EN-only since #116)
- ZH: about_telegram_community (RU already had it) Remaining EN-only strings are translatable=false (URLs/emoji) — correctly default-only.