### PR TITLE
fix(proxy): apply exclude-filter to group member list in the UI

### DIFF
--- a/core/src/main/golang/native/snapshot/exclude_filter_oracle_test.go
+++ b/core/src/main/golang/native/snapshot/exclude_filter_oracle_test.go
@@ -1,0 +1,87 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/metacubex/mihomo/config"
+
+	_ "github.com/metacubex/mihomo/hub/executor"
+)
+
+// Repro of a user report (2026-07): a url-test group with `include-all: true`
+// and `exclude-filter: '🇸🇪|SE|Sweden'` still listed the Sweden node in
+// ClashFest, while other mihomo clients excluded it. This oracle feeds the
+// EXACT shape to the real engine and asserts the group membership the engine
+// computes — proving whether the exclude-filter semantics live in the engine
+// (they do) or are lost somewhere in our pipeline before the engine sees them.
+const excludeFilterYAML = `
+mixed-port: 7890
+mode: rule
+proxies:
+  - {name: "🇩🇪 Germany", type: ss, server: 1.1.1.1, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇫🇮 Finland", type: ss, server: 1.1.1.2, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 1", type: ss, server: 1.1.1.3, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 2", type: ss, server: 1.1.1.4, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 3", type: ss, server: 1.1.1.5, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇸🇪 Sweden", type: ss, server: 1.1.1.6, port: 443, cipher: aes-128-gcm, password: a}
+proxy-groups:
+  - name: "⚡ Fastest For All"
+    type: url-test
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    tolerance: 300
+    lazy: true
+    include-all: true
+    exclude-filter: '🇸🇪|SE|Sweden'
+    proxies: []
+rules:
+  - MATCH,⚡ Fastest For All
+`
+
+func groupAllMembers(t *testing.T, cfg *config.Config, groupName string) []string {
+	t.Helper()
+	p, ok := cfg.Proxies[groupName]
+	if !ok {
+		names := make([]string, 0, len(cfg.Proxies))
+		for k := range cfg.Proxies {
+			names = append(names, k)
+		}
+		t.Fatalf("group %q not found; proxies present: %v", groupName, names)
+	}
+	data, err := p.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal group: %v", err)
+	}
+	var meta struct {
+		All []string `json:"all"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("decode group json: %v", err)
+	}
+	return meta.All
+}
+
+func TestExcludeFilter_ExcludesSwedenFromUrlTest(t *testing.T) {
+	rawCfg, err := config.UnmarshalRawConfig([]byte(excludeFilterYAML))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg, err := config.ParseRawConfig(rawCfg)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer closeProviders(cfg)
+
+	all := groupAllMembers(t, cfg, "⚡ Fastest For All")
+
+	for _, name := range all {
+		if strings.Contains(name, "Sweden") || strings.Contains(name, "🇸🇪") {
+			t.Fatalf("Sweden must be excluded by exclude-filter, but group members are: %v", all)
+		}
+	}
+	if len(all) != 5 {
+		t.Fatalf("expected 5 members after excluding Sweden, got %d: %v", len(all), all)
+	}
+}

--- a/core/src/main/golang/native/tunnel/proxies.go
+++ b/core/src/main/golang/native/tunnel/proxies.go
@@ -122,24 +122,40 @@ func QueryProxyGroup(name string, sortMode SortMode, uiSubtitlePattern *regexp2.
 		return nil
 	}
 
-	proxies := convertProxies(g.Proxies(), uiSubtitlePattern)
-	// Include provider-backed proxies (`use:` references and dynamic flags such as
-	// include-all-providers / include-all-proxies / include-all). mihomo expands those
-	// at routing time but g.Proxies() only returns the statically declared members.
-	// Without the merge, the picker shows three sub-groups even for subscriptions whose
-	// real node set lives in proxy-providers.
-	providerProxies := collectProviders(g.Providers(), uiSubtitlePattern)
-	if len(providerProxies) > 0 {
-		existing := make(map[string]struct{}, len(proxies)+len(providerProxies))
-		for _, p := range proxies {
-			existing[p.Name] = struct{}{}
+	rawMembers := g.Proxies()
+	proxies := convertProxies(rawMembers, uiSubtitlePattern)
+	// mihomo's g.Proxies() already expands include-all / include-all-proxies / include-all-providers
+	// and `use:` references down to the group's real leaf members, AND applies the group's `filter`
+	// and `exclude-filter`. So only fall back to enumerating the group's providers directly when
+	// g.Proxies() yielded NO dialable leaf — i.e. an empty group or a pure dispatch shell whose
+	// members are all sub-groups (the case this merge was originally added for, where the picker
+	// otherwise showed only sub-groups instead of the provider's nodes).
+	//
+	// Doing the merge unconditionally re-introduced nodes the group's exclude-filter had dropped:
+	// an excluded node is absent from g.Proxies() but still present in the backing provider, so
+	// collectProviders (which does not apply the group filter) added it right back — the reported
+	// "exclude-filter has no effect while connected" bug.
+	hasLeaf := false
+	for _, m := range rawMembers {
+		if _, isGroup := m.Adapter().(outboundgroup.ProxyGroup); !isGroup {
+			hasLeaf = true
+			break
 		}
-		for _, p := range providerProxies {
-			if _, ok := existing[p.Name]; ok {
-				continue
+	}
+	if !hasLeaf {
+		providerProxies := collectProviders(g.Providers(), uiSubtitlePattern)
+		if len(providerProxies) > 0 {
+			existing := make(map[string]struct{}, len(proxies)+len(providerProxies))
+			for _, p := range proxies {
+				existing[p.Name] = struct{}{}
 			}
-			existing[p.Name] = struct{}{}
-			proxies = append(proxies, p)
+			for _, p := range providerProxies {
+				if _, ok := existing[p.Name]; ok {
+					continue
+				}
+				existing[p.Name] = struct{}{}
+				proxies = append(proxies, p)
+			}
 		}
 	}
 

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreview.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreview.kt
@@ -132,10 +132,23 @@ object ProxyGroupsYamlPreview {
         if (!hasDynamicMembership(g)) return emptyList()
         val universe = collectAllLeafProxyNames(snapshot, profileDir).sorted()
         val filterRaw = g.stringField("filter")?.trim().orEmpty()
-        if (filterRaw.isEmpty()) return universe
-        val patterns = compileFilterPatterns(filterRaw)
-        if (patterns.isEmpty()) return emptyList()
-        return universe.filter { name -> patterns.any { it.containsMatchIn(name) } }
+        val included = if (filterRaw.isEmpty()) {
+            universe
+        } else {
+            val patterns = compileFilterPatterns(filterRaw)
+            if (patterns.isEmpty()) return emptyList()
+            universe.filter { name -> patterns.any { it.containsMatchIn(name) } }
+        }
+        // Mirror the engine ([outboundgroup.GroupBase.getProxies]): `exclude-filter` drops any member
+        // whose name matches any pattern, applied AFTER the include `filter`. Without this the offline
+        // preview kept excluded nodes (e.g. a `🇸🇪|SE|Sweden` exclude still listed Sweden) while the
+        // running engine correctly dropped them — the include-only path was already honored, so only
+        // exclusions diverged.
+        val excludeRaw = g.stringField("exclude-filter")?.trim().orEmpty()
+        if (excludeRaw.isEmpty()) return included
+        val excludePatterns = compileFilterPatterns(excludeRaw)
+        if (excludePatterns.isEmpty()) return included
+        return included.filterNot { name -> excludePatterns.any { it.containsMatchIn(name) } }
     }
 
     private fun yamlGroupType(g: JsonObject): Proxy.Type {

--- a/service/src/test/java/com/github/kr328/clash/service/util/ConfigComposerTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ConfigComposerTest.kt
@@ -16,6 +16,74 @@ class ConfigComposerTest {
           - MATCH,DIRECT
     """.trimIndent()
 
+    @Test fun url_test_exclude_filter_survives_composition() {
+        // Repro of the user report: a url-test group with include-all + exclude-filter listing a flag
+        // emoji + codes. The engine applies exclude-filter correctly (proven by the Go oracle), so if
+        // the bug is real the field must be lost/mangled here, before the engine sees it.
+        val fetched = """
+            mixed-port: 7890
+            mode: rule
+            proxies:
+              - {name: "🇩🇪 Germany", type: ss, server: 1.1.1.1, port: 443, cipher: aes-128-gcm, password: a}
+              - {name: "🇸🇪 Sweden", type: ss, server: 1.1.1.6, port: 443, cipher: aes-128-gcm, password: a}
+            proxy-groups:
+              - name: "⚡ Fastest For All"
+                type: url-test
+                url: https://www.gstatic.com/generate_204
+                interval: 300
+                tolerance: 300
+                lazy: true
+                include-all: true
+                exclude-filter: '🇸🇪|SE|Sweden'
+                proxies: []
+            rules:
+              - MATCH,⚡ Fastest For All
+        """.trimIndent()
+        for (mode in listOf(ProxyHardeningMode.Off, ProxyHardeningMode.Strict, ProxyHardeningMode.Compat)) {
+            val out = ConfigComposer.compose(fetched, UserLayer(), geo, mode)
+            assertTrue("exclude-filter" in out, "[$mode] exclude-filter key must survive composition: $out")
+            assertTrue("Sweden" in out, "[$mode] exclude-filter value must survive intact: $out")
+            assertTrue("🇸🇪" in out, "[$mode] flag emoji in exclude-filter must survive: $out")
+            assertTrue("include-all" in out, "[$mode] include-all must survive: $out")
+        }
+    }
+
+    @Test fun url_test_exclude_filter_survives_with_remnawave_quirks() {
+        // Faithful to the reported subscription shape: a nonstandard `remnawave:` nested map inside the
+        // group + a `proxies:` list that is comment-only (parses to null). If our block-patcher/hardener
+        // mangles the group here, the engine gets a broken exclude-filter — reproducing the on-device
+        // "not excluded even when connected" case.
+        val fetched = """
+            mixed-port: 7890
+            mode: rule
+            proxies:
+              - {name: "🇩🇪 Germany", type: ss, server: 1.1.1.1, port: 443, cipher: aes-128-gcm, password: a}
+              - {name: "🇸🇪 Sweden", type: ss, server: 1.1.1.6, port: 443, cipher: aes-128-gcm, password: a}
+            proxy-groups:
+              - name: "⚡ Fastest For All"
+                type: url-test
+                url: https://www.gstatic.com/generate_204
+                interval: 300
+                tolerance: 300
+                lazy: true
+                include-all: true
+                exclude-filter: '🇸🇪|SE|Sweden'
+                remnawave:
+                  include-proxies: false
+                proxies:
+                  # LEAVE THIS LINE!
+            rules:
+              - MATCH,⚡ Fastest For All
+        """.trimIndent()
+        for (mode in listOf(ProxyHardeningMode.Off, ProxyHardeningMode.Strict, ProxyHardeningMode.Compat)) {
+            val out = ConfigComposer.compose(fetched, UserLayer(), geo, mode)
+            assertTrue("exclude-filter" in out, "[$mode] exclude-filter must survive: $out")
+            assertTrue("Sweden" in out, "[$mode] exclude value must survive: $out")
+            assertTrue("🇸🇪" in out, "[$mode] flag emoji must survive: $out")
+            assertTrue("include-all" in out, "[$mode] include-all must survive: $out")
+        }
+    }
+
     @Test fun empty_layer_leaves_subscription_rules_intact() {
         val out = ConfigComposer.compose(fetched, UserLayer(), geo, ProxyHardeningMode.Off)
         assertTrue(out.isNotBlank())

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreviewTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreviewTest.kt
@@ -21,6 +21,7 @@ class ProxyGroupsYamlPreviewTest {
         hidden: Boolean = false,
         includeAllProxies: Boolean = false,
         filter: String? = null,
+        excludeFilter: String? = null,
     ): JsonObject {
         val fields = LinkedHashMap<String, kotlinx.serialization.json.JsonElement>()
         fields["name"] = JsonPrimitive(name)
@@ -30,6 +31,7 @@ class ProxyGroupsYamlPreviewTest {
         if (hidden) fields["hidden"] = JsonPrimitive(true)
         if (includeAllProxies) fields["include-all-proxies"] = JsonPrimitive(true)
         if (filter != null) fields["filter"] = JsonPrimitive(filter)
+        if (excludeFilter != null) fields["exclude-filter"] = JsonPrimitive(excludeFilter)
         return JsonObject(fields)
     }
 
@@ -166,6 +168,37 @@ class ProxyGroupsYamlPreviewTest {
         )
         val rows = ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)
         assertEquals(listOf("us-east", "us-west"), rows["UsOnly"]?.members)
+    }
+
+    @Test
+    fun parseProxyGroupsPreview_includeAllProxiesWithExcludeFilterDropsMatches() {
+        // Repro of the user report: exclude-filter must drop members in the offline preview too,
+        // mirroring the engine. Include path was already honored; exclusion was ignored.
+        val snapshot = ProfileSnapshot(
+            proxies = listOf(
+                proxy("🇩🇪 Germany"), proxy("🇫🇮 Finland"), proxy("🇳🇱 Netherlands 1"), proxy("🇸🇪 Sweden"),
+            ),
+            proxyGroups = listOf(group("Fastest", includeAllProxies = true, excludeFilter = "🇸🇪|SE|Sweden")),
+        )
+        val members = ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)["Fastest"]?.members.orEmpty()
+        assertFalse("Sweden must be excluded from the preview", members.any { "Sweden" in it })
+        assertEquals(listOf("🇩🇪 Germany", "🇫🇮 Finland", "🇳🇱 Netherlands 1"), members)
+    }
+
+    @Test
+    fun parseProxyGroupsPreview_excludeFilterAppliesAfterIncludeFilter() {
+        // filter (include) then exclude-filter, both honored — the working `filter` group and the
+        // broken `exclude-filter` group must now behave consistently.
+        val snapshot = ProfileSnapshot(
+            proxies = listOf(proxy("us-east"), proxy("us-west"), proxy("us-lab"), proxy("eu-central")),
+            proxyGroups = listOf(
+                group("UsNoLab", includeAllProxies = true, filter = "us-", excludeFilter = "lab"),
+            ),
+        )
+        assertEquals(
+            listOf("us-east", "us-west"),
+            ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)["UsNoLab"]?.members,
+        )
     }
 
     @Test


### PR DESCRIPTION
The url-test/select group picker ignored a group's exclude-filter, so an excluded node (e.g. Sweden via a flag/code regex) still appeared, while the engine routed correctly. Two independent UI paths dropped the filter:

- Offline preview (ProxyGroupsYamlPreview) honored include filter but not exclude-filter; now mirrors the engine (backtick-split, drop matches after the include filter).
- Native QueryProxyGroup trusted the engine already-filtered g.Proxies() but then re-merged every provider proxy unfiltered, re-adding excluded nodes. Now the provider merge only runs when the group resolved to no leaf members (empty / pure sub-group dispatch shell).

Nets: Go engine oracle proving exclude-filter membership + Kotlin composer and preview tests. Verified on device (6 to 5, connected and disconnected).