### PR TITLE
Feat/soft recreate

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
@@ -18,7 +18,6 @@ import com.github.kr328.clash.core.bridge.ClashException
 import com.github.kr328.clash.design.Design
 import com.github.kr328.clash.design.model.DarkMode
 import com.github.kr328.clash.design.model.HomeBackgroundStyle
-import com.github.kr328.clash.design.model.ThemePalette
 import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.ui.DayNight
 import com.github.kr328.clash.design.util.resolveThemedBoolean
@@ -50,6 +49,17 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
     Broadcasts.Observer {
     
     protected val uiStore by lazy { UiStore(this) }
+
+    /**
+     * When true (default), applyDayNight bakes the optional theme overlays (Sloth / palette /
+     * dynamic-color / custom accent / brand / true-black) into the Activity theme at onCreate.
+     * MainActivity overrides to false: its design inflates from a per-design
+     * [com.github.kr328.clash.design.branding.BrandThemeApplier.themedContextFor] wrapper instead,
+     * so the accent can change without destroying the Activity (soft recreate) — an overlay baked
+     * into the Activity theme could never be un-applied.
+     */
+    protected open val themeOverlaysOnActivityTheme: Boolean = true
+
     protected val events = Channel<Event>(Channel.UNLIMITED)
     protected var activityStarted: Boolean = false
     protected val clashRunning: Boolean
@@ -164,11 +174,23 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        if (queryDayNight(newConfig) != dayNight) {
-            // Recreate only this activity. Mass-recreating every tracked activity caused
-            // recreate storms on some Android 15 OEM builds (Honor).
-            recreate()
+        val newDayNight = queryDayNight(newConfig)
+        if (newDayNight != dayNight) {
+            // Track the new mode BEFORE dispatching so a soft-recreating subclass (MainActivity)
+            // still detects the NEXT flip — recreate() re-derives it in onCreate anyway.
+            dayNight = newDayNight
+            onDayNightChanged()
         }
+    }
+
+    /**
+     * Day/night flipped while this activity is alive. Base behavior: recreate only this activity
+     * (mass-recreating every tracked activity caused recreate storms on some Android 15 OEM
+     * builds — Honor). MainActivity overrides this to re-inflate its content instead — destroying
+     * it risks the Android 16 ContentCapture SIGABRT (see soft-recreate change).
+     */
+    protected open fun onDayNightChanged() {
+        recreate()
     }
 
     open fun shouldDisplayHomeAsUpEnabled(): Boolean {
@@ -246,70 +268,73 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
         // MainApplication + on change) drives the real Configuration, so the config-qualified base
         // theme (BootstrapTheme -> AppThemeLight in values/, AppThemeDark in values-night/) and the
         // values-night/ colors already resolve to the correct mode. We only layer the OPTIONAL
-        // overlays (Sloth / palette / dynamic-color / user-accent / brand / true-black) on top.
-        // SlothClash skin is an exclusive look (warm surfaces + gold accent),
-        // selected via the Home background picker — it owns colors, so it
-        // bypasses palette / dynamic-color / true-black.
-        if (uiStore.homeBackgroundStyle == HomeBackgroundStyle.Sloth) {
-            theme.applyStyle(
-                if (night) R.style.ThemeOverlay_ClashFest_Sloth_Dark
-                else R.style.ThemeOverlay_ClashFest_Sloth_Light,
-                true,
-            )
-        } else {
-            val accent = uiStore.customAccent
-            if (accent != null) {
-                // User custom accent: harmonise a full M3 palette from the seed (same path as the
-                // operator brand). Takes precedence over preset palette / Material You; the operator
-                // brand (applied below) still overrides it. applySeed also re-pins TrueBlack in night.
-                com.github.kr328.clash.design.branding.BrandThemeApplier.applySeed(this, accent)
+        // overlays (Sloth / palette / dynamic-color / user-accent / brand / true-black) on top —
+        // unless the subclass delivers them through a per-design themed wrapper instead
+        // (MainActivity; see themeOverlaysOnActivityTheme + BrandThemeApplier.themedContextFor,
+        // which mirrors this exact overlay order).
+        if (themeOverlaysOnActivityTheme) {
+            // SlothClash skin is an exclusive look (warm surfaces + gold accent),
+            // selected via the Home background picker — it owns colors, so it
+            // bypasses palette / dynamic-color / true-black.
+            if (uiStore.homeBackgroundStyle == HomeBackgroundStyle.Sloth) {
+                theme.applyStyle(
+                    if (night) R.style.ThemeOverlay_ClashFest_Sloth_Dark
+                    else R.style.ThemeOverlay_ClashFest_Sloth_Light,
+                    true,
+                )
             } else {
-                paletteOverlay(uiStore.themePalette, dayNight)?.let {
-                    theme.applyStyle(it, true)
-                }
-                if (uiStore.dynamicColors) {
-                    DynamicColors.applyToActivityIfAvailable(this)
-                }
-                if (night && uiStore.trueBlack) {
-                    theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+                val accent = uiStore.customAccent
+                if (accent != null) {
+                    // User custom accent: harmonise a full M3 palette from the seed (same path as the
+                    // operator brand). Takes precedence over preset palette / Material You; the operator
+                    // brand (applied below) still overrides it. applySeed also re-pins TrueBlack in night.
+                    com.github.kr328.clash.design.branding.BrandThemeApplier.applySeed(this, accent)
+                } else {
+                    com.github.kr328.clash.design.branding.BrandThemeApplier
+                        .paletteOverlay(uiStore.themePalette, night)?.let {
+                            theme.applyStyle(it, true)
+                        }
+                    if (uiStore.dynamicColors) {
+                        DynamicColors.applyToActivityIfAvailable(this)
+                    }
+                    if (night && uiStore.trueBlack) {
+                        theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+                    }
                 }
             }
+
+            // Operator brand accent — applied as the FINAL theme overlay so the
+            // brand always wins over user palette / system dynamic-color choices.
+            // applyToActivity also pins neutral surface attrs after the harmoniser, keeping off-state
+            // widgets unambiguously neutral — and re-applies TrueBlack surfaces when pure-black is on
+            // (otherwise the neutral pin leaves grey cards on the black canvas).
+            com.github.kr328.clash.design.branding.BrandThemeApplier.applyToActivity(this)
         }
 
-        // Operator brand accent — applied as the FINAL theme overlay so the
-        // brand always wins over user palette / system dynamic-color choices.
-        // applyToActivity also pins neutral surface attrs after the harmoniser, keeping off-state
-        // widgets unambiguously neutral — and re-applies TrueBlack surfaces when pure-black is on
-        // (otherwise the neutral pin leaves grey cards on the black canvas).
-        com.github.kr328.clash.design.branding.BrandThemeApplier.applyToActivity(this)
-
-        window.isAllowForceDarkCompat = false
-        window.isSystemBarsTranslucentCompat = true
-        
-        window.statusBarColor = resolveThemedColor(android.R.attr.statusBarColor)
-        window.navigationBarColor = resolveThemedColor(android.R.attr.navigationBarColor)
-
-        if (Build.VERSION.SDK_INT >= 23) {
-            window.isLightStatusBarsCompat = resolveThemedBoolean(android.R.attr.windowLightStatusBar)
-        }
-
-        if (Build.VERSION.SDK_INT >= 27) {
-            window.isLightNavigationBarCompat = resolveThemedBoolean(android.R.attr.windowLightNavigationBar)
-        }
+        applyWindowAppearance(this)
 
         this.dayNight = dayNight
     }
 
-    private fun paletteOverlay(palette: ThemePalette, dayNight: DayNight): Int? {
-        val night = dayNight == DayNight.Night
-        return when (palette) {
-            ThemePalette.Clash -> null
-            ThemePalette.Blue -> if (night) R.style.ThemeOverlay_ClashFest_PaletteBlue_Dark else R.style.ThemeOverlay_ClashFest_PaletteBlue_Light
-            ThemePalette.Violet -> if (night) R.style.ThemeOverlay_ClashFest_PaletteViolet_Dark else R.style.ThemeOverlay_ClashFest_PaletteViolet_Light
-            ThemePalette.Rose -> if (night) R.style.ThemeOverlay_ClashFest_PaletteRose_Dark else R.style.ThemeOverlay_ClashFest_PaletteRose_Light
-            ThemePalette.Amber -> if (night) R.style.ThemeOverlay_ClashFest_PaletteAmber_Dark else R.style.ThemeOverlay_ClashFest_PaletteAmber_Light
-            ThemePalette.Mint -> if (night) R.style.ThemeOverlay_ClashFest_PaletteMint_Dark else R.style.ThemeOverlay_ClashFest_PaletteMint_Light
-            ThemePalette.Graphite -> if (night) R.style.ThemeOverlay_ClashFest_PaletteGraphite_Dark else R.style.ThemeOverlay_ClashFest_PaletteGraphite_Light
+    /**
+     * Resolve window-level appearance (system-bar colors + light/dark icon hints) from [themed]'s
+     * theme. For regular activities that's the activity itself (from applyDayNight); MainActivity
+     * re-runs this against the design's themed wrapper after every soft recreate so the bars
+     * follow the wrapper theme, not the deliberately-virgin Activity theme.
+     */
+    protected fun applyWindowAppearance(themed: Context) {
+        window.isAllowForceDarkCompat = false
+        window.isSystemBarsTranslucentCompat = true
+
+        window.statusBarColor = themed.resolveThemedColor(android.R.attr.statusBarColor)
+        window.navigationBarColor = themed.resolveThemedColor(android.R.attr.navigationBarColor)
+
+        if (Build.VERSION.SDK_INT >= 23) {
+            window.isLightStatusBarsCompat = themed.resolveThemedBoolean(android.R.attr.windowLightStatusBar)
+        }
+
+        if (Build.VERSION.SDK_INT >= 27) {
+            window.isLightNavigationBarCompat = themed.resolveThemedBoolean(android.R.attr.windowLightNavigationBar)
         }
     }
 

--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -52,6 +52,7 @@ import com.github.kr328.clash.design.model.DarkMode
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.applyFetchStatus
 import com.github.kr328.clash.design.util.isTelevision
+import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.design.util.showExceptionToast
 import com.github.kr328.clash.remote.Remote
 import com.github.kr328.clash.remote.StatusClient
@@ -78,6 +79,8 @@ import io.github.g00fy2.quickie.QRResult.QRSuccess
 import io.github.g00fy2.quickie.QRResult.QRUserCanceled
 import io.github.g00fy2.quickie.ScanQRCode
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -119,6 +122,34 @@ class MainActivity : BaseActivity<MainDesign>() {
     private val updatePrefs by lazy { getSharedPreferences("app_update", MODE_PRIVATE) }
     /** Incremented on each [onProfileLoaded] — used to await post-load selector patches. */
     private val profileLoadEpoch = AtomicInteger(0)
+
+    /** How [runDashboard] resolved. Cancellation (activity destroy) exits by exception instead. */
+    private enum class DashboardExit { SoftRecreate }
+
+    /**
+     * Doorbell: the current design's captured theme no longer matches desired state (brand
+     * accent changed, day/night flipped). Conflated — a burst of triggers collapses into one
+     * re-inflation, and the accent staleness check is level-based (desired vs applied), so an
+     * already-converged run never re-fires.
+     */
+    private val softRecreateRequests =
+        kotlinx.coroutines.channels.Channel<Unit>(kotlinx.coroutines.channels.Channel.CONFLATED)
+
+    /**
+     * Context for dialogs/menus/sheets spawned by MainActivity. The design's themed wrapper —
+     * the brand accent lives there, never on the Activity theme (see
+     * [themeOverlaysOnActivityTheme]). Falls back to the activity before the first design lands.
+     */
+    private val themedContext: Context
+        get() = design?.context ?: this
+
+    /**
+     * Main inflates its designs from [com.github.kr328.clash.design.branding.BrandThemeApplier
+     * .themedContextFor] wrappers so the accent path never has to destroy the Activity
+     * (Android 16 ContentCapture SIGABRT) — the Activity theme itself stays a virgin
+     * config-driven base theme that overlays are never baked into.
+     */
+    override val themeOverlaysOnActivityTheme: Boolean = false
 
     private fun clearPendingDownloadState() {
         pendingApkDownloadId = -1L
@@ -374,8 +405,9 @@ class MainActivity : BaseActivity<MainDesign>() {
     }
 
     private fun showHomeImportSheet(design: MainDesign) {
-        val dialog = AppBottomSheetDialog(this, fitContentHeight = false)
-        val view = layoutInflater.inflate(R.layout.bottom_sheet_home_import, null)
+        // design.context, not the activity: the brand accent lives in the design's themed wrapper.
+        val dialog = AppBottomSheetDialog(design.context, fitContentHeight = false)
+        val view = design.context.layoutInflater.inflate(R.layout.bottom_sheet_home_import, null)
         dialog.setContentView(view)
         view.findViewById<View>(R.id.opt_clipboard).setOnClickListener {
             dialog.dismiss()
@@ -424,7 +456,7 @@ class MainActivity : BaseActivity<MainDesign>() {
 
         try {
             FilesClient(this).copyDocument("$uuid/config.yaml", uri)
-            commitProfileWithProgress(uuid)
+            themedContext.commitProfileWithProgress(uuid)
         } catch (e: Exception) {
             showImportCommitFailureDialog(uuid, e)
             return
@@ -464,18 +496,59 @@ class MainActivity : BaseActivity<MainDesign>() {
     }
 
     override suspend fun main() {
-        val design = MainDesign(this)
-        design.applyInitialModeFromPreference(uiStore.tunnelModePreference)
+        // Design-generation loop (soft recreate, D2): the Activity object survives accent and
+        // day/night changes — destroying it probabilistically SIGABRTs the process on Android 16
+        // (platform ContentCapture teardown bug). Each iteration derives a fresh themed wrapper
+        // from current state, inflates a new MainDesign from it, and runs the dashboard loop
+        // until the captured theme goes stale.
+        var restoreTab: MainDesign.MainTab? = null
+        while (true) {
+            val themed = com.github.kr328.clash.design.branding.BrandThemeApplier.themedContextFor(this)
+            val design = MainDesign(themed)
+            design.applyInitialModeFromPreference(uiStore.tunnelModePreference)
+            restoreTab?.let { design.selectTab(it) }
+            val previous = this.design
+            setContentDesign(design)
+            // System bars follow the wrapper theme — the Activity theme is deliberately virgin.
+            applyWindowAppearance(themed)
+            // Mirror onDestroy for the replaced design; its jobs/tickers already died with the
+            // previous runDashboard scope.
+            previous?.cancel()
+            com.github.kr328.clash.common.log.Log.d(
+                "soft-recreate: dashboard inflated on live activity@" +
+                    Integer.toHexString(System.identityHashCode(this)),
+            )
 
-        setContentDesign(design)
+            val exit = runDashboard(design)
+            restoreTab = design.currentTab
+            if (exit != DashboardExit.SoftRecreate) break
+        }
+    }
+
+    /**
+     * The dashboard event loop — the moved (not rewritten) body of the pre-soft-recreate [main].
+     * Wrapped in [coroutineScope] so resolving cancels every child (tickers, the refresh
+     * consumer, proxy-detail jobs) via structured concurrency, with no manual bookkeeping of the
+     * old run. Only a [softRecreateRequests] signal resolves it; activity teardown cancels it by
+     * exception like before.
+     */
+    private suspend fun runDashboard(design: MainDesign): DashboardExit = coroutineScope {
+        // A fresh design starts from its default traffic label; drop the memo so the first
+        // fetchTraffic of this run always pushes the real total.
+        lastForwardedTrafficTotal = Long.MIN_VALUE
+        // These are normally reset by launched children (delayed unlock / finally), which die
+        // with this scope on a soft recreate — clear them so a recreate mid-flight can't wedge
+        // the power button or the About update check for the rest of the session.
+        isToggleStatusInFlight = false
+        isCheckingUpdates = false
 
         // Keep the companion agent alive whenever the app is open if the user enabled it — the
         // foreground service doesn't survive a process restart on its own, so a paired controller
         // could otherwise never reach this device after the app was killed.
-        if (com.github.kr328.clash.companion.CompanionStore(this).agentEnabled &&
+        if (com.github.kr328.clash.companion.CompanionStore(this@MainActivity).agentEnabled &&
             !com.github.kr328.clash.companion.agent.CompanionAgent.isReady()
         ) {
-            com.github.kr328.clash.companion.agent.CompanionGatewayService.start(this)
+            com.github.kr328.clash.companion.agent.CompanionGatewayService.start(this@MainActivity)
         }
         design.fetch()
         refreshAnnouncement(design)
@@ -546,8 +619,13 @@ class MainActivity : BaseActivity<MainDesign>() {
             }
         }
 
-        while (isActive) {
+        var exit: DashboardExit? = null
+        while (exit == null) {
             select<Unit> {
+                softRecreateRequests.onReceive {
+                    exit = DashboardExit.SoftRecreate
+                }
+
                 events.onReceive {
                     when (it) {
                         Event.ActivityStart,
@@ -555,7 +633,11 @@ class MainActivity : BaseActivity<MainDesign>() {
                         Event.ClashStop,
                         Event.ClashStart,
                         Event.ProfileLoaded,
-                        Event.ProfileChanged -> {
+                        Event.ProfileChanged,
+                        // Sub-bug #8: a subscription update can change or clear the brand accent
+                        // with no profile switch involved — the refresh below runs fetch(), whose
+                        // accent staleness check then converges the theme on this event.
+                        Event.ProfileUpdateCompleted -> {
                             // Coalesce expensive dashboard refreshes so a burst of
                             // service/profile broadcasts does not pile up parallel
                             // proxy-group queries and stall follow-up taps.
@@ -564,7 +646,10 @@ class MainActivity : BaseActivity<MainDesign>() {
                                 it == Event.ServiceRecreated
                             scheduleDashboardRefresh(
                                 includeAnnouncement = it == Event.ActivityStart ||
-                                    it == Event.ProfileChanged,
+                                    it == Event.ProfileChanged ||
+                                    // Updates rewrite fetch-headers.json (announce / support /
+                                    // brand headers) — re-render the announcement card too.
+                                    it == Event.ProfileUpdateCompleted,
                                 // ProfileLoaded is the authoritative "engine finished loading the new
                                 // profile's config" signal — the UI MUST re-fetch to re-prime the Home
                                 // node against the new groups. It must bypass the refresh throttle: on
@@ -721,7 +806,15 @@ class MainActivity : BaseActivity<MainDesign>() {
                                 DarkMode.ForceLight -> DarkMode.ForceDark
                                 else -> DarkMode.ForceLight
                             }
-                            recreate()
+                            // Config-driven day/night: sync AppCompat night mode; because Main
+                            // declares configChanges="uiMode", AppCompat delivers the flip as
+                            // onConfigurationChanged -> onDayNightChanged -> soft recreate (no
+                            // Activity destroy). The old raw recreate() here was both crash-prone
+                            // (ContentCapture SIGABRT) and skipped the night-mode sync entirely.
+                            syncNightModeFromUiStore()
+                            // No-op flip (e.g. ForceLight while already light): still refresh so
+                            // the theme-toggle icon reflects the stored preference.
+                            scheduleDashboardRefresh()
                         }
                     }
                 }
@@ -835,7 +928,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                         // observer (onProfileUpdateCompleted / Failed). Don't
                         // toast "started" here — the user sees that *after*
                         // the modal closes, by which point the work is done.
-                        runCatching { updateProfileWithProgress(profile.uuid) }
+                        runCatching { themedContext.updateProfileWithProgress(profile.uuid) }
                         // Run metadata sync in the background so the UI tap returns
                         // immediately. The earlier race (announcement-card hiding the
                         // active-card support button for a tick) was structural — we
@@ -962,10 +1055,16 @@ class MainActivity : BaseActivity<MainDesign>() {
                 }
             }
         }
+
+        // Structured teardown of this run: tickers, the refresh consumer and any in-flight
+        // launches die here; the design-generation loop in main() takes over.
+        coroutineContext.cancelChildren()
+        checkNotNull(exit)
     }
 
     private fun showProfileOverflowMenu(design: MainDesign, profile: Profile, anchor: View) {
-        val popup = PopupMenu(this, anchor)
+        // anchor.context is the design's themed wrapper (the row was inflated from it).
+        val popup = PopupMenu(anchor.context, anchor)
         popup.menuInflater.inflate(R.menu.menu_profile_home, popup.menu)
         val m = popup.menu
         m.findItem(R.id.profile_menu_set_active).isVisible =
@@ -1017,7 +1116,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                     true
                 }
                 R.id.profile_menu_delete -> {
-                    MaterialAlertDialogBuilder(this)
+                    MaterialAlertDialogBuilder(design.context)
                         .setTitle(R.string.delete)
                         .setMessage(R.string.profile_delete_confirm)
                         .setPositiveButton(R.string.delete) { _, _ ->
@@ -1067,7 +1166,7 @@ class MainActivity : BaseActivity<MainDesign>() {
             create(Profile.Type.Url, pending.preliminaryName, url)
         }
         try {
-            commitProfileWithProgress(uuid)
+            themedContext.commitProfileWithProgress(uuid)
         } catch (e: Exception) {
             pending.betterName.cancel()
             showImportCommitFailureDialog(uuid, e)
@@ -1115,7 +1214,7 @@ class MainActivity : BaseActivity<MainDesign>() {
         withContext(Dispatchers.Main) {
             val raw = e.message?.trim().orEmpty().ifBlank { e.javaClass.simpleName }
             val msg = if (raw.length > 6000) raw.take(6000) + "…" else raw
-            MaterialAlertDialogBuilder(this@MainActivity)
+            MaterialAlertDialogBuilder(themedContext)
                 .setTitle(getString(R.string.import_failed_title))
                 .setMessage(msg)
                 .setNegativeButton(android.R.string.cancel, null)
@@ -1128,9 +1227,10 @@ class MainActivity : BaseActivity<MainDesign>() {
 
     private suspend fun showProxyYamlDialog(title: String, body: String) {
         withContext(Dispatchers.Main) {
+            val themed = themedContext
             val pad = (16 * resources.displayMetrics.density).toInt()
-            val scroll = ScrollView(this@MainActivity)
-            val tv = TextView(this@MainActivity).apply {
+            val scroll = ScrollView(themed)
+            val tv = TextView(themed).apply {
                 text = body
                 setTextIsSelectable(true)
                 setPadding(pad, pad, pad, pad)
@@ -1138,7 +1238,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                 typeface = Typeface.MONOSPACE
             }
             scroll.addView(tv)
-            MaterialAlertDialogBuilder(this@MainActivity)
+            MaterialAlertDialogBuilder(themed)
                 .setTitle(title)
                 .setView(scroll)
                 .setPositiveButton(android.R.string.ok, null)
@@ -1651,7 +1751,7 @@ class MainActivity : BaseActivity<MainDesign>() {
         val info = AppUpdateChecker.peekCachedRelease(this) ?: return
         val body = info.body.takeIf { it.isNotBlank() }
             ?: getString(R.string.update_dialog_message_fallback)
-        val dialog = MaterialAlertDialogBuilder(this)
+        val dialog = MaterialAlertDialogBuilder(themedContext)
             .setTitle(getString(R.string.update_dialog_title_fmt, info.tagName))
             .setMessage(body)
             .setNegativeButton(R.string.update_dialog_button_later, null)
@@ -1818,7 +1918,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                 append("\n\n")
                 append(getString(R.string.ru_bypass_prompt_tile_note))
             }
-            val dialog = MaterialAlertDialogBuilder(this)
+            val dialog = MaterialAlertDialogBuilder(themedContext)
                 .setTitle(R.string.ru_bypass_prompt_title)
                 .setMessage(message)
                 .setPositiveButton(R.string.ru_bypass_prompt_apply) { d, _ ->
@@ -1860,6 +1960,25 @@ class MainActivity : BaseActivity<MainDesign>() {
     override fun onProfileLoaded() {
         profileLoadEpoch.incrementAndGet()
         super.onProfileLoaded()
+    }
+
+    /**
+     * Day/night flips ride the same soft path as accent changes (4.2): the wrapper for the next
+     * design is derived under the new Configuration, and the virgin config-driven Activity theme
+     * rebases by itself — no recreate, no ContentCapture teardown.
+     */
+    override fun onDayNightChanged() {
+        softRecreateRequests.trySend(Unit)
+    }
+
+    /**
+     * External nudge from other screens that used to `recreate()` Main (ThemeSettings palette /
+     * accent / true-black changes): re-derive the wrapper from current uiStore state and
+     * re-inflate, without destroying the Activity. NOT sufficient for font-scale or language
+     * changes — those are baked in attachBaseContext and still need a real recreate.
+     */
+    fun requestSoftRecreate() {
+        softRecreateRequests.trySend(Unit)
     }
 
     override fun onProfileUpdateCompleted(uuid: UUID?) {
@@ -2057,11 +2176,15 @@ class MainActivity : BaseActivity<MainDesign>() {
                 ),
             )
         } finally {
-            // Theme overlay is captured at inflate time. If the active profile's
-            // accent diverges from what's actually applied, recreate so the new
-            // (or absent) harmonised palette flows into every widget that reads
-            // ?attr/colorPrimary etc.
-            com.github.kr328.clash.design.branding.BrandThemeApplier.maybeRecreateOnAccentChange(this)
+            // Theme overlay is captured at design-inflation time. If the active profile's accent
+            // diverges from what the current design's wrapper carries, resolve the dashboard loop
+            // with a soft recreate so the new (or absent) harmonised palette flows into every
+            // widget that reads ?attr/colorPrimary etc. — without ever destroying the Activity
+            // (Android 16 ContentCapture SIGABRT). Runs on EVERY fetch, so switches, updates and
+            // brand clears all converge through the same level-based check.
+            if (com.github.kr328.clash.design.branding.BrandThemeApplier.accentStale(this)) {
+                softRecreateRequests.trySend(Unit)
+            }
         }
     }
 

--- a/app/src/main/java/com/github/kr328/clash/ThemeSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ThemeSettingsActivity.kt
@@ -8,8 +8,18 @@ import kotlinx.coroutines.selects.select
 
 class ThemeSettingsActivity : BaseActivity<ThemeSettingsDesign>() {
 
-    private fun staggerRecreate(activities: List<Activity>) {
+    /**
+     * @param softMain route MainActivity through its soft path (design re-inflation, no Activity
+     * destroy — Android 16 ContentCapture SIGABRT) instead of `recreate()`. Only valid for pure
+     * theme-overlay changes (palette / accent / true-black); font scale and reset re-run
+     * attachBaseContext and need the real recreate.
+     */
+    private fun staggerRecreate(activities: List<Activity>, softMain: Boolean) {
         activities.forEachIndexed { index, activity ->
+            if (softMain && activity is MainActivity) {
+                activity.requestSoftRecreate()
+                return@forEachIndexed
+            }
             activity.window?.decorView?.postDelayed({
                 if (activity.isFinishing) return@postDelayed
                 if (activity.isDestroyed) return@postDelayed
@@ -36,6 +46,7 @@ class ThemeSettingsActivity : BaseActivity<ThemeSettingsDesign>() {
                         ThemeSettingsDesign.Request.ReCreateOtherActivities -> {
                             staggerRecreate(
                                 ApplicationObserver.createdActivities.filter { it !is ThemeSettingsActivity },
+                                softMain = true,
                             )
                             val old = current
                             current = newDesign()
@@ -43,7 +54,8 @@ class ThemeSettingsActivity : BaseActivity<ThemeSettingsDesign>() {
                             old.disposeForReplace()
                         }
                         ThemeSettingsDesign.Request.ReCreateAllActivities -> {
-                            staggerRecreate(ApplicationObserver.createdActivities.toList())
+                            // Font scale / reset — attachBaseContext must re-run, soft path can't.
+                            staggerRecreate(ApplicationObserver.createdActivities.toList(), softMain = false)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/kr328/clash/util/ProfileQuickEditSheet.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/ProfileQuickEditSheet.kt
@@ -11,6 +11,7 @@ import com.github.kr328.clash.design.Design
 import com.github.kr328.clash.design.R as DesignR
 import com.github.kr328.clash.design.dialog.AppBottomSheetDialog
 import com.github.kr328.clash.design.ui.ToastDuration
+import com.github.kr328.clash.design.util.layoutInflater
 import com.github.kr328.clash.service.model.Profile
 import com.github.kr328.clash.service.store.ServiceStore
 import com.google.android.material.button.MaterialButton
@@ -25,8 +26,10 @@ fun BaseActivity<*>.showProfileQuickEditSheet(
     profile: Profile,
     afterSaved: suspend () -> Unit,
 ) {
-    val dialog = AppBottomSheetDialog(this, fitContentHeight = true)
-    val view = layoutInflater.inflate(R.layout.bottom_sheet_profile_quick_edit, null)
+    // Inflate from the design's context, not the activity: on the main screen the design carries
+    // the themed wrapper (brand accent lives there, never on the Activity theme).
+    val dialog = AppBottomSheetDialog(design.context, fitContentHeight = true)
+    val view = design.context.layoutInflater.inflate(R.layout.bottom_sheet_profile_quick_edit, null)
     dialog.setContentView(view)
 
     val nameInput = view.findViewById<EditText>(R.id.input_profile_name)

--- a/design/src/main/java/com/github/kr328/clash/design/Design.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/Design.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.github.kr328.clash.design.ui.Surface
 import com.github.kr328.clash.design.ui.ToastDuration
 import com.github.kr328.clash.design.util.currentWindowInsetsSnapshot
+import com.github.kr328.clash.design.util.hostActivity
 import com.github.kr328.clash.design.util.resolveThemedColor
 import com.github.kr328.clash.design.util.setOnInsertsChangedListener
 import com.google.android.material.snackbar.Snackbar
@@ -90,18 +91,19 @@ abstract class Design<R>(val context: Context) :
     }
 
     init {
-        when (context) {
-            is AppCompatActivity -> {
-                val decor = context.window.decorView
-                decor.currentWindowInsetsSnapshot()?.let {
-                    if (surface.insets != it) {
-                        surface.insets = it
-                    }
+        // Unwrap ContextThemeWrapper chains (MainDesign inflates from a themed wrapper over its
+        // activity) — insets always come from the hosting activity's decor.
+        val activity = context.hostActivity() as? AppCompatActivity
+        if (activity != null) {
+            val decor = activity.window.decorView
+            decor.currentWindowInsetsSnapshot()?.let {
+                if (surface.insets != it) {
+                    surface.insets = it
                 }
-                decor.setOnInsertsChangedListener {
-                    if (surface.insets != it) {
-                        surface.insets = it
-                    }
+            }
+            decor.setOnInsertsChangedListener {
+                if (surface.insets != it) {
+                    surface.insets = it
                 }
             }
         }

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -100,7 +100,8 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         OpenCompanion,
     }
 
-    private enum class MainTab {
+    /** Public: MainActivity captures/restores the active tab across a soft recreate. */
+    enum class MainTab {
         Home,
         Profiles,
         Routing,
@@ -1302,7 +1303,6 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
      * See architecture/backend/branding.md (F-BRAND-3).
      */
     private fun showBrandDevDialog() {
-        val activity = context as? android.app.Activity ?: return
         val uuid = ServiceStore(context).activeProfile
         if (uuid == null) {
             Toast.makeText(context, "No active profile — select a subscription first", Toast.LENGTH_LONG).show()
@@ -1404,9 +1404,15 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
                         enabled = sEnabled.boolValue(),
                     ),
                 )
-                activity.recreate()
+                // Kick a dashboard refresh: fetch() re-reads the manifest and the accent
+                // staleness check resolves a soft recreate — same convergence path a real
+                // operator brand change takes (never Activity.recreate on Main).
+                profileExpandChanged.trySend(Unit)
             }
-            .setNeutralButton("Clear brand") { _, _ -> store.clearFor(uuid); activity.recreate() }
+            .setNeutralButton("Clear brand") { _, _ ->
+                store.clearFor(uuid)
+                profileExpandChanged.trySend(Unit)
+            }
             .setNegativeButton("Cancel", null)
             .show()
     }
@@ -1818,6 +1824,23 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
 
     /** Switch to the Profiles tab (the in-app profile manager) instead of opening a separate screen. */
     fun openProfilesTab() = selectMainTab(MainTab.Profiles)
+
+    /** The logical tab currently shown — captured by MainActivity before a soft recreate (D5). */
+    val currentTab: MainTab?
+        get() = mainTabForPagerPosition(binding.mainPager.currentItem)
+
+    /**
+     * Non-animated tab restore after a soft recreate. Reuses the pager-position math of
+     * [selectMainTab] but skips the smooth scroll + scroll-to-top behavior — this runs on a
+     * freshly inflated design before it is even attached. No-op if [tab] isn't in the current
+     * tab set (e.g. the Operator tab vanished with the brand that owned it).
+     */
+    fun selectTab(tab: MainTab) {
+        val logicalIndex = activeTabs.indexOf(tab)
+        if (logicalIndex < 0) return
+        binding.mainPager.setCurrentItem(logicalIndex + 1, false)
+        renderMainTab(tab)
+    }
 
     private fun selectMainTab(tab: MainTab) {
         val logicalIndex = activeTabs.indexOf(tab)

--- a/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
@@ -1,8 +1,13 @@
 package com.github.kr328.clash.design.branding
 
 import android.app.Activity
+import android.content.Context
 import android.graphics.Color
+import android.view.ContextThemeWrapper
 import com.github.kr328.clash.design.R
+import com.github.kr328.clash.design.model.HomeBackgroundStyle
+import com.github.kr328.clash.design.model.ThemePalette
+import com.github.kr328.clash.design.store.UiStore
 import com.google.android.material.color.DynamicColors
 import com.google.android.material.color.DynamicColorsOptions
 
@@ -61,14 +66,14 @@ object BrandThemeApplier {
         val activeUuid = com.github.kr328.clash.service.store.ServiceStore(activity).activeProfile
         if (activeUuid == null || !store.isActiveFor(activeUuid)) {
             // No brand for the active profile (or no active profile at all) →
-            // record that the theme is *unbranded* so [maybeRecreateOnAccentChange]
+            // record that the theme is *unbranded* so [accentStale]
             // can compare against the actual state next tick. Crucially, we mark
             // this AFTER the theme reflects it; if recreate ever silently fails
             // we want the next tick to still observe last != current and retry.
             store.lastAppliedAccent = ""
             return
         }
-        // Derive the applicable accent through the SAME helper maybeRecreateOnAccentChange uses,
+        // Derive the applicable accent through the SAME helper accentStale uses,
         // so "what is applied" and "what is desired" can never disagree on parseability.
         val hex = applicableAccent(store.manifestFor(activeUuid).accentColor)
         val accent = if (hex.isNotEmpty()) runCatching { Color.parseColor(hex) }.getOrNull() else null
@@ -81,7 +86,7 @@ object BrandThemeApplier {
         applySeed(activity, accent)
 
         // Mark the accent that's now baked into this Activity's theme.
-        // [maybeRecreateOnAccentChange] reads this on the next dashboard tick
+        // [accentStale] reads this on the next dashboard tick
         // and compares to the desired-for-active-profile accent.
         store.lastAppliedAccent = hex
 
@@ -91,45 +96,206 @@ object BrandThemeApplier {
     }
 
     /**
-     * Recreate the Activity when the brand accent (or active brand state)
-     * has changed since this Activity was inflated. The harmoniser overlay
-     * is captured at inflate time — there's no way to update an already-
-     * inflated theme.
+     * True when the brand accent (or active brand state) has changed since the current main-screen
+     * design was inflated. The harmoniser overlay is captured at inflate time — there's no way to
+     * update an already-inflated theme — so MainActivity resolves `true` by re-inflating its design
+     * from a fresh [themedContextFor] wrapper (soft recreate; the Activity itself is never
+     * destroyed — Android 16 ContentCapture SIGABRT on Activity destroy).
      *
      * **Do not** update [com.github.kr328.clash.service.branding.BrandStore.lastAppliedAccent]
-     * here — that field is owned by [applyToActivity] and represents what is
-     * actually applied to the live theme. Writing it pre-recreate created a
-     * race: if [Activity.recreate] silently no-op'd (Activity in STOPPED
-     * state, lifecycle race, OEM quirk), the stored value would advance to
-     * the new accent while the theme stayed on the old one, and every
-     * follow-up tick would see `current == last` and bail without retrying.
-     * Result: brand accent permanently stuck on the home screen until the
-     * process was killed.
+     * here — that field is owned by [applyToActivity]/[themedContextFor] and represents what the
+     * newest inflated surface actually carries. Advancing it from the check would make every
+     * follow-up tick see `current == last` and bail without converging.
      */
-    fun maybeRecreateOnAccentChange(activity: Activity) {
-        val activeUuid = com.github.kr328.clash.service.store.ServiceStore(activity).activeProfile
-        val store = com.github.kr328.clash.service.branding.BrandStore(activity)
+    fun accentStale(context: Context): Boolean {
+        val activeUuid = com.github.kr328.clash.service.store.ServiceStore(context).activeProfile
+        val store = com.github.kr328.clash.service.branding.BrandStore(context)
         val desired = if (activeUuid != null && store.isActiveFor(activeUuid)) {
             applicableAccent(store.manifestFor(activeUuid).accentColor)
         } else {
             ""
         }
         val applied = store.lastAppliedAccent
-        if (desired == applied) return
+        if (desired == applied) return false
         com.github.kr328.clash.common.log.Log.d(
-            "BrandThemeApplier: accent mismatch (applied='$applied', desired='$desired'), recreating ${activity::class.java.simpleName}",
+            "BrandThemeApplier: accent stale (applied='$applied', desired='$desired')",
         )
-        activity.recreate()
+        return true
+    }
+
+    /**
+     * Build the themed [Context] the main screen's design inflates from — a [ContextThemeWrapper]
+     * chain over [activity] carrying the FULL optional-overlay stack that [applyToActivity] +
+     * BaseActivity.applyDayNight would otherwise bake into the Activity theme: Sloth skin /
+     * preset palette / Material You / user custom accent / TrueBlack, with the operator brand
+     * accent layered last so it always wins (same order as the activity path).
+     *
+     * MainActivity's own theme deliberately stays a virgin config-driven base theme: overlays can
+     * never be *un*-applied from a live theme, so a brand baked into the Activity theme would make
+     * "switch away from a branded profile" impossible without destroying the Activity, and a
+     * day/night flip would leave stale `_Light`/`_Dark` palette + TrueBlack attrs behind. The
+     * wrapper dies with the design; each soft recreate derives a fresh one from current state.
+     *
+     * Also records what accent the wrapper carries in
+     * [com.github.kr328.clash.service.branding.BrandStore.lastAppliedAccent] (the same contract
+     * [applyToActivity] follows for regular activities), so [accentStale] compares against the
+     * surface the user actually sees.
+     */
+    fun themedContextFor(activity: Activity): Context {
+        val uiStore = UiStore(activity)
+        val night = isNight(activity)
+        val sloth = uiStore.homeBackgroundStyle == HomeBackgroundStyle.Sloth
+
+        // Operator brand accent wins over the user's custom accent; the custom accent (like the
+        // preset palette) is only read outside the Sloth skin — same precedence as applyDayNight.
+        val store = com.github.kr328.clash.service.branding.BrandStore(activity)
+        val activeUuid = com.github.kr328.clash.service.store.ServiceStore(activity).activeProfile
+        val brandHex = if (activeUuid != null && store.isActiveFor(activeUuid)) {
+            applicableAccent(store.manifestFor(activeUuid).accentColor)
+        } else {
+            ""
+        }
+        val brandSeed = if (brandHex.isNotEmpty()) runCatching { Color.parseColor(brandHex) }.getOrNull() else null
+        val customSeed = if (!sloth) uiStore.customAccent else null
+        val seed = brandSeed ?: customSeed
+
+        // Overlays that sit UNDER the harmonised seed palette (or stand alone without one).
+        // A custom accent replaces the preset palette in the activity path too, so it
+        // contributes no underlay.
+        val underlay: Int? = when {
+            sloth ->
+                if (night) R.style.ThemeOverlay_ClashFest_Sloth_Dark
+                else R.style.ThemeOverlay_ClashFest_Sloth_Light
+            customSeed == null -> paletteOverlay(uiStore.themePalette, night)
+            else -> null
+        }
+
+        val themed: Context = if (seed != null) {
+            seededContext(activity, seed, underlay, night, uiStore.trueBlack)
+        } else {
+            var ctx: Context = activity
+            underlay?.let { ctx = ContextThemeWrapper(activity, it) }
+            if (!sloth && uiStore.dynamicColors) {
+                // No content seed → material returns a plain (loader-free) wrapper; safe to nest.
+                ctx = DynamicColors.wrapContextIfAvailable(ctx)
+            }
+            if (!sloth && night && uiStore.trueBlack) {
+                ctx = if (ctx === activity) {
+                    ContextThemeWrapper(activity, R.style.ThemeOverlay_ClashFest_TrueBlack)
+                } else {
+                    ctx.apply { theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true) }
+                }
+            }
+            ctx
+        }
+
+        // What the wrapper actually carries — owned contract shared with applyToActivity.
+        store.lastAppliedAccent = if (brandSeed != null) brandHex else ""
+        if (brandSeed != null) {
+            com.github.kr328.clash.common.log.Log.d(
+                "BrandThemeApplier: themed wrapper carries brand accent=$brandHex",
+            )
+        }
+        return themed
+    }
+
+    /**
+     * Context-wrapper twin of [applySeed]: harmonised M3 palette from [seed] + neutral off-state
+     * surface pin (+ TrueBlack re-pin in night). Material's content-based dynamic color needs
+     * API 30+ (ResourcesLoader) — exactly the same gate [applySeed] is behind, so the two paths
+     * light up on the same devices.
+     *
+     * ⚠ Material's loader-wrapper MUST wrap the Activity directly. Nesting it over another
+     * ContextThemeWrapper silently drops theme attr entries when the base theme is copied into
+     * the forked Resources — device-verified crash on inflation
+     * (`Failed to resolve attribute … selectableItemBackgroundBorderless` with
+     * PaletteRose_Dark chained under PersonalizedColors). So [underlay] (Sloth / preset palette)
+     * is applied onto the SAME wrapper's theme, with the seed palette re-asserted on top to keep
+     * the activity path's overlay order (brand always wins).
+     */
+    private fun seededContext(
+        activity: Activity,
+        seed: Int,
+        underlay: Int?,
+        night: Boolean,
+        trueBlack: Boolean,
+    ): Context {
+        val wrapped = DynamicColors.wrapContextIfAvailable(
+            activity,
+            DynamicColorsOptions.Builder()
+                .setContentBasedSource(seed)
+                .build(),
+        )
+        if (wrapped === activity) {
+            // Harmoniser unavailable (pre-API-30): match applySeed — the underlay + neutral pin
+            // (and TrueBlack re-pin) still apply.
+            val ctx = ContextThemeWrapper(
+                activity,
+                underlay ?: R.style.ThemeOverlay_App_BrandNeutralSurfaces,
+            )
+            if (underlay != null) {
+                ctx.theme.applyStyle(R.style.ThemeOverlay_App_BrandNeutralSurfaces, true)
+            }
+            if (night && trueBlack) {
+                ctx.theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+            }
+            return ctx
+        }
+        // Android 16 (device-verified): Theme.setTo() into the wrapper's forked Resources loses
+        // the copied base-theme content — every attr the activity theme provided resolves as
+        // missing and inflation crashes on the first `?attr/` lookup. Re-apply the activity's
+        // manifest theme with force=false: it only fills the holes, so everything the
+        // personalized (seed) overlay defined stays on top.
+        val baseTheme = runCatching {
+            activity.packageManager.getActivityInfo(activity.componentName, 0).themeResource
+        }.getOrDefault(0)
+        if (baseTheme != 0) {
+            wrapped.theme.applyStyle(baseTheme, false)
+        }
+        if (underlay != null) {
+            wrapped.theme.applyStyle(underlay, true)
+            // Re-assert the harmonised palette over the underlay — same end state as the
+            // activity path, where the seed is applied after Sloth / preset palette.
+            wrapped.theme.applyStyle(
+                com.google.android.material.R.style.ThemeOverlay_Material3_PersonalizedColors,
+                true,
+            )
+        }
+        wrapped.theme.applyStyle(R.style.ThemeOverlay_App_BrandNeutralSurfaces, true)
+        if (night && trueBlack) {
+            wrapped.theme.applyStyle(R.style.ThemeOverlay_ClashFest_TrueBlack, true)
+        }
+        return wrapped
+    }
+
+    private fun isNight(context: Context): Boolean =
+        (context.resources.configuration.uiMode and
+            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+            android.content.res.Configuration.UI_MODE_NIGHT_YES
+
+    /**
+     * Preset palette → theme-overlay style, per day/night. Single source of truth shared by
+     * BaseActivity.applyDayNight (activity-theme path, all other screens) and [themedContextFor]
+     * (wrapper path, main screen).
+     */
+    fun paletteOverlay(palette: ThemePalette, night: Boolean): Int? = when (palette) {
+        ThemePalette.Clash -> null
+        ThemePalette.Blue -> if (night) R.style.ThemeOverlay_ClashFest_PaletteBlue_Dark else R.style.ThemeOverlay_ClashFest_PaletteBlue_Light
+        ThemePalette.Violet -> if (night) R.style.ThemeOverlay_ClashFest_PaletteViolet_Dark else R.style.ThemeOverlay_ClashFest_PaletteViolet_Light
+        ThemePalette.Rose -> if (night) R.style.ThemeOverlay_ClashFest_PaletteRose_Dark else R.style.ThemeOverlay_ClashFest_PaletteRose_Light
+        ThemePalette.Amber -> if (night) R.style.ThemeOverlay_ClashFest_PaletteAmber_Dark else R.style.ThemeOverlay_ClashFest_PaletteAmber_Light
+        ThemePalette.Mint -> if (night) R.style.ThemeOverlay_ClashFest_PaletteMint_Dark else R.style.ThemeOverlay_ClashFest_PaletteMint_Light
+        ThemePalette.Graphite -> if (night) R.style.ThemeOverlay_ClashFest_PaletteGraphite_Dark else R.style.ThemeOverlay_ClashFest_PaletteGraphite_Light
     }
 
     private val HEX_COLOR = Regex("^#[0-9A-Fa-f]{6}$")
 
     /**
      * The accent that can actually be baked into the theme: a `#RRGGBB` hex, or "" otherwise.
-     * BOTH [applyToActivity] (what is applied) and [maybeRecreateOnAccentChange] (what is desired)
-     * MUST derive their accent through this. Otherwise a non-blank-but-unapplicable accent would
-     * ping-pong applied="" vs desired=raw and recreate the Activity on every dashboard tick
-     * (a recreate storm). Pure + matches BrandValidation.cleanHexColor's accepted form, so it is
+     * BOTH [applyToActivity]/[themedContextFor] (what is applied) and [accentStale] (what is
+     * desired) MUST derive their accent through this. Otherwise a non-blank-but-unapplicable
+     * accent would ping-pong applied="" vs desired=raw and re-inflate the design on every
+     * dashboard tick (a soft-recreate storm). Pure + matches BrandValidation.cleanHexColor's accepted form, so it is
      * unit-testable without android.graphics.Color (stubbed in JVM tests).
      */
     internal fun applicableAccent(hex: String?): String =

--- a/design/src/main/java/com/github/kr328/clash/design/util/Context.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/util/Context.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.design.util
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -12,17 +13,19 @@ import com.github.kr328.clash.common.compat.fromHtmlCompat
 val Context.layoutInflater: LayoutInflater
     get() = LayoutInflater.from(this)
 
+/**
+ * The [Activity] hosting this context, unwrapping any [ContextWrapper] chain — designs may be
+ * inflated from a ContextThemeWrapper over their activity (MainDesign under a brand accent)
+ * instead of the activity itself.
+ */
+tailrec fun Context.hostActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.hostActivity()
+    else -> null
+}
+
 val Context.root: ViewGroup?
-    get() {
-        return when (this) {
-            is Activity -> {
-                findViewById(android.R.id.content)
-            }
-            else -> {
-                null
-            }
-        }
-    }
+    get() = hostActivity()?.findViewById(android.R.id.content)
 
 fun Context.getPixels(@DimenRes resId: Int): Int {
     return resources.getDimensionPixelSize(resId)

--- a/design/src/test/java/com/github/kr328/clash/design/branding/BrandThemeApplierTest.kt
+++ b/design/src/test/java/com/github/kr328/clash/design/branding/BrandThemeApplierTest.kt
@@ -4,11 +4,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Guards the recreate-loop fix: `applyToActivity` (what's applied) and
- * `maybeRecreateOnAccentChange` (what's desired) both derive the accent through
+ * Guards the recreate-loop fix: `applyToActivity`/`themedContextFor` (what's applied) and
+ * `accentStale` (what's desired) all derive the accent through
  * [BrandThemeApplier.applicableAccent]. As long as that single function decides
  * applicability, applied and desired can never disagree, so an unapplicable accent
- * cannot ping-pong into an endless Activity recreate.
+ * cannot ping-pong into an endless soft-recreate storm.
  */
 class BrandThemeApplierTest {
 


### PR DESCRIPTION
## Why

Switching to/away from a branded profile changes the M3 accent baked into the theme at
inflation time, so `BrandThemeApplier` used to call `Activity.recreate()`. On Android 16
(Pixel 7 Pro) destroying MainActivity probabilistically crashes the whole process with a
platform ContentCapture SIGABRT (`Parcel.markForBinder → finishSession`), regardless of
timing — debounce/idle/settle-gate approaches were all tried and reverted. The only
structural fix is to never destroy the Activity on this path.

## What

**Soft recreate:** `MainActivity.main()` is now a design-generation loop — each iteration
derives a themed `ContextThemeWrapper` (`BrandThemeApplier.themedContextFor`), inflates a
fresh `MainDesign` from it and runs the dashboard loop (`runDashboard`, the moved body of
the old `main()`) inside a `coroutineScope`; a `SoftRecreate` signal cancels every child
(tickers, refresh consumer, jobs) via structured concurrency and loops. The Activity
object survives.

- **Theme delivery:** the wrapper carries the full overlay stack (Sloth / preset palette /
  Material You / custom accent / TrueBlack / brand accent, in `applyDayNight`'s order);
  Main's own Activity theme stays a virgin config-driven base
  (`themeOverlaysOnActivityTheme = false`). Overlays can never be *un*-applied from a live
  theme, so this is what makes "switch away from a brand" and day/night rebasing converge.
- **Triggers:** pure `accentStale()` level-check on every `fetch()` (incl.
  `ProfileUpdateCompleted` — a brand changed/cleared by a subscription update converges
  without a switch); overridable `BaseActivity.onDayNightChanged()` (base keeps
  `recreate()`, Main routes to the soft path); the Home theme toggle (`CycleTheme`) now
  syncs AppCompat night mode instead of calling raw `recreate()` (which also skipped the
  night-mode sync entirely); ThemeSettings palette changes nudge Main softly too.
- **State:** the active bottom tab is captured/restored across re-inflations; everything
  else repopulates through the existing fetch/ticker paths. Per-run session flags
  (`isToggleStatusInFlight`, `isCheckingUpdates`, traffic memo) reset with the scope.
- **Dialogs/menus/sheets** spawned by MainActivity inflate from the design's wrapper
  context (the brand accent lives there now); `Context.root` / `Design` insets unwrap
  ContextWrapper chains.

**Android 16 platform workaround** (found while verifying): `Theme.setTo()` into the
loader-wrapper's forked Resources (`DynamicColors.wrapContextIfAvailable` +
content-based seed) silently drops the copied theme content — inflation crashes on the
first `?attr/` lookup (`selectableItemBackgroundBorderless`), a guaranteed crash-loop
with brand accent + preset palette combined. Fixed by re-applying the activity's manifest
theme with `force=false` after wrapping (fills only the holes; the personalized palette
stays on top).

## Verification (Pixel 7 Pro, Android 16, VPN up)

- 22 scripted branded↔unbranded profile switches — every re-inflation on the **same
  Activity instance**, crash buffer empty, accent correct both ways (brand purple ↔ user
  Rose palette), Operator tab appears/disappears with the brand, Profiles tab preserved.
- 10 day/night flips (`cmd uimode night`) — soft path, same instance, both modes render
  correctly.
- `:app:assembleAlphaDebug` + unit tests green.

## Out of scope

- Other activities keep stock `recreate()` (short-lived, negligible crash odds).
- Font-scale / language changes still hard-recreate Main (they must re-run
  `attachBaseContext`) — the residual ContentCapture risk on those rare paths is accepted.
- Manual passes still open: dialog surfaces under a brand, operator-recolors-accent-via-
  update scenario (shares the verified code path).
