### PR TITLE
fix(home): populate the Node row on connect without opening the picker

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -1219,6 +1219,22 @@ class MainActivity : BaseActivity<MainDesign>() {
         )
         if (!running || activeUuid == null || proxyNames.isEmpty()) {
             clearProxyDetails()
+        } else {
+            // After connect the Home "Node" row needs the active profile's summary group's live
+            // `now`, but nothing queries it until the user opens the picker — so it stayed blank for
+            // seconds. Prime just that one group (O-07-safe: a single query, not a blanket warmup),
+            // and only when it isn't already cached, so this is effectively one-shot per connect
+            // rather than a per-refresh engine hit.
+            val summaryGroup = active?.let { summaryGroupFor(it) }
+            if (!summaryGroup.isNullOrBlank() && !hasLiveDetailForGroup(summaryGroup)) {
+                val primed = refreshRuntimeGroupDetails(setOf(summaryGroup))
+                if (primed.isNotEmpty()) {
+                    patchProxyDetails(primed)
+                    // The Home node row was already bound above with empty details; re-render it now
+                    // that the summary group's `now` is loaded so it fills without user interaction.
+                    patchProfiles(profiles)
+                }
+            }
         }
         syncThemeToggleIcon(uiStore.darkMode)
 

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -1186,6 +1186,12 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         }
     }
 
+    /** Group whose selection the Home "Node" row summarises for [profile] (for connect-time priming). */
+    fun summaryGroupFor(profile: Profile): String? = profileAdapter.summaryGroupForProfile(profile)
+
+    /** True when live engine detail for [groupName] is already cached (skip the connect-time prime). */
+    fun hasLiveDetailForGroup(groupName: String): Boolean = profileAdapter.hasLiveDetailForGroup(groupName)
+
     suspend fun patchSingleProxyDelay(group: String, proxy: String, delayMs: Int) {
         withContext(Dispatchers.Main) {
             profileAdapter.patchSingleProxyDelay(group, proxy, delayMs)

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -591,6 +591,17 @@ class ProfileAdapter(
     fun activeNodeDisplayName(profile: Profile): String? =
         resolveCurrentNodeDisplayName(profile)?.takeIf { it.isNotBlank() }
 
+    /**
+     * The proxy group whose current selection the Home "Node" summary displays for [profile].
+     * Callers (MainActivity) use this to prime that one group's live detail on connect so the row
+     * isn't blank until the user opens the picker.
+     */
+    fun summaryGroupForProfile(profile: Profile): String? = selectedGroupForSummary(profile)
+
+    /** True when live engine detail (carrying `now`) is already cached for [groupName]. */
+    fun hasLiveDetailForGroup(groupName: String): Boolean =
+        proxyDetails[groupName] != null || proxyDetails.keys.any { groupsMatchKey(groupName, it) }
+
     private fun groupsForSelectionSummary(profile: Profile): List<String> {
         if (!profile.imported) return emptyList()
         return if (useEngineFor(profile)) {


### PR DESCRIPTION
After connect the Home Node row stayed blank for seconds: the live `now` of the summary group was only queried when the user opened the proxy picker (which expands the profile and triggers the group fetch). Now fetch() primes just that one summary group's detail on connect — guarded so it runs once (skipped when the group is already cached), keeping the O-07 lazy-warmup contract — and re-renders the row so it fills on its own.