### PR TITLE
feat(rules): REMATCH-NAME support + unknown proxy-type crash fix

### DIFF
--- a/core/src/main/java/com/github/kr328/clash/core/model/Proxy.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/Proxy.kt
@@ -3,7 +3,12 @@ package com.github.kr328.clash.core.model
 import android.os.Parcel
 import android.os.Parcelable
 import com.github.kr328.clash.core.util.Parcelizer
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 data class Proxy(
@@ -14,12 +19,15 @@ data class Proxy(
     val delay: Int,
 ) : Parcelable {
     @Suppress("unused")
+    @Serializable(with = Type.FallbackSerializer::class)
     enum class Type(val group: Boolean) {
         Direct(false),
         Reject(false),
         RejectDrop(false),
         Compatible(false),
         Pass(false),
+        PassRule(false),
+        Rematch(false),
 
         Shadowsocks(false),
         ShadowsocksR(false),
@@ -40,6 +48,9 @@ data class Proxy(
         Sudoku(false),
         Masque(false),
         TrustTunnel(false),
+        OpenVPN(false),
+        Tailscale(false),
+        GostRelay(false),
 
 
         Relay(true),
@@ -49,6 +60,27 @@ data class Proxy(
         LoadBalance(true),
 
         Unknown(false);
+
+        /**
+         * Decodes adapter-type names the app does not know yet to [Unknown]
+         * instead of throwing. mihomo grows outbound types faster than this
+         * enum tracks them (Rematch arrived in v1.19.28; OpenVPN, Tailscale
+         * and GostRelay were already missing) — with the default enum
+         * serializer a group containing a single member of an untracked type
+         * failed the whole [com.github.kr328.clash.core.Clash.queryGroup]
+         * decode with a SerializationException and blanked the proxy screen.
+         */
+        internal object FallbackSerializer : KSerializer<Type> {
+            override val descriptor =
+                PrimitiveSerialDescriptor("com.github.kr328.clash.core.model.Proxy.Type", PrimitiveKind.STRING)
+
+            override fun serialize(encoder: Encoder, value: Type) = encoder.encodeString(value.name)
+
+            override fun deserialize(decoder: Decoder): Type {
+                val name = decoder.decodeString()
+                return entries.firstOrNull { it.name.equals(name, ignoreCase = true) } ?: Unknown
+            }
+        }
     }
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/core/src/test/java/com/github/kr328/clash/core/model/ProxyTypeFallbackTest.kt
+++ b/core/src/test/java/com/github/kr328/clash/core/model/ProxyTypeFallbackTest.kt
@@ -1,0 +1,50 @@
+package com.github.kr328.clash.core.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [Proxy.Type.FallbackSerializer] guards the JNI JSON decode path
+ * ([com.github.kr328.clash.core.Clash.queryGroup]): the Go side sends
+ * `p.Type().String()` verbatim, so every mihomo outbound type the enum does
+ * not list yet must decode to [Proxy.Type.Unknown] instead of throwing a
+ * SerializationException and blanking the proxy screen (a group with a single
+ * Rematch/OpenVPN/Tailscale member used to fail the whole group decode).
+ */
+class ProxyTypeFallbackTest {
+
+    private fun decodeProxy(type: String): Proxy = Json.decodeFromString(
+        Proxy.serializer(),
+        """{"name":"n","title":"t","subtitle":"s","type":"$type","delay":0}""",
+    )
+
+    @Test
+    fun known_types_decode_exactly() {
+        assertEquals(Proxy.Type.Selector, decodeProxy("Selector").type)
+        assertEquals(Proxy.Type.Vless, decodeProxy("Vless").type)
+        assertEquals(Proxy.Type.Rematch, decodeProxy("Rematch").type)
+        assertEquals(Proxy.Type.PassRule, decodeProxy("PassRule").type)
+        assertEquals(Proxy.Type.OpenVPN, decodeProxy("OpenVPN").type)
+        assertEquals(Proxy.Type.Tailscale, decodeProxy("Tailscale").type)
+        assertEquals(Proxy.Type.GostRelay, decodeProxy("GostRelay").type)
+    }
+
+    @Test
+    fun unknown_type_falls_back_instead_of_throwing() {
+        assertEquals(Proxy.Type.Unknown, decodeProxy("SomeFutureMihomoType").type)
+    }
+
+    @Test
+    fun decode_is_case_insensitive() {
+        // mihomo's String() casing is stable today, but a fallback path should
+        // not depend on it.
+        assertEquals(Proxy.Type.URLTest, decodeProxy("urltest").type)
+    }
+
+    @Test
+    fun encode_uses_enum_name() {
+        val json = Json.encodeToString(Proxy.serializer(), Proxy("n", "t", "s", Proxy.Type.Rematch, 0))
+        assertEquals(true, json.contains("\"Rematch\""))
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/util/RuleTypeCatalog.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/util/RuleTypeCatalog.kt
@@ -92,6 +92,11 @@ object RuleTypeCatalog {
         "DOMAIN-REGEX", "IP-CIDR6", "IP-SUFFIX", "IP-ASN", "SRC-IP-CIDR", "SRC-PORT",
         "IN-PORT", "IN-TYPE", "IN-NAME", "PROCESS-PATH", "PROCESS-NAME-REGEX",
         "UID", "DSCP", "RULE-SET",
+        // Matches connections remarked by a `type: rematch` outbound (mihomo
+        // v1.19.28+): value = the rematch mark name, policy = where they go on
+        // the second pass. Only meaningful when the config declares a rematch
+        // proxy, hence advanced.
+        "REMATCH-NAME",
     ).map { type ->
         val numeric = type in setOf("SRC-PORT", "IN-PORT", "UID", "DSCP")
         RuleTypeMeta(
@@ -101,6 +106,7 @@ object RuleTypeCatalog {
             validate = when (type) {
                 "SRC-PORT", "IN-PORT" -> ::port
                 "SRC-IP-CIDR" -> ::cidr
+                "REMATCH-NAME" -> ::nonEmptyNoSep
                 else -> { v -> if (v.isBlank()) RuleValueError.EMPTY else null }
             },
         )

--- a/design/src/main/java/com/github/kr328/clash/design/util/RuleTypeIcons.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/util/RuleTypeIcons.kt
@@ -12,7 +12,7 @@ object RuleTypeIcons {
         "DST-PORT", "SRC-PORT", "IN-PORT" -> R.drawable.ic_baseline_bolt
         "PROCESS-NAME", "PROCESS-PATH", "PROCESS-NAME-REGEX" -> R.drawable.ic_baseline_get_app
         "NETWORK", "IN-TYPE" -> R.drawable.ic_baseline_route
-        "MATCH" -> R.drawable.ic_baseline_filter_list
+        "MATCH", "REMATCH-NAME" -> R.drawable.ic_baseline_filter_list
         else -> R.drawable.ic_baseline_extension
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/RuleMapperTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/RuleMapperTest.kt
@@ -305,6 +305,23 @@ class RuleMapperTest {
     }
 
     @Test
+    fun parseRuleLine_rematchName_roundTrips() {
+        // REMATCH-NAME (mihomo v1.19.28) is a plain three-part rule: value = the
+        // rematch mark, policy = second-pass target. It must survive our pipeline
+        // as a regular rule (not opaque, not stripped) and re-render byte-identical.
+        val line = "REMATCH-NAME,my-mark,Proxy-Selector"
+        val rule = RuleMapper.parseRuleLine(line, 0, defaultSource = RuleSource.PROVIDER)
+
+        assertNotNull(rule)
+        rule!!
+        assertEquals("REMATCH-NAME", rule.type)
+        assertEquals("my-mark", rule.value)
+        assertEquals("Proxy-Selector", rule.policy)
+        assertEquals(RuleSource.PROVIDER, rule.source)
+        assertEquals(line, RuleMapper.toRuleLine(rule))
+    }
+
+    @Test
     fun parseRuleLine_returnsNullForBlank() {
         assertEquals(null, RuleMapper.parseRuleLine("", 0))
         assertEquals(null, RuleMapper.parseRuleLine("   ", 0))


### PR DESCRIPTION
mihomo v1.19.28 added the Rematch outbound and REMATCH-NAME rule. Audit of our pipeline found the real hazard: Proxy.Type is decoded from the JNI JSON with the default enum serializer, so ANY adapter type the enum does not list threw a SerializationException and blanked the proxy screen - Rematch, PassRule, OpenVPN, Tailscale and GostRelay were all missing. Add the missing entries and a fallback serializer that degrades future unknown types to Unknown instead of throwing (upstream hit the same bug and dropped the enum entirely; we keep the type-safe enum since our UI switches on it).

Rule editor: REMATCH-NAME added to the advanced type list with a no-separator value validator and the MATCH-family icon. RuleMapper/RuleValidator already handle it as a plain three-part rule - locked in by a round-trip test.