### PR TITLE
Feat/userinfo in go

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -1962,11 +1962,21 @@ class MainActivity : BaseActivity<MainDesign>() {
         meta.subscriptionUserinfo?.let { uiStore.subscriptionUserinfo = it }
         meta.profileWebPageUrl?.let { uiStore.profileWebPageUrl = it }
         meta.profileUpdateIntervalHours?.let { hours ->
+            val previousHeaderMs =
+                java.util.concurrent.TimeUnit.HOURS.toMillis(uiStore.profileUpdateIntervalHours.toLong())
             uiStore.profileUpdateIntervalHours = hours
             if (!uiStore.subscriptionMetadataLockUser) {
-                val ms = java.util.concurrent.TimeUnit.HOURS.toMillis(hours.toLong())
-                runCatching {
-                    withProfile { applySubscriptionUpdateInterval(active.uuid, ms) }
+                // The header only *seeds* the interval — it must not override a value
+                // the user set by hand (upstream 71cb215d class of bug: the panel
+                // silently reverted a custom interval every metadata sync). Apply it
+                // only when auto-update is unconfigured, or the current interval is
+                // the one WE derived from the previous header value (i.e. untouched).
+                val userCustomized = active.interval != 0L && active.interval != previousHeaderMs
+                if (!userCustomized) {
+                    val ms = java.util.concurrent.TimeUnit.HOURS.toMillis(hours.toLong())
+                    runCatching {
+                        withProfile { applySubscriptionUpdateInterval(active.uuid, ms) }
+                    }
                 }
             }
         }

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -34,16 +34,18 @@ type providerFetchTask struct {
 	path string
 }
 
-func openUrl(ctx context.Context, url string) (io.ReadCloser, error) {
+func openUrl(ctx context.Context, url string) (io.ReadCloser, map[string][]string, error) {
 	base := http.Header{"User-Agent": {"ClashMetaForAndroid/" + app.VersionName()}}
 	hdr := app.MergeSubscriptionFetchHeaders(base)
 	response, err := clashHttp.HttpRequest(ctx, url, http.MethodGet, hdr, nil)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return response.Body, nil
+	// Plain map type: mihomo's forked metacubex/http.Header and net/http.Header
+	// are distinct named types over the same underlying map.
+	return response.Body, response.Header, nil
 }
 
 func openContent(url string) (io.ReadCloser, error) {
@@ -65,16 +67,22 @@ const (
 // the main subscription is one critical fetch and gets generous room for slow
 // CDNs / DPI, while each rule-/proxy-provider runs on a short budget so a stuck
 // provider can't hold up the (parallel, see [fetchProviders]) import.
-func fetch(url *U.URL, file string, timeout time.Duration) error {
+//
+// For http(s) URLs the response headers are returned too (nil for content://
+// and on error) — the subscription fetch persists them via [writeFetchHeaders]
+// so the Kotlin side can read subscription-userinfo / X-Brand-* / naming
+// headers without issuing a second GET of its own.
+func fetch(url *U.URL, file string, timeout time.Duration) (map[string][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	var reader io.ReadCloser
+	var header map[string][]string
 	var err error
 
 	switch url.Scheme {
 	case "http", "https":
-		reader, err = openUrl(ctx, url.String())
+		reader, header, err = openUrl(ctx, url.String())
 	case "content":
 		reader, err = openContent(url.String())
 	default:
@@ -82,7 +90,7 @@ func fetch(url *U.URL, file string, timeout time.Duration) error {
 	}
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer reader.Close()
@@ -91,7 +99,7 @@ func fetch(url *U.URL, file string, timeout time.Duration) error {
 
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer f.Close()
@@ -99,9 +107,47 @@ func fetch(url *U.URL, file string, timeout time.Duration) error {
 	_, err = io.Copy(f, reader)
 	if err != nil {
 		_ = os.Remove(file)
+		return nil, err
 	}
 
-	return err
+	return header, nil
+}
+
+// FetchHeadersFileName is the per-profile snapshot of the subscription
+// response headers, written next to config.yaml on every successful
+// subscription download. One flat JSON object, keys lowercased, multi-value
+// headers joined the HTTP way (", "). The Kotlin side feeds it to the same
+// header parsers (usage / brand / display-name) that used to run against a
+// SECOND OkHttp GET of the subscription — that extra request doubled traffic
+// (panels count fetches against quota), raced the primary download, and kept
+// a whole parallel header path alive (the mojibake class of bugs).
+const FetchHeadersFileName = "fetch-headers.json"
+
+func writeFetchHeaders(profilePath string, header map[string][]string) {
+	file := P.Join(profilePath, FetchHeadersFileName)
+
+	if header == nil {
+		// content:// / inline imports have no HTTP response; drop any stale
+		// snapshot from a previous source so consumers don't read old quota.
+		_ = os.Remove(file)
+		return
+	}
+
+	flat := make(map[string]string, len(header))
+	for key, values := range header {
+		if len(values) == 0 {
+			continue
+		}
+		flat[strings.ToLower(key)] = strings.Join(values, ", ")
+	}
+
+	bytes, err := json.Marshal(flat)
+	if err != nil {
+		return
+	}
+
+	// Best-effort: header persistence must never fail the import itself.
+	_ = os.WriteFile(file, bytes, 0600)
 }
 
 func FetchAndValid(
@@ -126,6 +172,8 @@ func FetchAndValid(
 		if err := writeConfigFromMierusShare(configPath, trimmed); err != nil {
 			return err
 		}
+
+		writeFetchHeaders(path, nil)
 	} else if _, err := os.Stat(configPath); os.IsNotExist(err) || force {
 		parsed, err := U.Parse(url)
 		if err != nil {
@@ -141,9 +189,12 @@ func FetchAndValid(
 
 		reportStatus(string(bytes))
 
-		if err := fetch(parsed, configPath, subscriptionFetchTimeout); err != nil {
+		header, err := fetch(parsed, configPath, subscriptionFetchTimeout)
+		if err != nil {
 			return err
 		}
+
+		writeFetchHeaders(path, header)
 	}
 
 	defer runtime.GC()
@@ -298,7 +349,9 @@ func fetchProviders(rawCfg *config.RawConfig, force bool, reportStatus func(stri
 			// behaviour): a missing rule-provider should not abort the whole
 			// import — the user can still activate the profile and the
 			// provider re-fetches on the next FetchProvidersAndValid pass.
-			_ = fetch(t.url, t.path, providerFetchTimeout)
+			// Provider response headers are irrelevant (only the subscription
+			// fetch persists them, see writeFetchHeaders).
+			_, _ = fetch(t.url, t.path, providerFetchTimeout)
 
 			current := atomic.AddInt32(&done, 1)
 			bytes, _ := json.Marshal(&Status{

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -19,11 +19,6 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     implementation(libs.kaidl.runtime)
     implementation(libs.rikkax.multiprocess)
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.12.0"))
-
-    // define any required OkHttp artifacts without version
-    implementation("com.squareup.okhttp3:okhttp")
-    implementation("com.squareup.okhttp3:logging-interceptor")
     implementation("org.yaml:snakeyaml:2.2")
 
     testImplementation("junit:junit:4.13.2")

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -3,8 +3,6 @@ package com.github.kr328.clash.service
 import android.content.Context
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.common.util.SubscriptionNameGuesser
-import com.github.kr328.clash.common.util.SubscriptionOverrides
-import com.github.kr328.clash.common.util.SubscriptionRequestHeaders
 import com.github.kr328.clash.common.util.SubscriptionUsage
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ProfileSnapshot
@@ -29,6 +27,7 @@ import com.github.kr328.clash.service.util.DnsHostsConfig
 import com.github.kr328.clash.service.util.DnsHostsYamlEdit
 import com.github.kr328.clash.service.util.TunnelsConfig
 import com.github.kr328.clash.service.util.TunnelsYamlEdit
+import com.github.kr328.clash.service.util.FetchHeadersFile
 import com.github.kr328.clash.service.util.directoryLastModified
 import com.github.kr328.clash.service.util.generateProfileUUID
 import com.github.kr328.clash.service.util.ProfileComposer
@@ -57,8 +56,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.File
 import java.io.FileNotFoundException
 import java.util.*
@@ -404,72 +401,67 @@ class ProfileManager(private val context: Context) : IProfileManager,
     }
 
     suspend fun updateFlow(old: Imported) {
-        val client = OkHttpClient()
         try {
-            val request = Request.Builder()
-                .url(old.source)
-                .apply {
-                    SubscriptionRequestHeaders.build(
-                        context,
-                        SubscriptionOverrides.getUserAgent(context, old.uuid),
-                    ).forEach { (k, v) ->
-                        header(k, v)
-                    }
-                }
-                .build()
+            // ProfileProcessor.update just re-downloaded the subscription; the Go
+            // fetch persisted the response headers next to config.yaml
+            // (fetch-headers.json). Re-requesting the panel here — the old OkHttp
+            // GET — doubled traffic (panels count fetches against quota), could
+            // race the primary download, and kept a second header-decoding path
+            // alive. Absent snapshot = no HTTP response observed (content:// or a
+            // failed fetch) — same early-return the old `!response.isSuccessful`
+            // gave us.
+            val headers = FetchHeadersFile.readFrom(context.importedDir.resolve(old.uuid.toString()))
+                ?: return
 
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return
+            // Operator brand parses independently of subscription-userinfo —
+            // panels that don't carry quota (free tiers, custom auth flows)
+            // still need to brand the app. We do this BEFORE the
+            // subscription-userinfo early-return so brand survives even
+            // when the panel stops sending quota headers.
+            val brand = com.github.kr328.clash.common.branding.BrandManifestParser.parseHttpHeaders { key ->
+                headers.get(key)
+            }
+            // confirmedResponse=true: the header snapshot only exists for a fetch
+            // that completed AND passed engine validation (update() succeeded), so
+            // an empty brand here is a real "served the sub with no X-Brand-*
+            // headers" signal (not a transient failure) and feeds the debounced
+            // auto-clear.
+            BrandRefresh.apply(context, old.uuid, brand, confirmedResponse = true)
 
-                // Operator brand parses independently of subscription-userinfo —
-                // panels that don't carry quota (free tiers, custom auth flows)
-                // still need to brand the app. We do this BEFORE the
-                // subscription-userinfo early-return so brand survives even
-                // when the panel stops sending quota headers.
-                val brand = com.github.kr328.clash.common.branding.BrandManifestParser.parseHttpHeaders { key ->
-                    response.headers[key]
-                }
-                // confirmedResponse=true: we're past `if (!response.isSuccessful) return`, so an
-                // empty brand here is a real "served the sub with no X-Brand-* headers" signal
-                // (not a transient failure) and feeds the debounced auto-clear.
-                BrandRefresh.apply(context, old.uuid, brand, confirmedResponse = true)
-
-                // Re-derive the display name on EVERY update — not only when the panel sends
-                // subscription-userinfo. Tying the rename to the quota header meant subscriptions
-                // that don't send it never had their name corrected on update (the "белиберда /
-                // URL-tail" name bug). Usage/expiry still come from subscription-userinfo when
-                // present, but its absence must not skip the rename. (E-16)
-                val usage = SubscriptionUsage.parse(response.headers["subscription-userinfo"])
-                val renamed = deriveTitleFromHeaders(response.headers)
-                val effectiveName = if (looksLikeGeneratedTokenName(old.name) && !renamed.isNullOrBlank()) {
-                    renamed
-                } else {
-                    old.name
-                }
-
-                // Keep the previous quota/expiry when the panel didn't send subscription-userinfo
-                // this time, instead of zeroing them.
-                val new = Imported(
-                    old.uuid,
-                    effectiveName,
-                    old.type,
-                    old.source,
-                    old.interval,
-                    usage?.upload ?: old.upload,
-                    usage?.download ?: old.download,
-                    usage?.total ?: old.total,
-                    usage?.expireAt?.times(1000L) ?: old.expire,
-                    old.createdAt,
-                    old.profileOrder,
-                )
-
-                if (new != old) {
-                    ImportedDao().update(new)
-                    PendingDao().remove(new.uuid)
-                    context.sendProfileChanged(new.uuid)
-                }
+            // Re-derive the display name on EVERY update — not only when the panel sends
+            // subscription-userinfo. Tying the rename to the quota header meant subscriptions
+            // that don't send it never had their name corrected on update (the "белиберда /
+            // URL-tail" name bug). Usage/expiry still come from subscription-userinfo when
+            // present, but its absence must not skip the rename. (E-16)
+            val usage = SubscriptionUsage.parse(headers.get("subscription-userinfo"))
+            val renamed = deriveTitleFromHeaders(headers)
+            val effectiveName = if (looksLikeGeneratedTokenName(old.name) && !renamed.isNullOrBlank()) {
+                renamed
+            } else {
+                old.name
             }
 
+            // Keep the previous quota/expiry when the panel didn't send subscription-userinfo
+            // this time, instead of zeroing them.
+            val new = Imported(
+                old.uuid,
+                effectiveName,
+                old.type,
+                old.source,
+                old.interval,
+                usage?.upload ?: old.upload,
+                usage?.download ?: old.download,
+                usage?.total ?: old.total,
+                usage?.expireAt?.times(1000L) ?: old.expire,
+                old.createdAt,
+                old.profileOrder,
+            )
+
+            if (new != old) {
+                ImportedDao().update(new)
+                PendingDao().remove(new.uuid)
+                context.sendProfileChanged(new.uuid)
+            }
         } catch (e: Exception) {
             Log.w("updateFlow failed", e)
         }
@@ -478,8 +470,8 @@ class ProfileManager(private val context: Context) : IProfileManager,
     // Delegate to the shared resolver so import and update decode headers identically (E-19):
     // title headers → Content-Disposition filename* (RFC-5987) → Subscription-Userinfo. Keep the
     // 64-char safety cap.
-    private fun deriveTitleFromHeaders(headers: okhttp3.Headers): String? =
-        SubscriptionNameGuesser.titleFromHeaders { key -> headers[key] }
+    private fun deriveTitleFromHeaders(headers: FetchHeadersFile): String? =
+        SubscriptionNameGuesser.titleFromHeaders { key -> headers.get(key) }
             ?.let { if (it.length > 64) it.take(64) else it }
 
     private fun looksLikeGeneratedTokenName(name: String): Boolean {

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -12,6 +12,7 @@ import com.github.kr328.clash.service.data.PendingDao
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.remote.IFetchObserver
 import com.github.kr328.clash.service.store.ServiceStore
+import com.github.kr328.clash.service.util.FetchHeadersFile
 import com.github.kr328.clash.service.util.GeoUrlSanitizer
 import com.github.kr328.clash.service.util.MihomoConfigDocument
 import com.github.kr328.clash.service.util.RuleApplyService
@@ -36,8 +37,6 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -134,27 +133,16 @@ object ProfileProcessor {
                         var total: Long = 0
                         var expire: Long = 0
                         if (snapshot?.type == Profile.Type.Url) {
-                            if (snapshot.source.startsWith("https://", true)) {
-                                val client = OkHttpClient()
-                                val request = Request.Builder()
-                                    .url(snapshot.source)
-                                    .apply {
-                                        SubscriptionRequestHeaders.build(
-                                            context,
-                                            SubscriptionOverrides.getUserAgent(context, snapshot.uuid),
-                                        ).forEach { (k, v) ->
-                                            header(k, v)
-                                        }
-                                    }
-                                    .build()
-
-                                client.newCall(request).execute().use { response ->
-                                    val usage = SubscriptionUsage.parse(response.headers["subscription-userinfo"])
-                                    upload = usage?.upload ?: 0L
-                                    download = usage?.download ?: 0L
-                                    total = usage?.total ?: 0L
-                                    expire = usage?.expireAt?.times(1000L) ?: 0L
-                                }
+                            // Quota comes from the header snapshot the Go fetch persisted
+                            // alongside config.yaml — the import above IS the request, so
+                            // no second GET (which doubled traffic on fetch-counting
+                            // panels and could race the primary download) is needed.
+                            FetchHeadersFile.readFrom(context.processingDir)?.let { headers ->
+                                val usage = SubscriptionUsage.parse(headers.get("subscription-userinfo"))
+                                upload = usage?.upload ?: 0L
+                                download = usage?.download ?: 0L
+                                total = usage?.total ?: 0L
+                                expire = usage?.expireAt?.times(1000L) ?: 0L
                             }
                             val new = Imported(
                                 snapshot.uuid,

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchHeadersFile.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchHeadersFile.kt
@@ -1,0 +1,50 @@
+package com.github.kr328.clash.service.util
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+
+/**
+ * Reads the `fetch-headers.json` snapshot the Go side writes next to
+ * `config.yaml` on every successful subscription download (see
+ * `writeFetchHeaders` in core/src/main/golang/native/config/fetch.go).
+ *
+ * This replaces the SECOND OkHttp GET of the subscription that
+ * [com.github.kr328.clash.service.ProfileProcessor] / ProfileManager used to
+ * issue just to read response headers (subscription-userinfo quota, X-Brand-*
+ * manifest, display-name headers). The extra request doubled traffic — panels
+ * count fetches against quota — could race the primary download, and kept a
+ * parallel header-decoding path alive.
+ *
+ * Keys are lowercased by the Go writer; [get] is case-insensitive so existing
+ * consumers (`BrandManifestParser.parseHttpHeaders`,
+ * `SubscriptionNameGuesser.titleFromHeaders`, `SubscriptionUsage.parse`) can
+ * pass their historical mixed-case keys unchanged.
+ */
+class FetchHeadersFile private constructor(private val headers: Map<String, String>) {
+    fun get(key: String): String? = headers[key.lowercase()]
+
+    val isEmpty: Boolean get() = headers.isEmpty()
+
+    companion object {
+        const val FILE_NAME = "fetch-headers.json"
+
+        /**
+         * @return the parsed snapshot, or null when the profile has no fetched
+         *         headers (content:// / inline import, pre-migration profile,
+         *         or an unreadable file). Callers treat null as "no HTTP
+         *         response observed" — the same meaning the old code gave a
+         *         failed OkHttp request.
+         */
+        fun readFrom(profileDir: File): FetchHeadersFile? {
+            val file = File(profileDir, FILE_NAME)
+            if (!file.isFile) return null
+            return runCatching {
+                val root = Json.parseToJsonElement(file.readText()).jsonObject
+                val map = root.entries.associate { (k, v) -> k.lowercase() to v.jsonPrimitive.content }
+                FetchHeadersFile(map)
+            }.getOrNull()
+        }
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchHeadersFileTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchHeadersFileTest.kt
@@ -1,0 +1,36 @@
+package com.github.kr328.clash.service.util
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FetchHeadersFileTest {
+    private fun dirWith(json: String?): File {
+        val dir = Files.createTempDirectory("fhf").toFile()
+        if (json != null) File(dir, FetchHeadersFile.FILE_NAME).writeText(json)
+        return dir
+    }
+
+    @Test
+    fun reads_headers_case_insensitively() {
+        // The Go writer lowercases keys; consumers use historical mixed-case ones.
+        val h = FetchHeadersFile.readFrom(
+            dirWith("""{"subscription-userinfo":"upload=1; download=2; total=3; expire=4","content-disposition":"attachment; filename=x.yaml"}"""),
+        )!!
+        assertEquals("upload=1; download=2; total=3; expire=4", h.get("Subscription-Userinfo"))
+        assertEquals("attachment; filename=x.yaml", h.get("Content-Disposition"))
+        assertNull(h.get("x-brand-name"))
+    }
+
+    @Test
+    fun missing_file_returns_null() {
+        assertNull(FetchHeadersFile.readFrom(dirWith(null)))
+    }
+
+    @Test
+    fun malformed_json_returns_null() {
+        assertNull(FetchHeadersFile.readFrom(dirWith("not json at all")))
+    }
+}


### PR DESCRIPTION
The import/update pipeline issued a SECOND full GET of the subscription just to
read response headers (subscription-userinfo quota, X-Brand-* manifest, naming
headers). That doubled traffic on panels that count fetches against quota,
could race the primary download, and kept a parallel header-decoding path
alive (the mojibake class of bugs).

The Go fetch now persists all response headers to a per-profile
fetch-headers.json next to config.yaml (lowercased keys; content:// imports
clear it). ProfileProcessor.apply and ProfileManager.updateFlow read that
snapshot instead; the existing BrandManifestParser / SubscriptionNameGuesser /
SubscriptionUsage parsers are unchanged. Unlike upstream's userinfo-only move
(8a0e8182), we persist ALL headers - our second request also fed operator
branding and display-name derivation.

okhttp is no longer used anywhere in the service module; dependency removed.



