### PR TITLE
feat(profiles): auto-extract age key from the subscription link fragment; E-30 for undecryptable bodies

### DIFF
--- a/common/src/main/java/com/github/kr328/clash/common/util/AgeKeyUrl.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/AgeKeyUrl.kt
@@ -1,0 +1,30 @@
+package com.github.kr328.clash.common.util
+
+/**
+ * Subscription links may carry the profile's age decryption key in the URL
+ * fragment: `https://panel/sub/TOKEN#AGE-SECRET-KEY-…`. The fragment never
+ * leaves the device (HTTP clients strip it before sending), so this is the
+ * zero-UX way for an operator to hand the secret key to a user — one link,
+ * no manual key entry. On import/edit we split the key out into the profile's
+ * ageSecretKey field and keep the clean URL as the source.
+ */
+object AgeKeyUrl {
+    private const val KEY_PREFIX = "AGE-SECRET-KEY-"
+
+    data class Split(val source: String, val ageSecretKey: String?)
+
+    /**
+     * @return the source without the key fragment, plus the extracted key —
+     *         or the input unchanged when the fragment is absent or is not an
+     *         age identity (regular `#anchor` fragments pass through).
+     */
+    fun split(source: String): Split {
+        val hashAt = source.indexOf('#')
+        if (hashAt < 0) return Split(source, null)
+
+        val fragment = source.substring(hashAt + 1).trim()
+        if (!fragment.startsWith(KEY_PREFIX, ignoreCase = true)) return Split(source, null)
+
+        return Split(source.substring(0, hashAt), fragment.uppercase())
+    }
+}

--- a/common/src/test/java/com/github/kr328/clash/common/util/AgeKeyUrlTest.kt
+++ b/common/src/test/java/com/github/kr328/clash/common/util/AgeKeyUrlTest.kt
@@ -1,0 +1,44 @@
+package com.github.kr328.clash.common.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AgeKeyUrlTest {
+    private val key = "AGE-SECRET-KEY-1TZXEAXUUKQ8FFVZMLVRDG47D7VCQ2VRPFXU2LX5UCDTWKQMW3Z4SPKUCAT"
+
+    @Test
+    fun splits_key_fragment_from_url() {
+        val s = AgeKeyUrl.split("https://panel.example.com/sub/token#$key")
+        assertEquals("https://panel.example.com/sub/token", s.source)
+        assertEquals(key, s.ageSecretKey)
+    }
+
+    @Test
+    fun lowercase_key_is_normalized_uppercase() {
+        val s = AgeKeyUrl.split("https://x.example/s#${key.lowercase()}")
+        assertEquals(key, s.ageSecretKey)
+    }
+
+    @Test
+    fun plain_url_passes_through() {
+        val s = AgeKeyUrl.split("https://panel.example.com/sub/token")
+        assertEquals("https://panel.example.com/sub/token", s.source)
+        assertNull(s.ageSecretKey)
+    }
+
+    @Test
+    fun non_key_fragment_is_left_alone() {
+        // A regular anchor fragment is not ours to strip.
+        val s = AgeKeyUrl.split("https://panel.example.com/sub/token#section-2")
+        assertEquals("https://panel.example.com/sub/token#section-2", s.source)
+        assertNull(s.ageSecretKey)
+    }
+
+    @Test
+    fun empty_input_passes_through() {
+        val s = AgeKeyUrl.split("")
+        assertEquals("", s.source)
+        assertNull(s.ageSecretKey)
+    }
+}

--- a/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
@@ -176,7 +176,15 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
         }
         binding.editUrl.doAfterTextChanged { text ->
             if (suppressFieldSync) return@doAfterTextChanged
-            profile = profile.copy(source = text?.toString().orEmpty())
+            // Operator links carry the age key in the fragment — split it into
+            // the key field right as the URL is pasted, so the user sees both
+            // fields populate and the key never lingers inside the visible URL.
+            val split = com.github.kr328.clash.common.util.AgeKeyUrl.split(text?.toString().orEmpty())
+            profile = if (split.ageSecretKey != null) {
+                profile.copy(source = split.source, ageSecretKey = split.ageSecretKey)
+            } else {
+                profile.copy(source = split.source)
+            }
         }
         binding.editInterval.doAfterTextChanged { text ->
             if (suppressFieldSync) return@doAfterTextChanged

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -286,6 +286,7 @@ available in the `fetchProviders` closure, so this is cheaply fixable.
 | `E-10` | Body downloaded but blank | "server returned an empty response — try again later" |
 | `E-11` | Body is an HTML error/rate-limit page | "server returned a web page, not a config" |
 | `E-20` | Nothing downloaded + network-reach failure (DNS/TLS/connect timeout, host blocked) | "couldn't reach the subscription server — check your connection / host may be blocked" |
+| `E-30` | Body is an age armor the engine couldn't decrypt (missing/wrong key) | "subscription is age-encrypted — import the full link from your dashboard, or set the profile's age secret key" |
 
 `E-52` (provider-init timeout at activation) is **not** implemented: with B deferred,
 those failures stay non-fatal log lines (`initial rule provider … error`), not surfaced

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.service
 
 import android.content.Context
 import com.github.kr328.clash.common.log.Log
+import com.github.kr328.clash.common.util.AgeKeyUrl
 import com.github.kr328.clash.common.util.SubscriptionNameGuesser
 import com.github.kr328.clash.common.util.SubscriptionUsage
 import com.github.kr328.clash.core.Clash
@@ -202,19 +203,25 @@ class ProfileManager(private val context: Context) : IProfileManager,
 
     override suspend fun create(type: Profile.Type, name: String, source: String): UUID {
         val uuid = generateProfileUUID()
+        // Operator links may carry the age decryption key in the URL fragment
+        // (`…#AGE-SECRET-KEY-…`) — split it into the profile field so the user
+        // never types a key by hand. Every import surface (URL form, clipboard,
+        // QR, deep-link) funnels through here.
+        val split = AgeKeyUrl.split(source)
         profileOrderLock.withLock {
             val profileOrder = nextProfileOrder()
             val pending = Pending(
                 uuid = uuid,
                 name = name,
                 type = type,
-                source = source,
+                source = split.source,
                 interval = 0,
                 upload = 0,
                 total = 0,
                 download = 0,
                 expire = 0,
                 profileOrder = profileOrder,
+                ageSecretKey = split.ageSecretKey,
             )
 
             PendingDao().insert(pending)
@@ -263,6 +270,12 @@ class ProfileManager(private val context: Context) : IProfileManager,
     }
 
     override suspend fun patch(uuid: UUID, name: String, source: String, interval: Long, ageSecretKey: String?) {
+        // A key pasted as part of the URL (fragment) wins over the separate
+        // field — it is the more deliberate input, and leaving it inside
+        // `source` would leak it into every place that renders the URL.
+        val fragmentSplit = AgeKeyUrl.split(source)
+        @Suppress("NAME_SHADOWING") val source = fragmentSplit.source
+        @Suppress("NAME_SHADOWING") val ageSecretKey = fragmentSplit.ageSecretKey ?: ageSecretKey
         val locked = store.subscriptionShareLinksLockedFor(uuid)
         val resolvedSource =
             if (!locked) {

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
@@ -44,6 +44,10 @@ object FetchErrorClassifier {
             looksLikeHtml(body) ->
                 "the subscription server returned a web page, not a config " +
                     "(likely rate-limited or an error page) — try again later. [E-11]"
+            looksLikeAgeArmor(body) ->
+                "the subscription is age-encrypted and the decryption key is missing or wrong — " +
+                    "import the full link from your dashboard (it carries the key), or set the " +
+                    "profile's age secret key. [E-30]"
             else -> return original // valid-looking config body → keep the engine's precise error
         }
         return IllegalStateException(reason, original)
@@ -77,6 +81,14 @@ object FetchErrorClassifier {
         }
         return false
     }
+
+    /**
+     * The body downloaded fine but is an age armor the engine couldn't decrypt
+     * (no key set, or the wrong one) — the fetch pipeline decrypts in place on
+     * success, so an armor surviving to the error path means decryption failed.
+     */
+    internal fun looksLikeAgeArmor(body: String): Boolean =
+        body.trimStart().startsWith("-----BEGIN AGE ENCRYPTED FILE-----")
 
     internal fun looksLikeHtml(body: String): Boolean {
         val head = body.trimStart().take(512).lowercase()

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
@@ -31,6 +31,16 @@ class FetchErrorClassifierTest {
         assertTrue(out.message!!.contains("[E-10]"), out.message)
     }
 
+    @Test fun age_armor_body_becomes_friendly() {
+        // The Go fetch decrypts in place on success; an armor body surviving to
+        // the error path means the key was missing or wrong.
+        val armor = listOf("-----BEGIN AGE ENCRYPTED FILE-----", "YWdlLWVuY3J5cHRpb24ub3JnL3Yx").joinToString(System.lineSeparator())
+        val out = FetchErrorClassifier.clarify(dirWith(armor), original)
+        assertTrue(out.message!!.contains("age-encrypted"), out.message)
+        assertTrue(out.message!!.contains("[E-30]"), out.message)
+        assertSame(original, out.cause)
+    }
+
     @Test fun valid_config_keeps_original() {
         assertSame(original, FetchErrorClassifier.clarify(dirWith("proxies: []\nrules:\n  - MATCH,DIRECT\n"), original))
     }


### PR DESCRIPTION
Operators can now hand the decryption key inside the link itself: https://panel/sub/TOKEN#AGE-SECRET-KEY-... - the fragment never leaves the device (HTTP clients strip it before sending), so this is a safe zero-UX delivery channel. AgeKeyUrl.split extracts the key at every import surface (URL form, clipboard, QR, deep-link all funnel through ProfileManager create/patch); pasting such a link into the Properties URL field moves the key into the age field on the spot. Regular #anchor fragments pass through.

When a downloaded body is an age armor the engine could not decrypt (missing or wrong key), FetchErrorClassifier now surfaces a plain-language reason with a stable code [E-30] instead of the engine's cryptic decrypt error.