### PR TITLE
feat(theme): config-driven DayNight rework + custom accent picker

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.getSystemService
 import com.github.kr328.clash.common.compat.isAllowForceDarkCompat
 import com.github.kr328.clash.common.compat.isLightNavigationBarCompat
@@ -35,6 +36,14 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import com.github.kr328.clash.design.R
+
+/** Maps the app's darkMode choice to an AppCompat night mode (the single source of truth for the
+ *  Configuration night bit, so config-qualified resources resolve to match the chosen theme). */
+fun nightModeFor(darkMode: DarkMode): Int = when (darkMode) {
+    DarkMode.ForceLight -> AppCompatDelegate.MODE_NIGHT_NO
+    DarkMode.ForceDark -> AppCompatDelegate.MODE_NIGHT_YES
+    DarkMode.Auto -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+}
 
 abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
     CoroutineScope by MainScope(),
@@ -217,17 +226,27 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
         }
     }
 
-    fun applyThemeFromUiStore(config: Configuration = resources.configuration) {
-        applyDayNight(config)
+    /**
+     * Keep AppCompat night mode in sync with the user's darkMode. When it changes, AppCompat
+     * recreates every activity with the new Configuration — a single clean, full re-theme (this is
+     * what makes in-app dark/light switching actually take effect and never show a mixed transient).
+     * Palette / accent / true-black changes don't touch night mode; ThemeSettings recreates for those.
+     */
+    fun syncNightModeFromUiStore() {
+        val mode = nightModeFor(uiStore.darkMode)
+        if (AppCompatDelegate.getDefaultNightMode() != mode) {
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
     }
 
     private fun applyDayNight(config: Configuration = resources.configuration) {
         val dayNight = queryDayNight(config)
         val night = dayNight == DayNight.Night
-        when (dayNight) {
-            DayNight.Night -> theme.applyStyle(R.style.AppThemeDark, true)
-            DayNight.Day -> theme.applyStyle(R.style.AppThemeLight, true)
-        }
+        // Day/night is NOT faked here anymore: AppCompatDelegate night mode (set from darkMode in
+        // MainApplication + on change) drives the real Configuration, so the config-qualified base
+        // theme (BootstrapTheme -> AppThemeLight in values/, AppThemeDark in values-night/) and the
+        // values-night/ colors already resolve to the correct mode. We only layer the OPTIONAL
+        // overlays (Sloth / palette / dynamic-color / user-accent / brand / true-black) on top.
         // SlothClash skin is an exclusive look (warm surfaces + gold accent),
         // selected via the Home background picker — it owns colors, so it
         // bypasses palette / dynamic-color / true-black.
@@ -238,14 +257,22 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
                 true,
             )
         } else {
-            paletteOverlay(uiStore.themePalette, dayNight)?.let {
-                theme.applyStyle(it, true)
-            }
-            if (uiStore.dynamicColors) {
-                DynamicColors.applyToActivityIfAvailable(this)
-            }
-            if (night && uiStore.trueBlack) {
-                theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+            val accent = uiStore.customAccent
+            if (accent != null) {
+                // User custom accent: harmonise a full M3 palette from the seed (same path as the
+                // operator brand). Takes precedence over preset palette / Material You; the operator
+                // brand (applied below) still overrides it. applySeed also re-pins TrueBlack in night.
+                com.github.kr328.clash.design.branding.BrandThemeApplier.applySeed(this, accent)
+            } else {
+                paletteOverlay(uiStore.themePalette, dayNight)?.let {
+                    theme.applyStyle(it, true)
+                }
+                if (uiStore.dynamicColors) {
+                    DynamicColors.applyToActivityIfAvailable(this)
+                }
+                if (night && uiStore.trueBlack) {
+                    theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+                }
             }
         }
 
@@ -283,7 +310,6 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
             ThemePalette.Amber -> if (night) R.style.ThemeOverlay_ClashFest_PaletteAmber_Dark else R.style.ThemeOverlay_ClashFest_PaletteAmber_Light
             ThemePalette.Mint -> if (night) R.style.ThemeOverlay_ClashFest_PaletteMint_Dark else R.style.ThemeOverlay_ClashFest_PaletteMint_Light
             ThemePalette.Graphite -> if (night) R.style.ThemeOverlay_ClashFest_PaletteGraphite_Dark else R.style.ThemeOverlay_ClashFest_PaletteGraphite_Light
-            ThemePalette.Mono -> if (night) R.style.ThemeOverlay_ClashFest_PaletteMono_Dark else R.style.ThemeOverlay_ClashFest_PaletteMono_Light
         }
     }
 

--- a/app/src/main/java/com/github/kr328/clash/MainApplication.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainApplication.kt
@@ -39,6 +39,7 @@ class MainApplication : Application() {
 
         if (processName == packageName) {
             applyAppLanguage()
+            applyNightMode()
             ServiceStore.runMigrations(this)
             Remote.launch()
             setupShortcuts()
@@ -56,6 +57,18 @@ class MainApplication : Application() {
             LocaleListCompat.forLanguageTags(tag)
         }
         AppCompatDelegate.setApplicationLocales(locales)
+    }
+
+    /**
+     * Drive day/night through AppCompat's night mode so the real Configuration night bit follows the
+     * user's darkMode choice. The config-qualified base theme (BootstrapTheme -> AppThemeLight/Dark)
+     * and values-night/ colors then resolve to match the chosen mode — this is what makes a forced
+     * dark theme on a light-system device render (and not crash). Replaces the old approach of faking
+     * day/night with theme.applyStyle(AppThemeDark/Light) while leaving the config untouched.
+     */
+    private fun applyNightMode() {
+        val darkMode = runCatching { UiStore(this).darkMode }.getOrNull() ?: return
+        AppCompatDelegate.setDefaultNightMode(nightModeFor(darkMode))
     }
 
     private fun setupShortcuts() {

--- a/app/src/main/java/com/github/kr328/clash/ThemeSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ThemeSettingsActivity.kt
@@ -23,7 +23,7 @@ class ThemeSettingsActivity : BaseActivity<ThemeSettingsDesign>() {
     }
 
     override suspend fun main() {
-        fun newDesign() = ThemeSettingsDesign(this, uiStore) { applyThemeFromUiStore() }
+        fun newDesign() = ThemeSettingsDesign(this, uiStore) { syncNightModeFromUiStore() }
         var current = newDesign()
         setContentDesign(current)
 

--- a/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
@@ -16,6 +16,7 @@ import com.github.kr328.clash.design.model.ThemePalette
 import com.github.kr328.clash.design.model.ThemeTextScale
 import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.util.layoutInflater
+import com.github.kr328.clash.design.util.resolveThemedColor
 import com.github.kr328.clash.design.util.root
 import com.github.kr328.clash.design.view.ThemePaletteView
 import com.google.android.material.card.MaterialCardView
@@ -24,7 +25,7 @@ import kotlinx.coroutines.cancel
 class ThemeSettingsDesign(
     context: Context,
     private val uiStore: UiStore,
-    private val applyUiStoreThemeNow: () -> Unit,
+    private val syncNightMode: () -> Unit,
 ) : Design<ThemeSettingsDesign.Request>(context) {
     enum class Request {
         /** Reinflate Theme screen + stagger-recreate other activities (no Activity.recreate for Theme). */
@@ -40,6 +41,8 @@ class ThemeSettingsDesign(
         get() = binding.root
 
     private val paletteCards = mutableMapOf<ThemePalette, MaterialCardView>()
+    private var customAccentCard: MaterialCardView? = null
+    private var customAccentLabel: android.widget.TextView? = null
     private val recreateHandler = Handler(Looper.getMainLooper())
     private var pendingRecreateIncludesHost = false
     private val recreateRunnable = Runnable {
@@ -69,12 +72,15 @@ class ThemeSettingsDesign(
         cancel()
     }
 
-    private fun recreateAll(includeHostActivityInMassRecreate: Boolean = false) {
-        applyUiStoreThemeNow()
-        pendingRecreateIncludesHost = pendingRecreateIncludesHost || includeHostActivityInMassRecreate
+    /**
+     * A non-day/night theme change (palette, Material You, true-black, text scale, home background):
+     * recreate EVERY activity including this one, so the whole app re-themes from a clean inflate.
+     * We no longer applyStyle onto the already-drawn tree — that live merge left a mixed
+     * half-dark/half-light state. Day/night is handled by [syncNightMode] (AppCompat recreates).
+     */
+    private fun recreateAll() {
+        pendingRecreateIncludesHost = true
         recreateHandler.removeCallbacks(recreateRunnable)
-        // Activity applies theme synchronously in recreateAll; Theme screen content is swapped
-        // without Activity.recreate when possible (see ThemeSettingsActivity).
         recreateHandler.postDelayed(recreateRunnable, 240L)
     }
 
@@ -97,16 +103,25 @@ class ThemeSettingsDesign(
                 R.id.theme_mode_dark -> DarkMode.ForceDark
                 else -> DarkMode.Auto
             }
-            recreateAll(false)
+            // Day/night change: drive AppCompat night mode -> the real Configuration flips ->
+            // AppCompat recreates every activity cleanly with values-night resolved correctly.
+            syncNightMode()
         }
     }
 
     private fun setupDynamicColors() {
+        // Material You pulls colors from the wallpaper — only meaningful on Android 12+ where dynamic
+        // color exists. On older devices the toggle is a no-op, so hide it entirely rather than offer
+        // a control that does nothing.
+        if (!com.google.android.material.color.DynamicColors.isDynamicColorAvailable()) {
+            binding.dynamicColorSwitch.visibility = android.view.View.GONE
+            return
+        }
         binding.dynamicColorSwitch.isChecked = uiStore.dynamicColors
         binding.dynamicColorSwitch.setOnCheckedChangeListener { _, checked ->
             uiStore.dynamicColors = checked
             updatePaletteEnabled()
-            recreateAll(false)
+            recreateAll()
         }
     }
 
@@ -116,6 +131,8 @@ class ThemeSettingsDesign(
             paletteCards[palette] = card
             binding.themePaletteGrid.addView(card)
         }
+        // Append a "+" custom-accent tile as the last cell of the palette grid.
+        customAccentCard = createCustomAccentCard().also { binding.themePaletteGrid.addView(it) }
         updatePaletteSelection()
         updatePaletteEnabled()
     }
@@ -167,21 +184,26 @@ class ThemeSettingsDesign(
                     uiStore.homeBackgroundStyle = HomeBackgroundStyle.Preview
                     binding.homeBackgroundGroup.check(R.id.home_background_preview)
                 }
+                // Picking a preset clears any custom accent (they're mutually exclusive).
+                uiStore.customAccent = null
                 uiStore.themePalette = palette
                 updatePaletteEnabled()
                 updatePaletteSelection()
-                recreateAll(false)
+                recreateAll()
             }
         }
     }
 
     private fun updatePaletteSelection() {
+        // A custom accent overrides presets, so no preset reads as selected while one is set.
+        val presetActive = uiStore.customAccent == null
         paletteCards.forEach { (palette, card) ->
-            val checked = palette == uiStore.themePalette
+            val checked = presetActive && palette == uiStore.themePalette
             card.strokeWidth = dp(if (checked) 2 else 1)
             card.strokeColor = context.resolvePaletteStroke(palette, checked)
             ((card.getChildAt(0) as? FrameLayout)?.getChildAt(0) as? ThemePaletteView)?.checked = checked
         }
+        updateCustomAccentCard()
     }
 
     private fun updatePaletteEnabled() {
@@ -194,11 +216,178 @@ class ThemeSettingsDesign(
         }
     }
 
+    // --- Custom accent: a "+" tile appended to the palette grid. Tapping it lets the user pick any
+    //     color, which seeds the full M3 palette via the same harmoniser as the operator brand.
+    //     Overrides preset palettes / Material You; the operator brand still wins. ---
+    private fun createCustomAccentCard(): MaterialCardView {
+        val margin = dp(6)
+        val size = dp(76)
+        return MaterialCardView(context).apply {
+            layoutParams = GridLayout.LayoutParams().apply {
+                width = 0
+                height = size
+                columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f)
+                setMargins(margin, margin, margin, margin)
+            }
+            radius = dp(18).toFloat()
+            cardElevation = 0f
+            strokeWidth = dp(1)
+            isClickable = true
+            isFocusable = true
+            contentDescription = context.getString(R.string.theme_custom_accent_pick)
+            addView(
+                android.widget.TextView(context).apply {
+                    customAccentLabel = this
+                    text = "+"
+                    textSize = 26f
+                    gravity = Gravity.CENTER
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                    )
+                },
+            )
+            setOnClickListener { showCustomAccentDialog() }
+        }
+    }
+
+    private fun updateCustomAccentCard() {
+        val card = customAccentCard ?: return
+        val accent = uiStore.customAccent
+        if (accent != null) {
+            // Filled with the chosen color + a selection ring; a check reads on top for contrast.
+            card.setCardBackgroundColor(accent)
+            card.strokeWidth = dp(2)
+            card.strokeColor = context.resolveThemedColor(com.google.android.material.R.attr.colorOnSurface)
+            customAccentLabel?.apply {
+                text = "✓"
+                setTextColor(onColorFor(accent))
+            }
+        } else {
+            card.setCardBackgroundColor(context.resolveThemedColor(com.google.android.material.R.attr.colorSurfaceContainerHighest))
+            card.strokeWidth = dp(1)
+            card.strokeColor = context.resolveThemedColor(com.google.android.material.R.attr.colorOutline)
+            customAccentLabel?.apply {
+                text = "+"
+                setTextColor(context.resolveThemedColor(com.google.android.material.R.attr.colorOnSurfaceVariant))
+            }
+        }
+    }
+
+    /** Black or white, whichever contrasts better on [bg]. */
+    private fun onColorFor(bg: Int): Int {
+        val luminance = (0.299 * Color.red(bg) + 0.587 * Color.green(bg) + 0.114 * Color.blue(bg)) / 255.0
+        return if (luminance > 0.6) Color.BLACK else Color.WHITE
+    }
+
+    private fun selectAccent(color: Int) {
+        // A custom accent owns the palette, so leave Material You / Sloth (they'd override it).
+        if (uiStore.dynamicColors) {
+            uiStore.dynamicColors = false
+            binding.dynamicColorSwitch.isChecked = false
+        }
+        if (slothActive) {
+            uiStore.homeBackgroundStyle = HomeBackgroundStyle.Preview
+            binding.homeBackgroundGroup.check(R.id.home_background_preview)
+        }
+        uiStore.customAccent = color
+        updatePaletteSelection()
+        updatePaletteEnabled()
+        recreateAll()
+    }
+
+    private fun showCustomAccentDialog() {
+        val hsv = FloatArray(3)
+        Color.colorToHSV(uiStore.customAccent ?: 0xFF4CAF50.toInt(), hsv)
+
+        val svView = com.github.kr328.clash.design.view.SaturationValueView(context).apply {
+            layoutParams = android.widget.LinearLayout.LayoutParams(MATCH, dp(200))
+            setColor(hsv[0], hsv[1], hsv[2])
+        }
+        val hueView = com.github.kr328.clash.design.view.HueBarView(context).apply {
+            layoutParams = android.widget.LinearLayout.LayoutParams(MATCH, dp(26)).apply { topMargin = dp(16) }
+            hue = hsv[0]
+        }
+        val previewBg = android.graphics.drawable.GradientDrawable().apply { cornerRadius = dp(10).toFloat() }
+        val preview = View(context).apply {
+            layoutParams = android.widget.LinearLayout.LayoutParams(dp(44), dp(44))
+            background = previewBg
+        }
+        // Tap-to-edit hex field: dragging the square/bar rewrites it; typing a valid #RRGGBB drives the
+        // square/bar back. A guard flag breaks the drag<->text feedback loop.
+        val hexEdit = android.widget.EditText(context).apply {
+            layoutParams = android.widget.LinearLayout.LayoutParams(0, WRAP, 1f).apply { marginStart = dp(14) }
+            textSize = 18f
+            setTextColor(context.resolveThemedColor(com.google.android.material.R.attr.colorOnSurface))
+            setSingleLine()
+            imeOptions = android.view.inputmethod.EditorInfo.IME_ACTION_DONE
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            filters = arrayOf(android.text.InputFilter.LengthFilter(7))
+        }
+
+        var syncingFromViews = false
+        fun currentColor(): Int =
+            Color.HSVToColor(floatArrayOf(hueView.hue, svView.saturation, svView.value)) or (0xFF shl 24)
+        fun refresh() {
+            val c = currentColor()
+            previewBg.setColor(c)
+            syncingFromViews = true
+            hexEdit.setText(String.format("#%06X", 0xFFFFFF and c))
+            syncingFromViews = false
+        }
+        svView.onChanged = { _, _ -> refresh() }
+        hueView.onChanged = { h -> svView.hue = h; refresh() }
+        hexEdit.addTextChangedListener(object : android.text.TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: android.text.Editable?) {
+                if (syncingFromViews) return
+                val raw = s?.toString()?.trim().orEmpty()
+                val normalized = if (raw.startsWith("#")) raw else "#$raw"
+                if (normalized.length != 7) return
+                val parsed = runCatching { Color.parseColor(normalized) }.getOrNull() ?: return
+                val hsvOut = FloatArray(3)
+                Color.colorToHSV(parsed, hsvOut)
+                hueView.hue = hsvOut[0]
+                svView.setColor(hsvOut[0], hsvOut[1], hsvOut[2])
+                previewBg.setColor(parsed or (0xFF shl 24))
+            }
+        })
+        refresh()
+
+        val previewRow = android.widget.LinearLayout(context).apply {
+            orientation = android.widget.LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            layoutParams = android.widget.LinearLayout.LayoutParams(MATCH, WRAP).apply { topMargin = dp(18) }
+            addView(preview)
+            addView(hexEdit)
+        }
+        val content = android.widget.LinearLayout(context).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            setPadding(dp(22), dp(8), dp(22), 0)
+            addView(svView)
+            addView(hueView)
+            addView(previewRow)
+        }
+
+        com.google.android.material.dialog.MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.theme_custom_accent_dialog_title)
+            .setView(content)
+            .setPositiveButton(android.R.string.ok) { _, _ -> selectAccent(currentColor()) }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private companion object {
+        const val MATCH = android.widget.LinearLayout.LayoutParams.MATCH_PARENT
+        const val WRAP = android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+    }
+
     private fun setupTrueBlack() {
         binding.trueBlackSwitch.isChecked = uiStore.trueBlack
         binding.trueBlackSwitch.setOnCheckedChangeListener { _, checked ->
             uiStore.trueBlack = checked
-            recreateAll(false)
+            recreateAll()
         }
     }
 
@@ -219,7 +408,7 @@ class ThemeSettingsDesign(
                 R.id.text_scale_extra -> ThemeTextScale.ExtraLarge
                 else -> ThemeTextScale.Default
             }
-            recreateAll(true)
+            recreateAll()
         }
     }
 
@@ -239,7 +428,7 @@ class ThemeSettingsDesign(
                 else -> HomeBackgroundStyle.Preview
             }
             updatePaletteEnabled()
-            recreateAll(false)
+            recreateAll()
         }
     }
 
@@ -251,10 +440,14 @@ class ThemeSettingsDesign(
             uiStore.darkMode = DarkMode.Auto
             uiStore.dynamicColors = true
             uiStore.themePalette = ThemePalette.Clash
+            uiStore.customAccent = null
             uiStore.trueBlack = false
             uiStore.themeTextScale = ThemeTextScale.Default
             uiStore.homeBackgroundStyle = HomeBackgroundStyle.Preview
-            recreateAll(true)
+            // Reset also changes day/night (-> Auto), so sync night mode; recreateAll re-themes the
+            // rest and re-runs attachBaseContext for the text-scale change.
+            syncNightMode()
+            recreateAll()
         }
     }
 
@@ -267,7 +460,6 @@ class ThemeSettingsDesign(
             ThemePalette.Amber -> R.string.theme_palette_amber
             ThemePalette.Mint -> R.string.theme_palette_mint
             ThemePalette.Graphite -> R.string.theme_palette_graphite
-            ThemePalette.Mono -> R.string.theme_palette_mono
         }
 
     private val ThemePalette.previewColors: IntArray
@@ -279,7 +471,6 @@ class ThemeSettingsDesign(
             ThemePalette.Amber -> intArrayOf(0xFF8A5A00.toInt(), 0xFFFFDFA3.toInt(), 0xFFFBF2DF.toInt(), 0xFF52643B.toInt())
             ThemePalette.Mint -> intArrayOf(0xFF00856F.toInt(), 0xFFA8F2DF.toInt(), 0xFFEDF8F4.toInt(), 0xFF3E6373.toInt())
             ThemePalette.Graphite -> intArrayOf(0xFF54616F.toInt(), 0xFFD8E5F5.toInt(), 0xFFF0F3F7.toInt(), 0xFF705C73.toInt())
-            ThemePalette.Mono -> intArrayOf(0xFF5F5E62.toInt(), 0xFFE6E1E7.toInt(), 0xFFF4EFF4.toInt(), 0xFF7D5260.toInt())
         }
 
     private fun Context.resolvePaletteBackground(palette: ThemePalette): Int {

--- a/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
@@ -30,6 +30,32 @@ import com.google.android.material.color.DynamicColorsOptions
  */
 object BrandThemeApplier {
 
+    /**
+     * Apply an accent [seed] color as a Material 3 harmonised palette + neutral off-state surface pin
+     * (+ TrueBlack re-pin in night). Shared by the operator brand and the user's custom accent so both
+     * produce the same premium result. Works on every Android version (precondition overridden — the
+     * default only enables dynamic color on Android 12+).
+     */
+    fun applySeed(activity: Activity, seed: Int) {
+        DynamicColors.applyToActivityIfAvailable(
+            activity,
+            DynamicColorsOptions.Builder()
+                .setContentBasedSource(seed)
+                .setPrecondition { _, _ -> true }
+                .build(),
+        )
+        // Pin off-state surface attrs back to default M3 neutrals so disconnected / unchecked
+        // surfaces don't read as the accent.
+        activity.theme.applyStyle(R.style.ThemeOverlay_App_BrandNeutralSurfaces, true)
+        // Pure-black (OLED) must win over the neutral pin — re-apply TrueBlack surfaces right after.
+        val nightMode = (activity.resources.configuration.uiMode and
+            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+            android.content.res.Configuration.UI_MODE_NIGHT_YES
+        if (nightMode && com.github.kr328.clash.design.store.UiStore(activity).trueBlack) {
+            activity.theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+        }
+    }
+
     fun applyToActivity(activity: Activity) {
         val store = com.github.kr328.clash.service.branding.BrandStore(activity)
         val activeUuid = com.github.kr328.clash.service.store.ServiceStore(activity).activeProfile
@@ -51,29 +77,8 @@ object BrandThemeApplier {
             return
         }
 
-        // 1) Brand harmoniser → palette from seed (works on every Android version
-        //    when we override the precondition; the default precondition checks
-        //    system dynamic-color support which is Android 12+).
-        DynamicColors.applyToActivityIfAvailable(
-            activity,
-            DynamicColorsOptions.Builder()
-                .setContentBasedSource(accent)
-                .setPrecondition { _, _ -> true }
-                .build(),
-        )
-        // 2) Pin off-state surface attrs back to default M3 neutrals so
-        //    disconnected / unchecked surfaces don't read as the accent.
-        activity.theme.applyStyle(R.style.ThemeOverlay_App_BrandNeutralSurfaces, true)
-
-        // 3) Pure-black (OLED) must win over the neutral pin — re-apply TrueBlack surfaces here in
-        //    the SAME theme pass (right after the neutral pin) so grey cards don't survive on the
-        //    black canvas. Only touches surfaces/background, so the brand accent above still wins.
-        val nightMode = (activity.resources.configuration.uiMode and
-            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-            android.content.res.Configuration.UI_MODE_NIGHT_YES
-        if (nightMode && com.github.kr328.clash.design.store.UiStore(activity).trueBlack) {
-            activity.theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
-        }
+        // Harmonise the brand seed into a full M3 palette + neutral-surface pin (+ TrueBlack re-pin).
+        applySeed(activity, accent)
 
         // Mark the accent that's now baked into this Activity's theme.
         // [maybeRecreateOnAccentChange] reads this on the next dashboard tick

--- a/design/src/main/java/com/github/kr328/clash/design/model/ThemePalette.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/model/ThemePalette.kt
@@ -8,5 +8,4 @@ enum class ThemePalette {
     Amber,
     Mint,
     Graphite,
-    Mono,
 }

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -41,6 +41,23 @@ class UiStore(context: Context) {
         values = ThemePalette.values(),
     )
 
+    /** Raw backing store for [customAccent] — the ARGB int as a decimal string, "" when unset. */
+    private var customAccentRaw: String by store.string(
+        key = "custom_accent",
+        defaultValue = "",
+    )
+
+    /**
+     * User-chosen custom accent color (ARGB), or null when the user is on a preset palette / no custom
+     * accent. When set, it seeds the Material 3 harmoniser (same path as the operator brand) and takes
+     * precedence over preset palettes and Material You; the operator brand still overrides it.
+     */
+    var customAccent: Int?
+        get() = customAccentRaw.toIntOrNull()
+        set(value) {
+            customAccentRaw = value?.toString() ?: ""
+        }
+
     var trueBlack: Boolean by store.boolean(
         key = "true_black",
         defaultValue = false,

--- a/design/src/main/java/com/github/kr328/clash/design/view/HueBarView.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/view/HueBarView.kt
@@ -1,0 +1,73 @@
+package com.github.kr328.clash.design.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Shader
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * Horizontal rainbow hue bar (0..360°) with a draggable thumb. Part of the custom accent color
+ * picker; emits [onChanged] with the new hue so the [SaturationValueView] can re-tint.
+ */
+class HueBarView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : View(context, attrs) {
+
+    var hue: Float = 0f
+        set(value) {
+            field = value.coerceIn(0f, 360f)
+            invalidate()
+        }
+
+    var onChanged: ((hue: Float) -> Unit)? = null
+
+    private val barPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        color = Color.WHITE
+    }
+    private val thumbShadowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        color = 0x66000000
+    }
+
+    private val density = context.resources.displayMetrics.density
+    private val cornerPx = density * 8f
+
+    init {
+        thumbPaint.strokeWidth = density * 3f
+        thumbShadowPaint.strokeWidth = density * 4f
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        val hues = IntArray(7) { Color.HSVToColor(floatArrayOf(it * 60f, 1f, 1f)) }
+        barPaint.shader = LinearGradient(0f, 0f, w.toFloat(), 0f, hues, null, Shader.TileMode.CLAMP)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val w = width.toFloat()
+        val h = height.toFloat()
+        canvas.drawRoundRect(0f, 0f, w, h, cornerPx, cornerPx, barPaint)
+        val cx = (hue / 360f * w).coerceIn(h / 2f, w - h / 2f)
+        val r = h / 2f - density
+        canvas.drawCircle(cx, h / 2f, r, thumbShadowPaint)
+        canvas.drawCircle(cx, h / 2f, r, thumbPaint)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> parent?.requestDisallowInterceptTouchEvent(true)
+        }
+        hue = (event.x / width * 360f).coerceIn(0f, 360f)
+        onChanged?.invoke(hue)
+        invalidate()
+        return true
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/view/SaturationValueView.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/view/SaturationValueView.kt
@@ -1,0 +1,102 @@
+package com.github.kr328.clash.design.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Shader
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * Saturation × Value square for a fixed [hue]: saturation runs left→right (0..1), value runs
+ * top→bottom (1..0). A draggable dot marks the current pick. Part of the custom accent color picker;
+ * emits [onChanged] with the new (saturation, value). The parent supplies [hue] from the hue bar.
+ */
+class SaturationValueView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : View(context, attrs) {
+
+    var hue: Float = 0f
+        set(value) {
+            field = value.coerceIn(0f, 360f)
+            rebuildSaturationShader()
+            invalidate()
+        }
+
+    var saturation: Float = 1f
+        private set
+    var value: Float = 1f
+        private set
+
+    /** (saturation, value) both in 0..1, called on drag. */
+    var onChanged: ((saturation: Float, value: Float) -> Unit)? = null
+
+    private val saturationPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val valuePaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val ringPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        color = Color.WHITE
+    }
+    private val ringShadowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        color = 0x66000000
+    }
+
+    private val radiusPx = context.resources.displayMetrics.density * 12f
+    private val ringWidthPx = context.resources.displayMetrics.density * 3f
+    private val dotRadiusPx = context.resources.displayMetrics.density * 9f
+
+    init {
+        ringPaint.strokeWidth = ringWidthPx
+        ringShadowPaint.strokeWidth = ringWidthPx + context.resources.displayMetrics.density
+    }
+
+    fun setColor(hueDeg: Float, sat: Float, value: Float) {
+        this.saturation = sat.coerceIn(0f, 1f)
+        this.value = value.coerceIn(0f, 1f)
+        hue = hueDeg
+    }
+
+    private fun rebuildSaturationShader() {
+        if (width == 0) return
+        val hueColor = Color.HSVToColor(floatArrayOf(hue, 1f, 1f))
+        saturationPaint.shader = LinearGradient(
+            0f, 0f, width.toFloat(), 0f, Color.WHITE, hueColor, Shader.TileMode.CLAMP,
+        )
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        rebuildSaturationShader()
+        // Value overlay: transparent at the top, opaque black at the bottom.
+        valuePaint.shader = LinearGradient(
+            0f, 0f, 0f, h.toFloat(), Color.TRANSPARENT, Color.BLACK, Shader.TileMode.CLAMP,
+        )
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val w = width.toFloat()
+        val h = height.toFloat()
+        canvas.drawRoundRect(0f, 0f, w, h, radiusPx, radiusPx, saturationPaint)
+        canvas.drawRoundRect(0f, 0f, w, h, radiusPx, radiusPx, valuePaint)
+        val cx = (saturation * w).coerceIn(dotRadiusPx, w - dotRadiusPx)
+        val cy = ((1f - value) * h).coerceIn(dotRadiusPx, h - dotRadiusPx)
+        canvas.drawCircle(cx, cy, dotRadiusPx, ringShadowPaint)
+        canvas.drawCircle(cx, cy, dotRadiusPx, ringPaint)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> parent?.requestDisallowInterceptTouchEvent(true)
+        }
+        saturation = (event.x / width).coerceIn(0f, 1f)
+        value = (1f - event.y / height).coerceIn(0f, 1f)
+        onChanged?.invoke(saturation, value)
+        invalidate()
+        return true
+    }
+}

--- a/design/src/main/res/layout/design_main.xml
+++ b/design/src/main/res/layout/design_main.xml
@@ -857,7 +857,7 @@
                 android:visibility="gone"
                 app:cardBackgroundColor="?attr/colorSurfaceContainer"
                 app:cardCornerRadius="22dp"
-                app:cardElevation="6dp"
+                app:cardElevation="0dp"
                 app:strokeColor="@color/lumen_hairline"
                 app:strokeWidth="1dp">
 

--- a/design/src/main/res/layout/design_theme_settings.xml
+++ b/design/src/main/res/layout/design_theme_settings.xml
@@ -111,52 +111,36 @@
                     android:columnCount="4"
                     android:useDefaultMargins="false" />
 
-                <com.google.android.material.card.MaterialCardView
-                    style="@style/AppCard.Surface"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="24dp"
-                    app:cardBackgroundColor="?attr/colorSurfaceContainer"
-                    app:cardCornerRadius="20dp"
-                    app:cardElevation="0dp">
+                    android:layout_marginTop="18dp"
+                    android:baselineAligned="false"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                    <TextView
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="16dp">
+                        android:layout_weight="1"
+                        android:text="@string/theme_true_black"
+                        android:textAppearance="@style/TextAppearance.App.TitleMedium"
+                        android:textColor="?attr/colorOnSurface"
+                        android:textStyle="bold" />
 
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:baselineAligned="false"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal">
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/true_black_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
 
-                            <TextView
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_weight="1"
-                                android:text="@string/theme_true_black"
-                                android:textAppearance="@style/TextAppearance.App.TitleSmall"
-                                android:textColor="?attr/colorOnSurface"
-                                android:textStyle="bold" />
-
-                            <com.google.android.material.switchmaterial.SwitchMaterial
-                                android:id="@+id/true_black_switch"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content" />
-                        </LinearLayout>
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/theme_true_black_summary"
-                            android:textAppearance="@style/TextAppearance.App.BodySmall"
-                            android:textColor="?attr/colorOnSurfaceVariant" />
-                    </LinearLayout>
-                </com.google.android.material.card.MaterialCardView>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/theme_true_black_summary"
+                    android:textAppearance="@style/TextAppearance.App.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
 
                 <TextView
                     android:layout_width="match_parent"

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1013,6 +1013,8 @@
     <string name="theme_light">Светлая</string>
     <string name="theme_dark">Тёмная</string>
     <string name="theme_color">Цвет темы</string>
+    <string name="theme_custom_accent_pick">Свой цвет</string>
+    <string name="theme_custom_accent_dialog_title">Свой акцент</string>
     <string name="theme_dynamic_colors">Material You</string>
     <string name="theme_true_black">Чисто чёрный режим</string>
     <string name="theme_true_black_summary">Использует чёрные поверхности в тёмной теме для OLED-экранов.</string>
@@ -1029,7 +1031,6 @@
     <string name="theme_palette_amber">Янтарная</string>
     <string name="theme_palette_mint">Мятная</string>
     <string name="theme_palette_graphite">Графитовая</string>
-    <string name="theme_palette_mono">Моно</string>
     <string name="home_background_sloth">SlothClash</string>
     <!-- I18N-R2: RU backfill (design) -->
     <string name="about_app_version_label">Версия приложения</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -1043,6 +1043,8 @@
     <string name="support_url_placeholder">https://t.me/your_support_bot</string>
     <string name="theme_auto">自动</string>
     <string name="theme_color">主题颜色</string>
+    <string name="theme_custom_accent_pick">自定义颜色</string>
+    <string name="theme_custom_accent_dialog_title">自定义强调色</string>
     <string name="theme_dark">深色</string>
     <string name="theme_dynamic_colors">Material You</string>
     <string name="theme_light">浅色</string>
@@ -1052,7 +1054,6 @@
     <string name="theme_palette_clash">ClashFest</string>
     <string name="theme_palette_graphite">石墨</string>
     <string name="theme_palette_mint">薄荷</string>
-    <string name="theme_palette_mono">单色</string>
     <string name="home_background_sloth">SlothClash</string>
     <string name="theme_palette_rose">玫瑰</string>
     <string name="theme_palette_violet">紫罗兰</string>

--- a/design/src/main/res/values/colors_material3_light.xml
+++ b/design/src/main/res/values/colors_material3_light.xml
@@ -88,8 +88,10 @@
     <color name="proto_wireguard">#2E7D32</color>
     <color name="proto_default">#5F6368</color>
 
-    <!-- Lumen lux-card hairline (light: a faint dark edge). -->
-    <color name="lumen_hairline">#14000000</color>
+    <!-- Lumen lux-card hairline (light: a clearly visible dark edge so cards keep a crisp contour
+         without relying on elevation shadow. Black on a light surface reads lower-contrast than the
+         dark theme's white hairline, so it needs a higher alpha (~25%) to look equivalent). -->
+    <color name="lumen_hairline">#40000000</color>
 
     <!-- Proxy-group type chips — shared palette with SlothClash (brand unity), light variants. -->
     <color name="group_urltest">#1F7A44</color>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -1133,6 +1133,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_color">Theme color</string>
+    <string name="theme_custom_accent_pick">Custom color</string>
+    <string name="theme_custom_accent_dialog_title">Custom accent</string>
     <string name="theme_dynamic_colors">Material You</string>
     <string name="theme_true_black">Pure black mode</string>
     <string name="theme_true_black_summary">Uses black surfaces in dark mode for OLED screens.</string>
@@ -1149,7 +1151,6 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="theme_palette_amber">Amber</string>
     <string name="theme_palette_mint">Mint</string>
     <string name="theme_palette_graphite">Graphite</string>
-    <string name="theme_palette_mono">Mono</string>
     <string name="home_background_sloth">SlothClash</string>
     <!-- Companion remote control (clashctl) -->
     <string name="companion_title">Remote control</string>

--- a/design/src/main/res/values/themes.xml
+++ b/design/src/main/res/values/themes.xml
@@ -474,31 +474,6 @@
         <item name="colorTertiaryContainer">#57435A</item>
     </style>
 
-    <style name="ThemeOverlay_ClashFest_PaletteMono_Light">
-        <item name="colorPrimary">#5F5E62</item>
-        <item name="colorOnPrimary">#FFFFFF</item>
-        <item name="colorPrimaryContainer">#E6E1E7</item>
-        <item name="colorOnPrimaryContainer">#1C1B1F</item>
-        <item name="colorSecondary">#625B66</item>
-        <item name="colorSecondaryContainer">#E8DEF8</item>
-        <item name="colorTertiary">#7D5260</item>
-        <item name="colorTertiaryContainer">#FFD8E4</item>
-        <item name="colorSurfaceContainerLow">#F4EFF4</item>
-        <item name="colorSurfaceContainer">#EEE8EE</item>
-        <item name="colorSurfaceContainerHigh">#E8E2E8</item>
-    </style>
-
-    <style name="ThemeOverlay_ClashFest_PaletteMono_Dark">
-        <item name="colorPrimary">#C9C5CB</item>
-        <item name="colorOnPrimary">#312F35</item>
-        <item name="colorPrimaryContainer">#48464C</item>
-        <item name="colorOnPrimaryContainer">#E6E1E7</item>
-        <item name="colorSecondary">#CBC2CF</item>
-        <item name="colorSecondaryContainer">#4A4450</item>
-        <item name="colorTertiary">#EFB8C8</item>
-        <item name="colorTertiaryContainer">#633B48</item>
-    </style>
-
     <!-- SlothClash brand palette: warm gold accent (#C9A86C / #936B38) on a
          warm cream (light) / brown surface (dark), with an olive tertiary that
          echoes SlothClash's ok-green. -->


### PR DESCRIPTION
## Why

Forcing day/night via `theme.applyStyle(AppThemeDark/Light)` overlays on a
light base — decoupled from the system Configuration night bit — was the root
of three bugs: a launch **crash** on ForceDark over a light-system device
(`md3_dark_*` colors live only in `values-night/`), **mixed half-dark/half-light**
garbage while switching theme in-place, and shared-name colors resolving to the
wrong variant. Fixed at the foundation, no crutches.

## What

**Theme architecture (root fix)**
- Day/night now driven by `AppCompatDelegate.setDefaultNightMode` over a
  `Theme.Material3.DayNight` base → the real Configuration flips, `values-night/`
  resolves correctly. No more `applyStyle` day/night faking.
- Theme switching does a clean `recreate()` instead of live in-place restyle
  (kills the mixed-theme state).
- Removed the temporary `values/colors_material3_dark.xml` duplication crutch.

**Custom accent picker (new)**
- Visual picker: S/V square + rainbow hue bar + live preview + **tap-to-edit hex**
  (bidirectional). Seeded through the same M3 harmoniser as the operator brand.
- Precedence: brand > custom accent > Material You > preset palette.

**Theme settings polish**
- Palette grid trimmed to **2 rows**: dropped the redundant `Mono` preset;
  the custom `+` tile becomes the 8th cell.
- Material You hidden on devices below Android 12 (where it's a no-op).
- Flattened the Pure black mode card to match the other settings sections and
  evened out its spacing.

**Home**
- Announcement card: removed the elevation shadow that read as a stray frame,
  added a hairline contour instead (separate commit).

## Testing

Verified on a Pixel (arm64) via adb:
- ForceDark + a palette on a light-system device — no crash, renders fully dark.
- In-screen theme switching — no mixed half-dark/half-light state.
- Custom accent: drag + typed hex both harmonise the whole app; green→blue→rose tested.
- Grid renders 2 rows; Pure black / Material You sections styled consistently.