### PR TITLE
perf(proxy): fix 200-node subscription jank — virtualize picker, guard accordion, lazy warmup (O-07)

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -279,29 +279,6 @@ class MainActivity : BaseActivity<MainDesign>() {
     }
 
     /**
-     * Runs [healthCheck] on every auto proxy group after connect, regardless
-     * of tunnel mode.
-     *
-     * Earlier this only ran in Global mode because the original concern was
-     * that in Rule mode it would fight [ConfigurationModule] applying
-     * [SelectionDao] and flash the active card. That guard turned out to be
-     * over-conservative for two reasons:
-     *  1. [SelectionDao] only stores picks for Selector groups; auto types
-     *     (URLTest / Fallback / LoadBalance) have no user-stored selection,
-     *     so a health check on them can never overwrite a user's pick.
-     *  2. Subscriptions that wrap an entire url-test/fallback subtree behind
-     *     a single select root with `hidden: true` on the children (a very
-     *     common kaso.fyi-style layout) leave every node ping-less in Rule
-     *     mode without a warmup.
-     *
-     * A brief UI flash on connect is the acceptable trade-off for pings
-     * actually working on those subscriptions.
-     */
-    private suspend fun warmUpAutoProxyGroupsForGlobalOnly(): Set<String> {
-        return warmUpAutoProxyGroups()
-    }
-
-    /**
      * Run a per-proxy health check on [group] and stream each proxy's delay
      * into the active card as soon as URLTest resolves. Suspends until every
      * proxy has reported (or the call early-outed because the group is
@@ -345,47 +322,36 @@ class MainActivity : BaseActivity<MainDesign>() {
         }
     }
 
-    private suspend fun warmUpAutoProxyGroups(): Set<String> = coroutineScope {
+    /** Groups already warmed up this session, so a group is url-tested at most once (O-07). */
+    private val warmedGroups = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
+    /**
+     * Warm up (url-test) a single group and its nested auto subtree — once per session. This is the
+     * lazy replacement for the old blanket connect-time warmup that url-tested EVERY auto group;
+     * on a heavy subscription (200-node url-test groups) that saturated the engine on connect, which
+     * showed up as an "infinite ping" and made proxy switching sluggish (O-07). We now test only the
+     * group the user actually looks at (see [MainActivity]'s visibleGroupChanged handler); the
+     * subtree walk still covers kaso.fyi-style layouts where the visible root is a plain select over
+     * a `hidden: true` url-test subtree.
+     */
+    private suspend fun warmUpGroupSubtree(rootGroup: String): Set<String> = coroutineScope {
+        if (rootGroup.isBlank() || !warmedGroups.add(rootGroup)) return@coroutineScope emptySet()
         waitForProxyEngineReady()
 
-        // Walk every group (including hidden) so subscriptions whose entire
-        // url-test/fallback subtree is `hidden: true` (visible root is a
-        // plain select) still get warmed up. Filtering by visibility was the
-        // bug: hidden auto-groups were skipped entirely, so pings never ran.
-        val allGroupNames = runCatching {
-            withClash { queryAllProxyGroupNamesIncludingHidden() }
-        }.getOrDefault(emptyList())
-        val visibleGroupNames = runCatching {
-            withClash { queryProxyGroupNames(false) }
-        }.getOrDefault(emptyList())
-        if (allGroupNames.isEmpty() && visibleGroupNames.isEmpty()) return@coroutineScope emptySet()
-
-        val allGroupSet = allGroupNames.toSet()
+        val subtree = collectRuntimeGroupTree(rootGroup).ifEmpty { setOf(rootGroup) }
         val autoGroups = linkedSetOf<String>()
-        // Iterate over the union so we can both flag visible auto roots and
-        // discover hidden auto subgroups via their members.
-        for (groupName in (allGroupNames + visibleGroupNames).distinct()) {
+        for (groupName in subtree) {
             val group = runCatching {
                 withClash { queryProxyGroup(groupName, com.github.kr328.clash.core.model.ProxySort.Default) }
             }.getOrNull() ?: continue
             if (isAutoProxyGroup(groupName, group)) {
                 autoGroups += groupName
             }
-            for (proxy in group.proxies) {
-                if (proxy.name in allGroupSet &&
-                    (proxy.type == Proxy.Type.URLTest ||
-                        proxy.type == Proxy.Type.Fallback ||
-                        proxy.type == Proxy.Type.LoadBalance)
-                ) {
-                    autoGroups += proxy.name
-                }
-            }
         }
         if (autoGroups.isEmpty()) return@coroutineScope emptySet()
 
-        // Prime engine state so per-proxy push has rows to land on. Without
-        // this, the first warmup cycle on cold start would have nowhere to
-        // write — proxyDetails is empty until the user scrolls into a group.
+        // Prime engine state so per-proxy push has rows to land on. Without this, the first warmup
+        // cycle would have nowhere to write — proxyDetails is empty until the user scrolls in.
         val primed = refreshRuntimeGroupDetails(autoGroups)
         if (primed.isNotEmpty()) {
             design?.patchProxyDetails(primed)
@@ -865,6 +831,20 @@ class MainActivity : BaseActivity<MainDesign>() {
                 design.profileVisibleGroupChanged.onReceive { (profile, group) ->
                     uiStore.proxyLastGroup = group
                     scheduleProxyDetailsRefresh(profile, group)
+                    // Lazy warmup (O-07): url-test this group's subtree once, only when the user
+                    // actually opens it — instead of every auto group up front on connect.
+                    launch {
+                        try {
+                            val warmed = warmUpGroupSubtree(group)
+                            if (warmed.isNotEmpty()) {
+                                val patches = refreshRuntimeGroupDetails(warmed)
+                                if (patches.isNotEmpty()) design?.patchProxyDetails(patches)
+                            }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                        }
+                    }
                 }
 
                 proxyDetailRequests.onReceive { (profile, group) ->
@@ -1324,7 +1304,12 @@ class MainActivity : BaseActivity<MainDesign>() {
                     waitForProxyEngineReady()
                     waitForProfileLoadEpochAfter(loadEpochSnapshot)
                     d?.fetch()
-                    val warmed = warmUpAutoProxyGroupsForGlobalOnly()
+                    // O-07: warm up ONLY the group the user last looked at (+ its nested auto
+                    // subtree), not every auto group. The old blanket warmup url-tested 200-node
+                    // groups on connect and saturated the engine ("infinite ping" + sluggish
+                    // switch). Other groups warm lazily when opened (see visibleGroupChanged).
+                    warmedGroups.clear()
+                    val warmed = warmUpGroupSubtree(uiStore.proxyLastGroup)
                     d?.fetch()
                     // Force-push fresh delays into the UI immediately instead
                     // of waiting for the next dashboard ticker (interactive=2s,

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -8,8 +8,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import androidx.core.view.children
 import androidx.core.widget.addTextChangedListener
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.kr328.clash.core.model.Proxy
 import com.github.kr328.clash.core.model.ProxyGroup
@@ -831,7 +834,8 @@ class ProfileAdapter(
             sheet.proxySheetTestedDot.visibility = View.GONE
             sheet.proxySheetTestedText.visibility = View.GONE
             sheet.proxySheetPingSlot.visibility = View.GONE
-            addEmptyProxyHint(sheet.proxySheetNodesList, context)
+            sheet.proxySheetEmpty.text = context.getString(R.string.proxy_nodes_empty_connect_vpn)
+            sheet.proxySheetEmpty.visibility = View.VISIBLE
         } else {
             val picked = resolvePreferredGroupFromList(profile, groupNames)
             var idx = selectedGroupIndex[profile.uuid]
@@ -886,6 +890,28 @@ class ProfileAdapter(
                 sheet.proxySheetFilterButton.text = filterLabel(filter)
             }
 
+            // The node list is a RecyclerView (virtualized — see O-07). render() references
+            // nodeAdapter, and the adapter's selection callback references render(): break that
+            // cycle via renderFn, assigned right after render() is defined below.
+            var renderFn: (Int) -> Unit = {}
+            val nodeAdapter = ProxyNodeAdapter(profile) {
+                // Tapping a node sets a pending selection; the cached rows still carry the OLD
+                // `selected` flags, so drop the cache before re-render or submitList would diff
+                // against identical data and the check-mark would never move to the new node.
+                invalidateRowCache()
+                renderFn(selectedGroupIndex[profile.uuid] ?: 0)
+            }
+            sheet.proxySheetNodesList.layoutManager = LinearLayoutManager(context)
+            sheet.proxySheetNodesList.adapter = nodeAdapter
+            // Rebinds during live ping / selection are content-only; suppress the change animation
+            // so delay capsules update without a flicker.
+            sheet.proxySheetNodesList.itemAnimator = null
+            ContextCompat.getDrawable(context, R.drawable.divider_node_hairline)?.let { d ->
+                sheet.proxySheetNodesList.addItemDecoration(
+                    DividerItemDecoration(context, DividerItemDecoration.VERTICAL).apply { setDrawable(d) },
+                )
+            }
+
             fun render(selectedIndex: Int) {
                 selectedGroupIndex[profile.uuid] = selectedIndex
                 renderGroupSegmentsInto(
@@ -905,13 +931,23 @@ class ProfileAdapter(
                     filter = filter,
                     currentGroupIndex = selectedIndex,
                 )
-                fillProxyRowsInto(sheet.proxySheetNodesList, profile, rows)
+                nodeAdapter.showGroupInSubtitle = rows.map { it.groupName }.distinct().size > 1
+                nodeAdapter.submitList(rows)
+                if (rows.isEmpty()) {
+                    val groupHasNodes = rowsForCurrentGroup(selectedIndex).isNotEmpty()
+                    sheet.proxySheetEmpty.text =
+                        context.getString(proxyPickerEmptyHint(profile, groupNames.getOrNull(selectedIndex), groupHasNodes))
+                    sheet.proxySheetEmpty.visibility = View.VISIBLE
+                } else {
+                    sheet.proxySheetEmpty.visibility = View.GONE
+                }
                 bindTestedAgo(sheet, profile, context)
                 if (selectedScrolledGroupIndex != selectedIndex) {
                     selectedScrolledGroupIndex = selectedIndex
                     scrollProxyPickerToSelected(sheet, rows)
                 }
             }
+            renderFn = ::render
 
             fun visibleRows(): List<ProxyPickerRow> {
                 val currentIndex = (selectedGroupIndex[profile.uuid] ?: 0).coerceIn(0, groupNames.lastIndex)
@@ -934,12 +970,14 @@ class ProfileAdapter(
 
                     when {
                         pingingNow -> {
-                            // Live ping: update ONLY the delay capsules on the
-                            // existing row views. The list structure stays
-                            // frozen so the user can keep scrolling and tapping
-                            // nodes — the previous full re-inflate every 260ms
-                            // made both impossible (jank + missed taps).
-                            refreshProxyDelaysInPlace(sheet.proxySheetNodesList, profile)
+                            // Live ping: patch delays on the CURRENT row order (no re-sort /
+                            // re-filter, so the structure stays frozen and the user can keep
+                            // scrolling and tapping). DiffUtil rebinds only the capsules whose
+                            // delay actually changed — no full re-inflate.
+                            val patched = nodeAdapter.currentList.map {
+                                it.copy(delayMs = resolveProxyDelay(profile.uuid, it.proxy))
+                            }
+                            nodeAdapter.submitList(patched)
                         }
                         wasPinging -> {
                             // Ping just finished — one full render so Delay
@@ -1540,11 +1578,12 @@ class ProfileAdapter(
         groupNames: List<String>,
         groupIndex: Int,
     ) {
-        list.removeAllViews()
-
-        val groupName = groupNames.getOrNull(groupIndex) ?: return
-        val pg = proxyGroupForRow(profile, groupName) ?: return
+        // NB: do NOT clear the list up front — the 3-arg overload below is structure-guarded and
+        // must see the previously-inflated rows to update delays in place instead of re-inflating
+        // on every live-ping tick (O-07). Clearing happens only on the empty/early-out paths.
         val context = list.context
+        val groupName = groupNames.getOrNull(groupIndex) ?: run { list.removeAllViews(); list.tag = null; return }
+        val pg = proxyGroupForRow(profile, groupName) ?: run { list.removeAllViews(); list.tag = null; return }
         val pendingChoice = pendingMapValueForGroup(profile.uuid, groupName)?.takeIf { it.isNotBlank() }
         val effectiveNow = pendingChoice ?: pg.now
         val rows = pg.proxies
@@ -1570,6 +1609,8 @@ class ProfileAdapter(
                 else ->
                     R.string.proxy_nodes_empty_connect_vpn
             }
+            list.removeAllViews()
+            list.tag = null
             addEmptyProxyHint(list, context, hintRes)
             return
         }
@@ -1577,183 +1618,256 @@ class ProfileAdapter(
         fillProxyRowsInto(list, profile, rows)
     }
 
+    /**
+     * Inflates [rows] straight into a plain [list] container — the inline group-block accordion in
+     * the profile card. The bottom-sheet picker uses [ProxyNodeAdapter] (RecyclerView) instead; this
+     * path stays a simple fill because it lives inside the card's own scroll, where a nested
+     * RecyclerView could not recycle anyway. Reuses [bindProxyNodeRow] so both paths render rows
+     * identically.
+     */
     private fun fillProxyRowsInto(
         list: ViewGroup,
         profile: Profile,
         rows: List<ProxyPickerRow>,
     ) {
-        list.removeAllViews()
-
-        val inflater = list.context.layoutInflater
         val context = list.context
+        // Structure tag = the node identity list. During a live URL-test the engine pushes fresh
+        // delays ~8×/s and the card re-binds each push; without this guard we re-inflated every node
+        // on every tick (200 inflations/tick → ContentCapture assumeLayout flood → the device melts
+        // down during a ping, O-07). Same node set → patch the delay capsules on the existing views
+        // in place and return; only a changed node set falls through to a full re-inflate.
+        val structureTag = "nodes:" + rows.joinToString("|") { it.groupName + "/" + it.proxy.name }
+        if (rows.isNotEmpty() && list.tag == structureTag && list.childCount == rows.size) {
+            rows.forEachIndexed { i, pickerRow ->
+                list.getChildAt(i)?.let { updateProxyRowDynamic(it, pickerRow) }
+            }
+            return
+        }
 
+        list.removeAllViews()
+        list.tag = null
         if (rows.isEmpty()) {
             addEmptyProxyHint(list, context, R.string.profile_proxy_empty_filtered)
             return
         }
-
         val showGroupInSubtitle = rows.map { it.groupName }.distinct().size > 1
-
+        val inflater = context.layoutInflater
         for (pickerRow in rows) {
-            val p = pickerRow.proxy
-            val groupName = pickerRow.groupName
             val row = inflater.inflate(R.layout.adapter_home_proxy_node, list, false)
-
-            val title = p.title.ifBlank { p.name }
-            val flag = FlagParser.parse(title)
-            val cleanTitle = flag?.let {
-                title.removePrefix(it.emoji)
-                    .trimStart(' ', '|', '-', '_', '.', ':')
-                    .ifBlank { title }
-            } ?: title
-            val (namePart, cityPart) = splitNameAndCity(cleanTitle)
-            row.findViewById<TextView>(R.id.proxy_title).text = namePart
-            row.findViewById<TextView>(R.id.proxy_city).apply {
-                if (cityPart != null) {
-                    text = cityPart
-                    visibility = View.VISIBLE
-                } else {
-                    visibility = View.GONE
-                }
-            }
-            val flagCard = row.findViewById<View>(R.id.proxy_flag_card)
-            val flagImage = row.findViewById<com.google.android.material.imageview.ShapeableImageView>(R.id.proxy_flag_image)
-            val flagText = row.findViewById<TextView>(R.id.proxy_flag)
-            if (flag != null) {
-                flagCard.visibility = View.VISIBLE
-                val sizePx = context.dp(28)
-                val bitmap = FlagDrawableLoader.loadBitmap(context, flag.code, sizePx)
-                if (bitmap != null) {
-                    flagImage.setImageBitmap(bitmap)
-                    flagImage.visibility = View.VISIBLE
-                    flagText.visibility = View.GONE
-                } else {
-                    flagImage.visibility = View.GONE
-                    flagText.text = flag.emoji
-                    flagText.visibility = View.VISIBLE
-                }
-            } else {
-                flagCard.visibility = View.GONE
-            }
-
-            val typeBadge = row.findViewById<TextView>(R.id.proxy_type_badge)
-            val transportBadge = row.findViewById<TextView>(R.id.proxy_transport_badge)
-            val realityBadge = row.findViewById<TextView>(R.id.proxy_reality_badge)
-            val typeName = p.type.name
-
-            // Leaf node → protocol chips (VLESS / GRPC / REALITY). Nested auto-group →
-            // a single group-type chip (URL-TEST / FALLBACK / …) so groups read distinctly
-            // from nodes. Both resolve offline (overlay: type from transport/groups preview).
-            val groupTypeLabel = groupTypeLabel(p.type)
-            val showBadge: Boolean
-            if (p.type.group) {
-                if (groupTypeLabel != null) {
-                    applyProtoChip(typeBadge, groupTypeLabel, ContextCompat.getColor(context, groupTypeColor(p.type)))
-                } else {
-                    typeBadge.visibility = View.GONE
-                }
-                transportBadge.visibility = View.GONE
-                realityBadge.visibility = View.GONE
-                showBadge = groupTypeLabel != null
-            } else {
-                showBadge = typeName != "Unknown"
-                if (showBadge) {
-                    applyProtoChip(typeBadge, typeName.uppercase(), ContextCompat.getColor(context, protocolFamilyColor(typeName)))
-                } else {
-                    typeBadge.visibility = View.GONE
-                }
-
-                val transportInfo = if (showBadge) transportInfoByProfile[profile.uuid]?.get(p.name) else null
-                val transportLabel = transportLabel(transportInfo)
-                if (transportLabel != null) {
-                    applyProtoChip(transportBadge, transportLabel, ContextCompat.getColor(context, R.color.proto_transport))
-                } else {
-                    transportBadge.visibility = View.GONE
-                }
-                if (transportInfo?.reality == true) {
-                    applyProtoChip(realityBadge, "REALITY", ContextCompat.getColor(context, R.color.proto_reality))
-                } else {
-                    realityBadge.visibility = View.GONE
-                }
-            }
-
-            val rawSubtitle = p.subtitle
-                .takeIf { it.isNotBlank() && !it.equals(typeName, ignoreCase = true) }
-            val subtitle = buildList {
-                rawSubtitle?.let(::add)
-                if (showGroupInSubtitle) add(displayGroupName(groupName))
-            }.joinToString(" · ").takeIf { it.isNotBlank() }
-            row.findViewById<TextView>(R.id.proxy_subtitle).apply {
-                visibility = if (subtitle == null) View.GONE else View.VISIBLE
-                text = subtitle.orEmpty()
-            }
-            row.findViewById<View>(R.id.proxy_subtitle_sep).visibility =
-                if (showBadge && subtitle != null) View.VISIBLE else View.GONE
-
-            val delayMs = pickerRow.delayMs
-
-            val capsule = row.findViewById<View>(R.id.latency_capsule)
-            val dot = row.findViewById<View>(R.id.latency_dot)
-            val delayView = row.findViewById<TextView>(R.id.proxy_delay)
-            delayView.text = formatDelay(delayMs)
-            applyDelayStyle(capsule, dot, delayView, delayMs, context)
-
-            val selected = pickerRow.selected
-            row.isSelected = selected
-            row.findViewById<View>(R.id.selected_bar).visibility =
-                if (selected) View.VISIBLE else View.INVISIBLE
-            row.findViewById<View>(R.id.selected_check).visibility =
-                if (selected) View.VISIBLE else View.GONE
-            val mainHit = row.findViewById<View>(R.id.proxy_row_main_hit)
-            val tryPickNode: () -> Boolean = {
-                val canPickLive = clashRunning && useEngineFor(profile)
-                val canPickOffline = profile.imported && profile.uuid == activeProfileUuid
-                if (canPickLive || canPickOffline) {
-                    setPendingProxySelection(profile.uuid, groupName, p.name)
-                    markRowSelected(list, row)
-                    onProxyNodeSelected(profile, groupName, p.name)
-                    true
-                } else {
-                    false
-                }
-            }
-            mainHit.setOnClickListener {
-                if (!tryPickNode()) {
-                    onProxyYamlDetail(profile, groupName, p.name)
-                }
-            }
-            mainHit.setOnLongClickListener {
-                onProxyYamlDetail(profile, groupName, p.name)
-                true
-            }
-            // Tag the row with its Proxy so refreshProxyDelaysInPlace can
-            // update just the latency capsule during a live ping without
-            // rebuilding the whole list.
-            row.tag = p
+            bindProxyNodeRow(row, profile, pickerRow, showGroupInSubtitle) { markRowSelected(list, row) }
             list.addView(row)
         }
+        list.tag = structureTag
     }
 
     /**
-     * Updates only the latency capsule (delay text + colour) on each already-
-     * inflated proxy row, leaving the list structure untouched. Used during a
-     * live ping so the user can keep scrolling and tapping nodes — a full
-     * [fillProxyRowsInto] re-inflate on every 260ms tick made the list jank
-     * and swallowed taps. Re-sorting / re-filtering by the new delays happens
-     * once, after the ping finishes (see the refresh runnable).
+     * Refreshes only the values that change without a structural change — the latency capsule and the
+     * selection ornaments — on an already-inflated node row. Used on the live-ping tick so no view is
+     * re-inflated (the capsules follow the URL-test, and the check follows a server-side `now` change).
      */
-    private fun refreshProxyDelaysInPlace(list: ViewGroup, profile: Profile) {
-        val context = list.context
-        for (row in list.children) {
-            val proxy = row.tag as? Proxy ?: continue
-            val delayMs = resolveProxyDelay(profile.uuid, proxy)
-            val capsule = row.findViewById<View>(R.id.latency_capsule) ?: continue
-            val dot = row.findViewById<View>(R.id.latency_dot) ?: continue
-            val delayView = row.findViewById<TextView>(R.id.proxy_delay) ?: continue
+    private fun updateProxyRowDynamic(row: View, pickerRow: ProxyPickerRow) {
+        val delayMs = pickerRow.delayMs
+        val capsule = row.findViewById<View>(R.id.latency_capsule)
+        val dot = row.findViewById<View>(R.id.latency_dot)
+        val delayView = row.findViewById<TextView>(R.id.proxy_delay)
+        if (capsule != null && dot != null && delayView != null) {
             delayView.text = formatDelay(delayMs)
-            applyDelayStyle(capsule, dot, delayView, delayMs, context)
+            applyDelayStyle(capsule, dot, delayView, delayMs, row.context)
+        }
+        val selected = pickerRow.selected
+        row.isSelected = selected
+        row.findViewById<View>(R.id.selected_bar)?.visibility = if (selected) View.VISIBLE else View.INVISIBLE
+        row.findViewById<View>(R.id.selected_check)?.visibility = if (selected) View.VISIBLE else View.GONE
+    }
+
+    /**
+     * Binds one proxy-node row view from a [ProxyPickerRow]. Shared by [ProxyNodeAdapter], whose
+     * RecyclerView recycles views so only the ~10 visible rows are ever inflated — a 200-node group
+     * no longer inflates 200 views synchronously and freezes the UI on open (O-07).
+     */
+    private fun bindProxyNodeRow(
+        row: View,
+        profile: Profile,
+        pickerRow: ProxyPickerRow,
+        showGroupInSubtitle: Boolean,
+        onSelectionChanged: () -> Unit,
+    ) {
+        val context = row.context
+        val p = pickerRow.proxy
+        val groupName = pickerRow.groupName
+
+        val title = p.title.ifBlank { p.name }
+        val flag = FlagParser.parse(title)
+        val cleanTitle = flag?.let {
+            title.removePrefix(it.emoji)
+                .trimStart(' ', '|', '-', '_', '.', ':')
+                .ifBlank { title }
+        } ?: title
+        val (namePart, cityPart) = splitNameAndCity(cleanTitle)
+        row.findViewById<TextView>(R.id.proxy_title).text = namePart
+        row.findViewById<TextView>(R.id.proxy_city).apply {
+            if (cityPart != null) {
+                text = cityPart
+                visibility = View.VISIBLE
+            } else {
+                visibility = View.GONE
+            }
+        }
+        val flagCard = row.findViewById<View>(R.id.proxy_flag_card)
+        val flagImage = row.findViewById<com.google.android.material.imageview.ShapeableImageView>(R.id.proxy_flag_image)
+        val flagText = row.findViewById<TextView>(R.id.proxy_flag)
+        if (flag != null) {
+            flagCard.visibility = View.VISIBLE
+            val sizePx = context.dp(28)
+            val bitmap = FlagDrawableLoader.loadBitmap(context, flag.code, sizePx)
+            if (bitmap != null) {
+                flagImage.setImageBitmap(bitmap)
+                flagImage.visibility = View.VISIBLE
+                flagText.visibility = View.GONE
+            } else {
+                flagImage.visibility = View.GONE
+                flagText.text = flag.emoji
+                flagText.visibility = View.VISIBLE
+            }
+        } else {
+            flagCard.visibility = View.GONE
+        }
+
+        val typeBadge = row.findViewById<TextView>(R.id.proxy_type_badge)
+        val transportBadge = row.findViewById<TextView>(R.id.proxy_transport_badge)
+        val realityBadge = row.findViewById<TextView>(R.id.proxy_reality_badge)
+        val typeName = p.type.name
+
+        // Leaf node → protocol chips (VLESS / GRPC / REALITY). Nested auto-group →
+        // a single group-type chip (URL-TEST / FALLBACK / …) so groups read distinctly
+        // from nodes. Both resolve offline (overlay: type from transport/groups preview).
+        val groupTypeLabel = groupTypeLabel(p.type)
+        val showBadge: Boolean
+        if (p.type.group) {
+            if (groupTypeLabel != null) {
+                applyProtoChip(typeBadge, groupTypeLabel, ContextCompat.getColor(context, groupTypeColor(p.type)))
+            } else {
+                typeBadge.visibility = View.GONE
+            }
+            transportBadge.visibility = View.GONE
+            realityBadge.visibility = View.GONE
+            showBadge = groupTypeLabel != null
+        } else {
+            showBadge = typeName != "Unknown"
+            if (showBadge) {
+                applyProtoChip(typeBadge, typeName.uppercase(), ContextCompat.getColor(context, protocolFamilyColor(typeName)))
+            } else {
+                typeBadge.visibility = View.GONE
+            }
+
+            val transportInfo = if (showBadge) transportInfoByProfile[profile.uuid]?.get(p.name) else null
+            val transportLabel = transportLabel(transportInfo)
+            if (transportLabel != null) {
+                applyProtoChip(transportBadge, transportLabel, ContextCompat.getColor(context, R.color.proto_transport))
+            } else {
+                transportBadge.visibility = View.GONE
+            }
+            if (transportInfo?.reality == true) {
+                applyProtoChip(realityBadge, "REALITY", ContextCompat.getColor(context, R.color.proto_reality))
+            } else {
+                realityBadge.visibility = View.GONE
+            }
+        }
+
+        val rawSubtitle = p.subtitle
+            .takeIf { it.isNotBlank() && !it.equals(typeName, ignoreCase = true) }
+        val subtitle = buildList {
+            rawSubtitle?.let(::add)
+            if (showGroupInSubtitle) add(displayGroupName(groupName))
+        }.joinToString(" · ").takeIf { it.isNotBlank() }
+        row.findViewById<TextView>(R.id.proxy_subtitle).apply {
+            visibility = if (subtitle == null) View.GONE else View.VISIBLE
+            text = subtitle.orEmpty()
+        }
+        row.findViewById<View>(R.id.proxy_subtitle_sep).visibility =
+            if (showBadge && subtitle != null) View.VISIBLE else View.GONE
+
+        val delayMs = pickerRow.delayMs
+
+        val capsule = row.findViewById<View>(R.id.latency_capsule)
+        val dot = row.findViewById<View>(R.id.latency_dot)
+        val delayView = row.findViewById<TextView>(R.id.proxy_delay)
+        delayView.text = formatDelay(delayMs)
+        applyDelayStyle(capsule, dot, delayView, delayMs, context)
+
+        val selected = pickerRow.selected
+        row.isSelected = selected
+        row.findViewById<View>(R.id.selected_bar).visibility =
+            if (selected) View.VISIBLE else View.INVISIBLE
+        row.findViewById<View>(R.id.selected_check).visibility =
+            if (selected) View.VISIBLE else View.GONE
+        val mainHit = row.findViewById<View>(R.id.proxy_row_main_hit)
+        val tryPickNode: () -> Boolean = {
+            val canPickLive = clashRunning && useEngineFor(profile)
+            val canPickOffline = profile.imported && profile.uuid == activeProfileUuid
+            if (canPickLive || canPickOffline) {
+                setPendingProxySelection(profile.uuid, groupName, p.name)
+                // Re-submit the list so the newly-selected and previously-selected rows rebind
+                // (the RecyclerView is data-driven; DiffUtil touches just those two rows).
+                onSelectionChanged()
+                onProxyNodeSelected(profile, groupName, p.name)
+                true
+            } else {
+                false
+            }
+        }
+        mainHit.setOnClickListener {
+            if (!tryPickNode()) {
+                onProxyYamlDetail(profile, groupName, p.name)
+            }
+        }
+        mainHit.setOnLongClickListener {
+            onProxyYamlDetail(profile, groupName, p.name)
+            true
         }
     }
+
+    private val proxyNodeDiff = object : DiffUtil.ItemCallback<ProxyPickerRow>() {
+        override fun areItemsTheSame(oldItem: ProxyPickerRow, newItem: ProxyPickerRow): Boolean =
+            oldItem.groupName == newItem.groupName && oldItem.proxy.name == newItem.proxy.name
+
+        // ProxyPickerRow is a data class — equals covers delay/selected/proxy, so DiffUtil rebinds
+        // only the rows whose delay or selection actually changed (e.g. live-ping capsule updates),
+        // which is what refreshProxyDelaysInPlace used to hand-roll.
+        override fun areContentsTheSame(oldItem: ProxyPickerRow, newItem: ProxyPickerRow): Boolean =
+            oldItem == newItem
+    }
+
+    private inner class ProxyNodeAdapter(
+        private val profile: Profile,
+        private val onSelectionChanged: () -> Unit,
+    ) : ListAdapter<ProxyPickerRow, ProxyNodeViewHolder>(proxyNodeDiff) {
+        /** Recomputed by the caller before each submit; true when the rows span more than one group. */
+        var showGroupInSubtitle: Boolean = false
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProxyNodeViewHolder {
+            val v = parent.context.layoutInflater.inflate(R.layout.adapter_home_proxy_node, parent, false)
+            return ProxyNodeViewHolder(v)
+        }
+
+        override fun onBindViewHolder(holder: ProxyNodeViewHolder, position: Int) {
+            bindProxyNodeRow(holder.itemView, profile, getItem(position), showGroupInSubtitle, onSelectionChanged)
+        }
+    }
+
+    private class ProxyNodeViewHolder(view: View) : RecyclerView.ViewHolder(view)
+
+    /**
+     * Empty-state hint for the bottom-sheet node list: distinguishes "this group has no nodes yet"
+     * (loading / connect the VPN) from "the current filter matched nothing".
+     */
+    private fun proxyPickerEmptyHint(profile: Profile, groupName: String?, groupHasNodes: Boolean): Int =
+        when {
+            groupHasNodes -> R.string.profile_proxy_empty_filtered
+            useEngineFor(profile) && !hasLiveProxyDetail(profile, groupName.orEmpty()) -> R.string.proxy_nodes_loading
+            useEngineFor(profile) -> R.string.proxy_group_empty_runtime
+            else -> R.string.proxy_nodes_empty_connect_vpn
+        }
 
     private fun buildProxyPickerRows(
         profile: Profile,
@@ -1886,12 +2000,11 @@ class ProfileAdapter(
         sheet: BottomSheetProxyGroupsBinding,
         rows: List<ProxyPickerRow>,
     ) {
-        if (rows.none { it.selected }) return
+        val index = rows.indexOfFirst { it.selected }
+        if (index < 0) return
         sheet.proxySheetNodesList.post {
-            val row = sheet.proxySheetNodesList.children.firstOrNull { child ->
-                child.findViewById<View>(R.id.selected_bar)?.visibility == View.VISIBLE
-            } ?: return@post
-            sheet.proxySheetScroll.smoothScrollTo(0, row.top)
+            (sheet.proxySheetNodesList.layoutManager as? LinearLayoutManager)
+                ?.scrollToPositionWithOffset(index, 0)
         }
     }
 

--- a/design/src/main/res/layout/bottom_sheet_proxy_groups.xml
+++ b/design/src/main/res/layout/bottom_sheet_proxy_groups.xml
@@ -324,27 +324,34 @@
         </LinearLayout>
 
         <!-- Nodes list -->
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/proxy_sheet_scroll"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="8dp"
             android:layout_weight="1"
-            android:background="@drawable/bg_proxy_list_surface"
-            android:clipToPadding="false"
-            android:overScrollMode="never"
-            android:paddingHorizontal="6dp"
-            android:paddingTop="6dp"
-            android:paddingBottom="8dp">
+            android:background="@drawable/bg_proxy_list_surface">
 
-            <LinearLayout
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/proxy_sheet_nodes_list"
                 android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:overScrollMode="never"
+                android:paddingHorizontal="6dp"
+                android:paddingTop="6dp"
+                android:paddingBottom="8dp"
+                tools:listitem="@layout/adapter_home_proxy_node" />
+
+            <TextView
+                android:id="@+id/proxy_sheet_empty"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:divider="@drawable/divider_node_hairline"
-                android:dividerPadding="14dp"
-                android:orientation="vertical"
-                android:showDividers="middle" />
-        </androidx.core.widget.NestedScrollView>
+                android:layout_gravity="center"
+                android:padding="8dp"
+                android:textColor="@color/delay_timeout"
+                android:visibility="gone"
+                tools:text="Connect the VPN to load nodes"
+                tools:visibility="visible" />
+        </FrameLayout>
     </LinearLayout>
 </layout>


### PR DESCRIPTION
## What & why

Heavy subscriptions (200+ nodes in a single url-test group) made the phone choke:
opening a group froze the UI for ~2.7s, and during a live URL-test the device
melted down. Root-caused on-device with `adb logcat` (measure, don't guess).

Three distinct causes, three fixes:

### 1. Bottom-sheet node picker — inflated all rows synchronously
`LinearLayout`-in-`ScrollView` inflated all 200 node rows on open → **163 skipped
frames (~2.7s freeze)**. Migrated to a **RecyclerView** (`ListAdapter` + `DiffUtil`):
only the ~10 visible rows are ever inflated. Live-ping delay updates now go through
`submitList`, so `DiffUtil` rebinds only the capsules that actually changed.

### 2. Inline group-block accordion — re-inflated every node on every ping tick
During a URL-test the engine pushes fresh delays ~8×/s and the card re-binds each
push; the inline node list re-inflated **all 200 rows every tick** (ContentCapture
`assumeLayout` flood = 38). Added a **structure-guard**: same node-set → patch the
delay/selection on the existing views in place; only a changed set re-inflates.
`assumeLayout` flood **38 → 0** under a live ping.

### 3. Connect warmup — url-tested every auto group at once
`warmUpAutoProxyGroups` url-tested **every** auto group on connect (200-node Auto +
region groups = 400+ node-tests concurrently) → saturated the engine, endless
"pinging" spinner + sluggish proxy switching. Replaced with **`warmUpGroupSubtree(group)`**:
warm only the group the user looks at (last-viewed on connect, then each group lazily
via `visibleGroupChanged`), once per session. The subtree walk still covers
kaso.fyi-style layouts (visible select root over a `hidden: true` url-test subtree).

Also fixed a regression from the RecyclerView migration: the row cache carried stale
`selected` flags, so picking a node didn't move the check-mark — the cache is now
invalidated on pick.