### PR TITLE
feat(network): react to default-network switches - instant auto-group failover

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -669,6 +669,13 @@ class MainActivity : BaseActivity<MainDesign>() {
                             }
                         }
 
+                        // Sent by NetworkObserveModule after a default-network switch: stale
+                        // connections were closed and group health checks forced — re-fetch so
+                        // the Home node row shows where the auto groups converged, without
+                        // waiting for the next ticker.
+                        Event.ConnectionsChanged ->
+                            scheduleDashboardRefresh(force = true)
+
                         else -> Unit
                     }
                 }

--- a/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
@@ -81,6 +81,14 @@ class NetworkSettingsDesign(
                 summary = R.string.keep_connections_on_old_proxy_summary,
             )
 
+            // Read live by NetworkObserveModule on every network event — no VPN restart needed,
+            // hence not part of vpnDependencies.
+            switch(
+                value = srvStore::networkSwitchReaction,
+                title = R.string.network_switch_reaction,
+                summary = R.string.network_switch_reaction_summary,
+            )
+
             category(R.string.vpn_service_options)
 
             switch(

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -522,6 +522,8 @@
     <string name="keep_connections_on_old_proxy_summary">По умолчанию ClashFest закрывает активные соединения после ручной смены прокси, чтобы новый трафик сразу пошёл через выбранный сервер. Включите эту опцию, чтобы оставлять текущие соединения на старом прокси — полезно для долгих загрузок, видеостримов или игровых сессий, которые не хочется обрывать.</string>
     <string name="proxy_switch_selector_failed">Не удалось сменить прокси. Текущие соединения не тронуты.</string>
     <string name="proxy_switch_close_connections_failed">Прокси сменён, но активные соединения закрыть не удалось.</string>
+    <string name="network_switch_reaction">Реагировать на смену сети</string>
+    <string name="network_switch_reaction_summary">При смене сети (Wi-Fi ↔ мобильный интернет) сразу закрывать устаревшие соединения и перепроверять группы прокси — автоматические группы мгновенно выбирают рабочий сервер, не дожидаясь следующей плановой проверки.</string>
 
     <string name="bypass_private_network">Игнорировать частные сети</string>
     <string name="bypass_private_network_summary">Игнорировать адреса частных сетей</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -876,6 +876,8 @@
     <string name="home_qr">二维码</string>
     <string name="keep_connections_on_old_proxy">切换后保留旧代理上的连接</string>
     <string name="keep_connections_on_old_proxy_summary">默认情况下,手动切换代理后 ClashFest 会关闭活动连接,使新流量立即走所选代理。开启此项可让正在进行的连接保留在旧代理上——适合不想中断的大文件下载、视频流或游戏会话。</string>
+    <string name="network_switch_reaction">响应网络切换</string>
+    <string name="network_switch_reaction_summary">当设备切换网络(Wi-Fi ↔ 移动数据)时,立即关闭失效连接并重新测试代理组,使自动组马上选择可用服务器,而不必等待下一次计划的健康检查。</string>
     <string name="launch_name_alpha">ClashFest</string>
     <string name="main_activity_summary">实时连接与诊断</string>
     <string name="main_activity_title">活动</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -666,6 +666,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="keep_connections_on_old_proxy_summary">By default ClashFest closes active connections after a manual proxy switch so new traffic uses the selected proxy immediately. Enable this to keep running connections on the previous proxy — useful for long downloads, video streams, or game sessions you don\'t want to interrupt.</string>
     <string name="proxy_switch_selector_failed">Could not switch proxy. Existing connections were left untouched.</string>
     <string name="proxy_switch_close_connections_failed">Proxy switched, but active connections could not be closed.</string>
+    <string name="network_switch_reaction">React to network changes</string>
+    <string name="network_switch_reaction_summary">When the device switches networks (Wi-Fi ↔ mobile data), immediately close stale connections and re-test proxy groups so automatic groups pick a working server right away — instead of waiting for the next scheduled health check.</string>
 
     <string name="bypass_private_network">Bypass Private Network</string>
     <string name="bypass_private_network_summary">Bypass private network addresses</string>

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkObserveModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkObserveModule.kt
@@ -3,10 +3,13 @@ package com.github.kr328.clash.service.clash.module
 import android.app.Service
 import android.net.*
 import android.os.Build
+import android.os.SystemClock
 import androidx.core.content.getSystemService
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.core.Clash
+import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.asSocketAddressText
+import com.github.kr328.clash.service.util.sendConnectionsChanged
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.select
@@ -17,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 class NetworkObserveModule(service: Service) : Module<Network>(service) {
     private val connectivity = service.getSystemService<ConnectivityManager>()!!
+    private val store = ServiceStore(service)
     private val networks: Channel<Network> = Channel(Channel.CONFLATED)
     private val shouldEmitParentNetwork =
         service is VpnService && Build.VERSION.SDK_INT in 22..28
@@ -136,6 +140,69 @@ class NetworkObserveModule(service: Service) : Module<Network>(service) {
         }
     }
 
+    /** Highest-priority (= default route) network we last observed, per [networkToInt]. */
+    @Volatile
+    private var defaultNetwork: Network? = null
+    private var defaultNetworkInitialized = false
+    private var lastSwitchReactionAt = 0L
+    private val moduleStartedAt = SystemClock.elapsedRealtime()
+
+    /**
+     * The missing half of network handling (the callback above only refreshes DNS): when the
+     * DEFAULT network actually changes — Wi-Fi <-> cellular, Wi-Fi roaming, airplane-mode
+     * recovery — the engine's existing sockets ran over the dead network and its
+     * fallback/url-test groups won't re-evaluate the world until their test `interval` expires
+     * (minutes of "VPN on, nothing loads", e.g. leaving home Wi-Fi onto whitelisted LTE).
+     *
+     * So on a real switch we (1) close stale connections — re-dials go out over the new network
+     * and re-match the current group state, and (2) force-run group health checks so
+     * fallback/url-test converge in one probe round-trip instead of an interval. Capability
+     * chirps on the SAME network don't qualify — only a change of the winning [Network] handle.
+     */
+    private fun reactToDefaultNetworkSwitch() {
+        val winner = networkInfos.entries.minByOrNull { networkToInt(it) }?.key
+        if (!defaultNetworkInitialized) {
+            // First observation after module start: just record it. VPN startup delivers the
+            // initial batch of onAvailable events — reacting there would kill newborn
+            // connections for no reason.
+            defaultNetworkInitialized = true
+            defaultNetwork = winner
+            return
+        }
+        if (winner == defaultNetwork) return
+        // Everything vanished (airplane mode): nothing to probe; the recovery event reacts.
+        if (winner == null) {
+            defaultNetwork = null
+            return
+        }
+        if (!store.networkSwitchReaction) {
+            defaultNetwork = winner
+            return
+        }
+
+        val now = SystemClock.elapsedRealtime()
+        if (now - moduleStartedAt < 5_000) {
+            // Startup grace: the initial event burst can elect Wi-Fi after briefly seeing
+            // cellular — commit without reacting.
+            defaultNetwork = winner
+            return
+        }
+        // Flap guard: a bouncing network must not storm the engine with close/probe cycles.
+        // Deliberately do NOT commit defaultNetwork here — the periodic capability chirps of
+        // the surviving network retry the reaction once the guard window has passed, so a
+        // switch that lands inside the window is deferred, not lost.
+        if (now - lastSwitchReactionAt < 3_000) return
+        lastSwitchReactionAt = now
+        defaultNetwork = winner
+
+        val closed = Clash.closeAllConnections()
+        Clash.healthCheckAll()
+        Log.i("NetworkObserve default network switched -> $winner: closed $closed stale connections, forced group health checks")
+        // Nudge the UI (Event.ConnectionsChanged) so the dashboard re-fetches where the auto
+        // groups converged instead of waiting for the next ticker.
+        service.sendConnectionsChanged()
+    }
+
     override suspend fun run() {
         register()
 
@@ -145,6 +212,7 @@ class NetworkObserveModule(service: Service) : Module<Network>(service) {
                     networks.onReceive {
                         val network = coalesceNetworkEvents(it)
                         notifyDnsChange()
+                        reactToDefaultNetworkSwitch()
                         if (shouldEmitParentNetwork) {
                             enqueueEvent(network)
                         }

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -134,6 +134,17 @@ class ServiceStore(context: Context) {
         defaultValue = false
     )
 
+    /**
+     * When true (default), a default-network switch (Wi-Fi <-> cellular, Wi-Fi roaming,
+     * airplane-mode recovery) closes stale connections and force-runs group health checks so
+     * fallback/url-test groups converge immediately instead of waiting out their test interval.
+     * See NetworkObserveModule. Off = legacy behavior (DNS refresh only).
+     */
+    var networkSwitchReaction by store.boolean(
+        key = "network_switch_reaction",
+        defaultValue = true
+    )
+
     var geoDataSourcePreset: GeoDataSourcePreset by store.enum(
         key = "geo_data_source_preset",
         defaultValue = GeoDataSourcePreset.Global,


### PR DESCRIPTION
On Wi-Fi <-> cellular switches (and Wi-Fi roaming / airplane-mode recovery) the module previously only refreshed DNS: the engine's sockets ran over the dead network and fallback/url-test groups stayed blind until their test interval expired - minutes of 'VPN on, nothing loads' when leaving home Wi-Fi onto whitelisted LTE.

Now a real default-network change (winning Network handle changed, not capability chirps) closes stale connections (re-dials go out over the new network) and force-runs group health checks, so auto groups converge in one probe round-trip. Guards: no reaction on VPN startup (5s grace), 3s flap guard with deferred retry. Toggle in Network settings (on by default, read live). Main refreshes the dashboard on the signal so the node row shows where Auto converged.

Device-verified on Pixel: reaction ~100ms after the event burst settles; 4 stale LTE connections closed on Wi-Fi return; no repeat reactions on capability chirps.