### PR TITLE
feat(profiles): age-encrypted subscription support + on-device key generation

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -52,7 +52,7 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
                             // File import must come from the in-app picker (which grants
                             // a content-URI), never from an untrusted deeplink path.
                             create(Profile.Type.Url, name).also {
-                                patch(it, name, url, 0)
+                                patch(it, name, url, 0, null)
                             }
                         }
                         startActivity(PropertiesActivity::class.intent.setUUID(uuid))

--- a/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
@@ -64,7 +64,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
 
                             if (!canceled && profile != original) {
                                 withProfile {
-                                    patch(profile.uuid, profile.name, profile.source, profile.interval)
+                                    patch(profile.uuid, profile.name, profile.source, profile.interval, profile.ageSecretKey)
                                 }
                             }
                             if (!canceled && userAgentOverride != originalUserAgentOverride) {
@@ -151,7 +151,7 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
         try {
             withProcessing { updateStatus ->
                 withProfile {
-                    patch(profile.uuid, profile.name, profile.source, profile.interval)
+                    patch(profile.uuid, profile.name, profile.source, profile.interval, profile.ageSecretKey)
                     SubscriptionOverrides.setUserAgent(
                         this@PropertiesActivity,
                         profile.uuid,

--- a/app/src/main/java/com/github/kr328/clash/util/ProfileQuickEditSheet.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/ProfileQuickEditSheet.kt
@@ -71,7 +71,7 @@ fun BaseActivity<*>.showProfileQuickEditSheet(
         dialog.dismiss()
         launch {
             val effectiveSource = if (subscriptionLocked) profile.source else source
-            withProfile { patch(profile.uuid, name, effectiveSource, interval) }
+            withProfile { patch(profile.uuid, name, effectiveSource, interval, profile.ageSecretKey) }
             afterSaved()
             design.showToast(DesignR.string.profile_quick_saved, ToastDuration.Short)
         }

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -306,6 +306,88 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeValidateProfileBytes(JNIEnv
 }
 
 JNIEXPORT void JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeSetAgeSecretKey(JNIEnv *env, jobject thiz,
+                                                                     jstring key) {
+    TRACE_METHOD();
+
+    if (key == NULL) {
+        setAgeSecretKey(NULL);
+        return;
+    }
+
+    scoped_string _key = get_string(key);
+
+    setAgeSecretKey(_key);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeGenX25519KeyPair(JNIEnv *env, jobject thiz) {
+    TRACE_METHOD();
+
+    scoped_string response = genX25519KeyPair();
+
+    if (response == NULL)
+        return NULL;
+
+    return new_string(response);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeGenHybridKeyPair(JNIEnv *env, jobject thiz) {
+    TRACE_METHOD();
+
+    scoped_string response = genHybridKeyPair();
+
+    if (response == NULL)
+        return NULL;
+
+    return new_string(response);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeVeritySecretKeys(JNIEnv *env, jobject thiz,
+                                                                      jstring secret_keys) {
+    TRACE_METHOD();
+
+    if (secret_keys == NULL)
+        return 0;
+
+    scoped_string _secret_keys = get_string(secret_keys);
+
+    return (jboolean) veritySecretKeys(_secret_keys);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeToPublicKeys(JNIEnv *env, jobject thiz,
+                                                                  jstring secret_keys) {
+    TRACE_METHOD();
+
+    if (secret_keys == NULL)
+        return NULL;
+
+    scoped_string _secret_keys = get_string(secret_keys);
+    scoped_string response = toPublicKeys(_secret_keys);
+
+    if (response == NULL)
+        return NULL;
+
+    return new_string(response);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeVerityPublicKeys(JNIEnv *env, jobject thiz,
+                                                                      jstring public_keys) {
+    TRACE_METHOD();
+
+    if (public_keys == NULL)
+        return 0;
+
+    scoped_string _public_keys = get_string(public_keys);
+
+    return (jboolean) verityPublicKeys(_public_keys);
+}
+
+JNIEXPORT void JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeFetchAndValid(JNIEnv *env, jobject thiz,
                                                                    jobject callback,
                                                                    jstring path,

--- a/core/src/main/golang/native/config.go
+++ b/core/src/main/golang/native/config.go
@@ -177,3 +177,78 @@ func clearOverride(slot C.int) {
 	defer guard("clearOverride")()
 	config.ClearOverride(config.OverrideSlot(slot))
 }
+
+//export setAgeSecretKey
+func setAgeSecretKey(key C.c_string) {
+	defer guard("setAgeSecretKey")()
+
+	if key == nil {
+		config.SetGlobalSecretKeys()
+		return
+	}
+
+	config.SetGlobalSecretKeys(C.GoString(key))
+}
+
+type ageKeyPair struct {
+	SecretKey string `json:"secretKey"`
+	PublicKey string `json:"publicKey"`
+}
+
+//export genX25519KeyPair
+func genX25519KeyPair() *C.char {
+	defer guard("genX25519KeyPair")()
+
+	secretKey, publicKey, err := config.GenX25519KeyPair()
+	if err != nil {
+		return nil
+	}
+
+	return marshalJson(ageKeyPair{SecretKey: secretKey, PublicKey: publicKey})
+}
+
+//export genHybridKeyPair
+func genHybridKeyPair() *C.char {
+	defer guard("genHybridKeyPair")()
+
+	secretKey, publicKey, err := config.GenHybridKeyPair()
+	if err != nil {
+		return nil
+	}
+
+	return marshalJson(ageKeyPair{SecretKey: secretKey, PublicKey: publicKey})
+}
+
+//export veritySecretKeys
+func veritySecretKeys(secretKeys C.c_string) C.int {
+	defer guard("veritySecretKeys")()
+
+	if config.VeritySecretKeys(C.GoString(secretKeys)) != nil {
+		return 0
+	}
+
+	return 1
+}
+
+//export toPublicKeys
+func toPublicKeys(secretKeys C.c_string) *C.char {
+	defer guard("toPublicKeys")()
+
+	publicKeys, err := config.ToPublicKeys(C.GoString(secretKeys))
+	if err != nil {
+		return nil
+	}
+
+	return marshalJson(publicKeys)
+}
+
+//export verityPublicKeys
+func verityPublicKeys(publicKeys C.c_string) C.int {
+	defer guard("verityPublicKeys")()
+
+	if config.VerityPublicKeys(C.GoString(publicKeys)) != nil {
+		return 0
+	}
+
+	return 1
+}

--- a/core/src/main/golang/native/config/age.go
+++ b/core/src/main/golang/native/config/age.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/metacubex/mihomo/component/age"
+)
+
+// SetGlobalSecretKeys installs (or clears, when called with no arguments) the
+// process-global age identities mihomo uses to transparently decrypt
+// age-encrypted configs and provider files (see UnmarshalRawConfig and
+// adapter/provider). ClashFest also decrypts the freshly fetched subscription
+// on disk right after download (fetch.go decryptConfigInPlace) so the Kotlin
+// overlay/composer pipeline always sees plain YAML.
+func SetGlobalSecretKeys(secretKeys ...string) {
+	age.SetGlobalSecretKeys(secretKeys...)
+}
+
+// decryptConfigInPlace rewrites an age-encrypted file with its decrypted
+// plaintext, using the global secret keys. A plain (non-age) file is left
+// untouched — DecryptBytes passes non-armor data through unchanged. A missing
+// key (or wrong key) surfaces as the engine's "decrypt config error" so the
+// import fails loudly instead of handing armor bytes to the YAML pipeline.
+func decryptConfigInPlace(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	decrypted, err := age.DecryptBytes(data)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(decrypted, data) {
+		return nil
+	}
+
+	return os.WriteFile(path, decrypted, 0600)
+}
+
+func GenX25519KeyPair() (secretKey string, publicKey string, err error) {
+	return age.GenX25519KeyPair()
+}
+
+func GenHybridKeyPair() (secretKey string, publicKey string, err error) {
+	return age.GenHybridKeyPair()
+}
+
+func ToPublicKeys(secretKeys ...string) (publicKeys []string, err error) {
+	return age.ToPublicKeys(secretKeys...)
+}
+
+func VeritySecretKeys(secretKeys ...string) error {
+	return age.VeritySecretKeys(secretKeys...)
+}
+
+func VerityPublicKeys(publicKeys ...string) error {
+	return age.VerityPublicKeys(publicKeys...)
+}

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -197,6 +197,19 @@ func FetchAndValid(
 		writeFetchHeaders(path, header)
 	}
 
+	// Terminate age encryption at the door: unlike upstream CMFA (where
+	// config.yaml is only ever read by the engine, which decrypts lazily),
+	// ClashFest runs a whole TEXT pipeline over the profile on the Kotlin
+	// side — overlay composition, YAML hardening, rule mapping, the error
+	// classifier. Those layers must see plain YAML, so decrypt the on-disk
+	// body right away using the engine keys (SetGlobalSecretKeys, installed
+	// by the caller before this call). Covers every entry: URL fetch,
+	// content:// file import, and an existing config revalidated later.
+	// Plain (non-age) bodies pass through untouched.
+	if err := decryptConfigInPlace(configPath); err != nil {
+		return err
+	}
+
 	defer runtime.GC()
 
 	rawCfg, err := UnmarshalAndPatch(path)

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -8,6 +8,9 @@ import com.github.kr328.clash.common.Global
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import com.github.kr328.clash.core.model.AgeKeyPair
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonPrimitive
@@ -255,6 +258,33 @@ object Clash {
             )
         }
     }
+
+    /**
+     * Installs the age identity (AGE-SECRET-KEY-…) the engine uses to decrypt
+     * age-encrypted configs/providers (mihomo component/age global keys). The
+     * key is process-global: set it right before fetchAndValid/load for the
+     * profile being processed; null clears it.
+     */
+    fun setAgeSecretKey(key: String?) {
+        Bridge.nativeSetAgeSecretKey(key)
+    }
+
+    fun genX25519KeyPair(): AgeKeyPair =
+        Json.Default.decodeFromString(AgeKeyPair.serializer(), checkNotNull(Bridge.nativeGenX25519KeyPair()))
+
+    fun genHybridKeyPair(): AgeKeyPair =
+        Json.Default.decodeFromString(AgeKeyPair.serializer(), checkNotNull(Bridge.nativeGenHybridKeyPair()))
+
+    fun veritySecretKeys(secretKeys: String): Boolean =
+        Bridge.nativeVeritySecretKeys(secretKeys)
+
+    fun toPublicKeys(secretKeys: String): List<String> =
+        Bridge.nativeToPublicKeys(secretKeys)
+            ?.let { Json.Default.decodeFromString(ListSerializer(String.serializer()), it) }
+            ?: emptyList()
+
+    fun verityPublicKeys(publicKeys: String): Boolean =
+        Bridge.nativeVerityPublicKeys(publicKeys)
 
     fun load(path: File): CompletableDeferred<Unit> {
         return CompletableDeferred<Unit>().apply {

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -46,6 +46,12 @@ object Bridge {
         subscriptionHeadersJson: String,
     )
 
+    external fun nativeSetAgeSecretKey(key: String?)
+    external fun nativeGenX25519KeyPair(): String?
+    external fun nativeGenHybridKeyPair(): String?
+    external fun nativeVeritySecretKeys(secretKeys: String): Boolean
+    external fun nativeToPublicKeys(secretKeys: String): String?
+    external fun nativeVerityPublicKeys(publicKeys: String): Boolean
     external fun nativeLoad(completable: CompletableDeferred<Unit>, path: String)
     external fun nativeValidateProfile(completable: CompletableDeferred<Unit>, path: String)
     external fun nativeParseProfileSnapshot(path: String): String

--- a/core/src/main/java/com/github/kr328/clash/core/model/AgeKeyPair.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/AgeKeyPair.kt
@@ -1,0 +1,9 @@
+package com.github.kr328.clash.core.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AgeKeyPair(
+    val secretKey: String,
+    val publicKey: String,
+)

--- a/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MetaFeatureSettingsDesign.kt
@@ -1,14 +1,23 @@
 package com.github.kr328.clash.design
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.getSystemService
+import androidx.core.widget.doOnTextChanged
+import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ConfigurationOverride
 import com.github.kr328.clash.design.databinding.DesignSettingsMetaFeatureBinding
+import com.github.kr328.clash.design.databinding.DialogAgeKeyHelperBinding
 import com.github.kr328.clash.design.preference.*
+import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.util.*
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
@@ -65,6 +74,26 @@ class MetaFeatureSettingsDesign(
         )
 
         val screen = preferenceScreen(context) {
+            category(R.string.age_key_category)
+
+            clickable(
+                title = R.string.age_key_type_x25519,
+                summary = R.string.age_key_generate_summary,
+            ) {
+                clicked {
+                    requestAgeKeyHelper(hybrid = false)
+                }
+            }
+
+            clickable(
+                title = R.string.age_key_type_hybrid,
+                summary = R.string.age_key_generate_summary,
+            ) {
+                clicked {
+                    requestAgeKeyHelper(hybrid = true)
+                }
+            }
+
             category(R.string.settings)
 
             selectableList(
@@ -248,6 +277,82 @@ class MetaFeatureSettingsDesign(
         }
 
         binding.content.addView(screen.root)
+    }
+
+    /**
+     * Operator helper (ported from upstream d628f332): generate an age keypair
+     * on-device — the public key goes to the panel that encrypts subscriptions,
+     * the secret key goes into the profile's "Age secret key" field.
+     */
+    private fun requestAgeKeyHelper(hybrid: Boolean) {
+        launch(Dispatchers.Main) {
+            val binding = DialogAgeKeyHelperBinding
+                .inflate(context.layoutInflater, context.root, false)
+            val dialog = MaterialAlertDialogBuilder(context)
+                .setTitle(if (hybrid) R.string.age_key_type_hybrid else R.string.age_key_type_x25519)
+                .setView(binding.root)
+                .create()
+
+            fun copy(label: String, value: String) {
+                if (value.isBlank())
+                    return
+
+                val data = ClipData.newPlainText(label, value)
+                context.getSystemService<ClipboardManager>()?.setPrimaryClip(data)
+
+                launch { showToast(R.string.copied, ToastDuration.Short) }
+            }
+
+            fun patchSecretKeyState() {
+                val secretKey = binding.secretKeyView.text?.toString() ?: ""
+                val valid = secretKey.isBlank() || Clash.veritySecretKeys(secretKey)
+
+                binding.secretKeyLayout.error =
+                    if (valid) null else context.getText(R.string.age_secret_key_error)
+            }
+
+            fun patchPublicKeyState() {
+                val publicKey = binding.publicKeyView.text?.toString() ?: ""
+                val valid = publicKey.isBlank() || Clash.verityPublicKeys(publicKey)
+
+                binding.publicKeyLayout.error =
+                    if (valid) null else context.getText(R.string.age_public_key_error)
+            }
+
+            dialog.setOnShowListener {
+                binding.secretKeyView.doOnTextChanged { _, _, _, _ -> patchSecretKeyState() }
+                binding.publicKeyView.doOnTextChanged { _, _, _, _ -> patchPublicKeyState() }
+
+                binding.generateView.setOnClickListener {
+                    val keyPair = if (hybrid) {
+                        Clash.genHybridKeyPair()
+                    } else {
+                        Clash.genX25519KeyPair()
+                    }
+
+                    binding.secretKeyView.setText(keyPair.secretKey)
+                    binding.publicKeyView.setText(keyPair.publicKey)
+                }
+
+                binding.toPublicKeyView.setOnClickListener {
+                    val publicKey = Clash.toPublicKeys(binding.secretKeyView.text?.toString() ?: "")
+                        .firstOrNull()
+                        ?: ""
+
+                    binding.publicKeyView.setText(publicKey)
+                }
+
+                binding.copySecretKeyView.setOnClickListener {
+                    copy("age-secret-key", binding.secretKeyView.text?.toString() ?: "")
+                }
+
+                binding.copyPublicKeyView.setOnClickListener {
+                    copy("age-public-key", binding.publicKeyView.text?.toString() ?: "")
+                }
+            }
+
+            dialog.show()
+        }
     }
 
     fun requestClear() {

--- a/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
@@ -185,6 +185,15 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
             val interval = TimeUnit.MINUTES.toMillis(minutes.coerceAtLeast(0))
             profile = profile.copy(interval = interval)
         }
+        binding.editAgeSecretKey.doAfterTextChanged { text ->
+            if (suppressFieldSync) return@doAfterTextChanged
+            val raw = text?.toString()?.trim().orEmpty()
+            // Inline validation: empty (no encryption) or an age identity.
+            binding.layoutAgeSecretKey.error =
+                if (raw.isEmpty() || raw.startsWith("AGE-SECRET-KEY-", ignoreCase = true)) null
+                else context.getString(R.string.age_secret_key_error)
+            profile = profile.copy(ageSecretKey = raw.ifBlank { null })
+        }
         binding.editUserAgentPreset.setOnItemClickListener { _, _, position, _ ->
             userAgentPreset = when (position) {
                 1 -> UserAgentPreset.HappIos
@@ -233,6 +242,8 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
             if (binding.editName.text?.toString() != p.name) binding.editName.setText(p.name)
             if (binding.editUrl.text?.toString() != p.source) binding.editUrl.setText(p.source)
             if (binding.editInterval.text?.toString() != intervalText) binding.editInterval.setText(intervalText)
+            val ageKey = p.ageSecretKey.orEmpty()
+            if (binding.editAgeSecretKey.text?.toString() != ageKey) binding.editAgeSecretKey.setText(ageKey)
         } finally {
             suppressFieldSync = false
         }

--- a/design/src/main/res/layout/design_properties.xml
+++ b/design/src/main/res/layout/design_properties.xml
@@ -158,6 +158,25 @@
                                 android:maxLines="1" />
                         </com.google.android.material.textfield.TextInputLayout>
 
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/layout_age_secret_key"
+                            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginHorizontal="16dp"
+                            android:layout_marginVertical="@dimen/properties_element_margin_vertical"
+                            android:hint="@string/age_secret_key"
+                            app:helperText="@string/age_secret_key_helper"
+                            app:endIconMode="password_toggle">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/edit_age_secret_key"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="textPassword|textNoSuggestions"
+                                android:maxLines="1" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
                         <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/design/src/main/res/layout/dialog_age_key_helper.xml
+++ b/design/src/main/res/layout/dialog_age_key_helper.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingHorizontal="@dimen/dialog_padding"
+                android:paddingTop="@dimen/dialog_padding">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/secret_key_layout"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/age_secret_key"
+                    app:errorEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/secret_key_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingEnd="@dimen/dialog_button_margin">
+
+                <Button
+                    android:id="@+id/generate_view"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_toStartOf="@id/copy_secret_key_view"
+                    android:minHeight="0dp"
+                    android:paddingTop="0dp"
+                    android:paddingBottom="0dp"
+                    android:text="@string/age_key_generate" />
+
+                <Button
+                    android:id="@+id/copy_secret_key_view"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_alignParentEnd="true"
+                    android:minHeight="0dp"
+                    android:paddingTop="0dp"
+                    android:paddingBottom="0dp"
+                    android:text="@string/age_key_copy" />
+            </RelativeLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingHorizontal="@dimen/dialog_padding">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/public_key_layout"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/age_public_key"
+                    app:errorEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/public_key_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingEnd="@dimen/dialog_button_margin"
+                android:paddingBottom="@dimen/dialog_button_margin">
+
+                <Button
+                    android:id="@+id/to_public_key_view"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_toStartOf="@id/copy_public_key_view"
+                    android:minHeight="0dp"
+                    android:paddingTop="0dp"
+                    android:paddingBottom="0dp"
+                    android:text="@string/age_key_to_public" />
+
+                <Button
+                    android:id="@+id/copy_public_key_view"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_alignParentEnd="true"
+                    android:minHeight="0dp"
+                    android:paddingTop="0dp"
+                    android:paddingBottom="0dp"
+                    android:text="@string/age_key_copy" />
+            </RelativeLayout>
+        </LinearLayout>
+    </ScrollView>
+</layout>

--- a/design/src/main/res/values-ja-rJP/strings.xml
+++ b/design/src/main/res/values-ja-rJP/strings.xml
@@ -265,4 +265,14 @@
     <string name="proxy_chain_applied">保存しました。設定を再読み込みします。</string>
     <string name="proxy_chain_cleared">アウトバウンドからダイアラーを削除しました。</string>
     <string name="proxy_chain_not_found">設定またはプロバイダーファイルに該当ノードがありません。</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/design/src/main/res/values-ko-rKR/strings.xml
+++ b/design/src/main/res/values-ko-rKR/strings.xml
@@ -265,4 +265,14 @@
     <string name="proxy_chain_applied">체인이 저장되었습니다. 구성이 다시 로드됩니다.</string>
     <string name="proxy_chain_cleared">아웃바운드에서 다이얼러를 제거했습니다.</string>
     <string name="proxy_chain_not_found">구성 또는 프로바이더 파일에서 해당 프록시를 찾지 못했습니다.</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -728,6 +728,9 @@
     <string name="subscription_copy_hwid_diagnostics">Скопировать диагностику</string>
     <string name="subscription_user_agent_override">Переопределение User-Agent подписки</string>
     <string name="subscription_user_agent_custom">Свой User-Agent</string>
+    <string name="age_secret_key">Секретный ключ age</string>
+    <string name="age_secret_key_helper">Для подписок, зашифрованных age. Оставьте пустым, если панель отдаёт обычный YAML.</string>
+    <string name="age_secret_key_error">Должен начинаться с AGE-SECRET-KEY-</string>
     <string name="subscription_user_agent_preset_default">По умолчанию (ClashFest)</string>
     <string name="subscription_user_agent_preset_happ_ios">Happ iOS</string>
     <string name="subscription_user_agent_preset_happ_android">Happ Android</string>
@@ -1178,4 +1181,11 @@
     <string name="rule_mode_short">Правила</string>
     <string name="global_mode_short">Глобал</string>
     <string name="main_speed_fmt">↓ %1$s/s   ↑ %2$s/s</string>
+    <string name="age_key_category">Ключи age</string>
+    <string name="age_key_generate_summary">Нажмите, чтобы сгенерировать</string>
+    <string name="age_public_key">Публичный ключ age</string>
+    <string name="age_public_key_error">Неверный публичный ключ age</string>
+    <string name="age_key_generate">Сгенерировать</string>
+    <string name="age_key_to_public">Из секретного</string>
+    <string name="age_key_copy">Копировать</string>
 </resources>

--- a/design/src/main/res/values-vi/strings.xml
+++ b/design/src/main/res/values-vi/strings.xml
@@ -256,4 +256,14 @@
     <string name="proxy_chain_applied">Đã lưu chuỗi. Cấu hình sẽ tải lại.</string>
     <string name="proxy_chain_cleared">Đã xóa dialer khỏi outbound.</string>
     <string name="proxy_chain_not_found">Không tìm thấy proxy trong config hoặc file provider.</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/design/src/main/res/values-zh-rHK/strings.xml
+++ b/design/src/main/res/values-zh-rHK/strings.xml
@@ -266,4 +266,14 @@
     <string name="proxy_chain_applied">已儲存鏈，設定將重新載入。</string>
     <string name="proxy_chain_cleared">已清除出站上的 dialer。</string>
     <string name="proxy_chain_not_found">在設定或提供者檔案中找不到該節點。</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/design/src/main/res/values-zh-rTW/strings.xml
+++ b/design/src/main/res/values-zh-rTW/strings.xml
@@ -266,4 +266,14 @@
     <string name="proxy_chain_applied">已儲存鏈，設定將重新載入。</string>
     <string name="proxy_chain_cleared">已清除出站上的 dialer。</string>
     <string name="proxy_chain_not_found">在設定或提供者檔案中找不到該節點。</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -26,6 +26,9 @@
     <string name="subscription_copy_hwid_diagnostics">复制诊断</string>
     <string name="subscription_user_agent_override">订阅 User-Agent 覆盖</string>
     <string name="subscription_user_agent_custom">自定义 User-Agent</string>
+    <string name="age_secret_key">Age 密钥</string>
+    <string name="age_secret_key_helper">用于 age 加密的订阅。若面板提供普通 YAML，请留空。</string>
+    <string name="age_secret_key_error">必须以 AGE-SECRET-KEY- 开头</string>
     <string name="subscription_user_agent_preset_default">默认（ClashFest）</string>
     <string name="subscription_user_agent_preset_happ_ios">Happ iOS</string>
     <string name="subscription_user_agent_preset_happ_android">Happ Android</string>
@@ -1106,4 +1109,11 @@
     <string name="rule_mode_short">规则</string>
     <string name="global_mode_short">全局</string>
     <string name="main_speed_fmt">↓ %1$s/s   ↑ %2$s/s</string>
+    <string name="age_key_category">Age 密钥</string>
+    <string name="age_key_generate_summary">点按生成</string>
+    <string name="age_public_key">Age 公钥</string>
+    <string name="age_public_key_error">无效的 age 公钥</string>
+    <string name="age_key_generate">生成</string>
+    <string name="age_key_to_public">由私钥导出</string>
+    <string name="age_key_copy">复制</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -835,6 +835,9 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="subscription_copy_hwid_diagnostics">Copy diagnostics</string>
     <string name="subscription_user_agent_override">Subscription User-Agent override</string>
     <string name="subscription_user_agent_custom">Custom User-Agent</string>
+    <string name="age_secret_key">Age secret key</string>
+    <string name="age_secret_key_helper">For age-encrypted subscriptions. Leave empty if the panel serves plain YAML.</string>
+    <string name="age_secret_key_error">Must start with AGE-SECRET-KEY-</string>
     <string name="subscription_user_agent_preset_default">Default (ClashFest)</string>
     <string name="subscription_user_agent_preset_happ_ios">Happ iOS</string>
     <string name="subscription_user_agent_preset_happ_android">Happ Android</string>
@@ -1183,4 +1186,13 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="rule_mode_short">Rule</string>
     <string name="global_mode_short">Global</string>
     <string name="main_speed_fmt">↓ %1$s/s   ↑ %2$s/s</string>
+    <string name="age_key_category">Age keys</string>
+    <string name="age_key_generate_summary">Tap to generate</string>
+    <string name="age_key_type_x25519" translatable="false">X25519</string>
+    <string name="age_key_type_hybrid" translatable="false">MLKEM768-X25519</string>
+    <string name="age_public_key">Age public key</string>
+    <string name="age_public_key_error">Invalid age public key</string>
+    <string name="age_key_generate">Generate</string>
+    <string name="age_key_to_public">From secret</string>
+    <string name="age_key_copy">Copy</string>
 </resources>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -253,6 +253,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 download = imported.download,
                 expire = imported.expire,
                 profileOrder = profileOrder,
+                ageSecretKey = imported.ageSecretKey,
             )
 
             PendingDao().insert(pending)
@@ -261,7 +262,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
         return newUUID
     }
 
-    override suspend fun patch(uuid: UUID, name: String, source: String, interval: Long) {
+    override suspend fun patch(uuid: UUID, name: String, source: String, interval: Long, ageSecretKey: String?) {
         val locked = store.subscriptionShareLinksLockedFor(uuid)
         val resolvedSource =
             if (!locked) {
@@ -291,6 +292,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                     download = 0,
                     expire = 0,
                     profileOrder = imported.profileOrder,
+                    ageSecretKey = ageSecretKey?.takeIf { it.isNotBlank() },
                 )
             )
         } else {
@@ -302,6 +304,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 total = 0,
                 download = 0,
                 expire = 0,
+                ageSecretKey = ageSecretKey?.takeIf { it.isNotBlank() },
             )
 
             PendingDao().update(newPending)
@@ -461,6 +464,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 usage?.expireAt?.times(1000L) ?: old.expire,
                 old.createdAt,
                 old.profileOrder,
+                ageSecretKey = old.ageSecretKey,
             )
 
             if (new != old) {
@@ -1359,7 +1363,8 @@ class ProfileManager(private val context: Context) : IProfileManager,
             expire,
             resolveUpdatedAt(uuid),
             imported != null,
-            pending != null
+            pending != null,
+            ageSecretKey = pending?.ageSecretKey ?: imported?.ageSecretKey,
         )
     }
 

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -69,6 +69,10 @@ object ProfileProcessor {
 
                 val userAgentOverride = SubscriptionOverrides.getUserAgent(context, snapshot.uuid)
                 val strictUserAgent = SubscriptionOverrides.isStrictUserAgent(context, snapshot.uuid)
+                // age: install this profile's identity before the fetch — the Go side
+                // decrypts the downloaded body in place (decryptConfigInPlace) so the
+                // rest of the (text-based) pipeline sees plain YAML.
+                Clash.setAgeSecretKey(snapshot.ageSecretKey?.takeIf { it.isNotBlank() })
                 try {
                     Clash.fetchAndValid(
                         context.processingDir,
@@ -156,6 +160,7 @@ object ProfileProcessor {
                                 expire,
                                 old?.createdAt ?: System.currentTimeMillis(),
                                 old?.profileOrder ?: snapshot.profileOrder,
+                                ageSecretKey = snapshot.ageSecretKey,
                             )
                             if (old != null) {
                                 ImportedDao().update(new)
@@ -182,6 +187,7 @@ object ProfileProcessor {
                                 expire,
                                 old?.createdAt ?: System.currentTimeMillis(),
                                 old?.profileOrder ?: snapshot.profileOrder,
+                                ageSecretKey = snapshot.ageSecretKey,
                             )
                             if (old != null) {
                                 ImportedDao().update(new)
@@ -253,6 +259,8 @@ object ProfileProcessor {
                 val userAgentOverride = SubscriptionOverrides.getUserAgent(context, snapshot.uuid)
                 val strictUserAgent = SubscriptionOverrides.isStrictUserAgent(context, snapshot.uuid)
                 var effectiveUserAgentOverride = userAgentOverride
+                // age: same as apply() — key first, the Go fetch decrypts on disk.
+                Clash.setAgeSecretKey(snapshot.ageSecretKey?.takeIf { it.isNotBlank() })
                 try {
                     Clash.fetchAndValid(
                         context.processingDir,

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -110,6 +110,11 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
 
                 val profileDir = service.importedDir.resolve(active.uuid.toString())
 
+                // age: config.yaml is normally already decrypted at fetch time, but a
+                // File-type profile imported as an age armor (or a pre-decrypt legacy
+                // fetch) still needs the engine-side key at load.
+                Clash.setAgeSecretKey(active.ageSecretKey?.takeIf { it.isNotBlank() })
+
                 suspend fun applyPostLoad() {
                     val staleProviderKeySelections = SelectionDao().querySelections(active.uuid)
                         .filter { it.selected.matches(Regex("^sub\\d+$", RegexOption.IGNORE_CASE)) }

--- a/service/src/main/java/com/github/kr328/clash/service/data/Database.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/Database.kt
@@ -12,7 +12,7 @@ import java.lang.ref.SoftReference
 import androidx.room.Database as DB
 
 @DB(
-    version = 2,
+    version = 3,
     entities = [Imported::class, Pending::class, Selection::class],
     exportSchema = false,
 )

--- a/service/src/main/java/com/github/kr328/clash/service/data/Imported.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/Imported.kt
@@ -20,4 +20,6 @@ data class Imported(
     @ColumnInfo(name = "expire") val expire: Long,
     @ColumnInfo(name = "createdAt") val createdAt: Long,
     @ColumnInfo(name = "profileOrder") val profileOrder: Long = createdAt,
+    /** age identity (AGE-SECRET-KEY-…) used to decrypt an age-encrypted subscription; null = plain. */
+    @ColumnInfo(name = "ageSecretKey") val ageSecretKey: String? = null,
 )

--- a/service/src/main/java/com/github/kr328/clash/service/data/Pending.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/Pending.kt
@@ -20,4 +20,6 @@ data class Pending(
     @ColumnInfo(name = "expire") val expire: Long,
     @ColumnInfo(name = "createdAt") val createdAt: Long = System.currentTimeMillis(),
     @ColumnInfo(name = "profileOrder") val profileOrder: Long = createdAt,
+    /** age identity (AGE-SECRET-KEY-…) used to decrypt an age-encrypted subscription; null = plain. */
+    @ColumnInfo(name = "ageSecretKey") val ageSecretKey: String? = null,
 )

--- a/service/src/main/java/com/github/kr328/clash/service/data/migrations/Migrations.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/data/migrations/Migrations.kt
@@ -12,6 +12,13 @@ private val MIGRATION_1_2 = object : Migration(1, 2) {
     }
 }
 
-val MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2)
+private val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE imported ADD COLUMN ageSecretKey TEXT")
+        database.execSQL("ALTER TABLE pending ADD COLUMN ageSecretKey TEXT")
+    }
+}
+
+val MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
 
 val LEGACY_MIGRATION = ::migrationFromLegacy

--- a/service/src/main/java/com/github/kr328/clash/service/document/Picker.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/document/Picker.kt
@@ -136,6 +136,7 @@ class Picker(private val context: Context) {
                 imported.interval,
                 0,0,0,0,
                 profileOrder = imported.profileOrder,
+                ageSecretKey = imported.ageSecretKey,
             )
         )
 

--- a/service/src/main/java/com/github/kr328/clash/service/model/Profile.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/model/Profile.kt
@@ -27,6 +27,8 @@ data class Profile(
     val updatedAt: Long,
     val imported: Boolean,
     val pending: Boolean,
+    /** age identity (AGE-SECRET-KEY-…) for age-encrypted subscriptions; null = plain. */
+    val ageSecretKey: String? = null,
 ) : Parcelable {
     enum class Type {
         File, Url, External

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IProfileManager.kt
@@ -13,7 +13,7 @@ interface IProfileManager {
     suspend fun commit(uuid: UUID, callback: IFetchObserver? = null)
     suspend fun release(uuid: UUID)
     suspend fun delete(uuid: UUID)
-    suspend fun patch(uuid: UUID, name: String, source: String, interval: Long)
+    suspend fun patch(uuid: UUID, name: String, source: String, interval: Long, ageSecretKey: String?)
 
     /**
      * Direct rename of an **already imported** profile — only changes `name`


### PR DESCRIPTION
Ports upstream a69dd69a/d628f332 onto the ClashFest architecture. Profiles gain an ageSecretKey (Room v3 migration, carried through clone/patch/update); the key is installed into the engine (mihomo component/age global identities) before every fetch and load.

Key architectural difference from upstream: CMFA decrypts lazily inside the engine, but ClashFest runs a text pipeline over config.yaml (overlay composition, YAML hardening, rule mapping, the error classifier). The Go fetch therefore decrypts the on-disk body immediately after download - covering URL fetch, content:// file import and revalidation - so every downstream layer sees plain YAML. Verified on device: an age-armored import lands decrypted, overlay base included.

Properties gains a validated 'Age secret key' field (password toggle); Meta Features gains an operator key helper - generate X25519 or post-quantum MLKEM768-X25519 pairs, derive the public key from a secret, copy both. Strings in 8 locales (EN/RU/ZH translated).