### PR TITLE
fix(security): exclude age profiles from Android backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:allowBackup="true"
         android:banner="@mipmap/ic_banner"
         android:fullBackupContent="@xml/full_backup_content"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/application_name"
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include
+            domain="sharedpref"
+            path="." />
+        <include
+            domain="database"
+            path="." />
+        <exclude
+            domain="database"
+            path="profiles" />
+        <exclude
+            domain="database"
+            path="profiles-shm" />
+        <exclude
+            domain="database"
+            path="profiles-wal" />
+        <include
+            domain="file"
+            path="imported" />
+        <exclude
+            domain="file"
+            path="imported" />
+        <include
+            domain="file"
+            path="pending" />
+        <exclude
+            domain="file"
+            path="pending" />
+        <include
+            domain="file"
+            path="clash/override.json" />
+    </cloud-backup>
+    <device-transfer>
+        <include
+            domain="sharedpref"
+            path="." />
+        <include
+            domain="database"
+            path="." />
+        <exclude
+            domain="database"
+            path="profiles" />
+        <exclude
+            domain="database"
+            path="profiles-shm" />
+        <exclude
+            domain="database"
+            path="profiles-wal" />
+        <include
+            domain="file"
+            path="imported" />
+        <exclude
+            domain="file"
+            path="imported" />
+        <include
+            domain="file"
+            path="pending" />
+        <exclude
+            domain="file"
+            path="pending" />
+        <include
+            domain="file"
+            path="clash/override.json" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/full_backup_content.xml
+++ b/app/src/main/res/xml/full_backup_content.xml
@@ -6,10 +6,25 @@
     <include
         domain="database"
         path="." />
+    <exclude
+        domain="database"
+        path="profiles" />
+    <exclude
+        domain="database"
+        path="profiles-shm" />
+    <exclude
+        domain="database"
+        path="profiles-wal" />
     <include
         domain="file"
         path="imported" />
+    <exclude
+        domain="file"
+        path="imported" />
     <include
+        domain="file"
+        path="pending" />
+    <exclude
         domain="file"
         path="pending" />
     <include


### PR DESCRIPTION
### Motivation
- A recent change persisted age secret keys into Room tables and rewrote age-encrypted subscriptions to plaintext under the app files directory, which are covered by the app's backup selection; this exposes keys and decrypted subscription contents to Android cloud/device-transfer and Auto Backup.
- The goal is to prevent age identities and decrypted profile YAML from being selected for backup or device transfer while preserving other non-sensitive backups.

### Description
- Add Android 12+ data extraction rules file `@xml/data_extraction_rules` that excludes the `profiles` database (and `-shm`/`-wal`) and the `imported`/`pending` profile directories for both cloud-backup and device-transfer paths.
- Wire the data extraction rules into the manifest via `android:dataExtractionRules="@xml/data_extraction_rules"` on the `<application>` tag so Android 12+ backup behaviors respect the exclusions.
- Update legacy Auto Backup selection `app/src/main/res/xml/full_backup_content.xml` to explicitly exclude the `profiles` DB (and `-shm`/`-wal`) and to exclude `files/imported` and `files/pending` so decrypted configs and persisted age keys are not included.
- Keep other backup inclusions (shared prefs and `clash/override.json`) intact to avoid regressions in non-sensitive data preservation.

### Testing
- Parsed and validated the three modified/added XML files with `python3`/`xml.etree.ElementTree` to ensure they are well-formed and the intended `exclude` entries are present, and the assertions passed.
- Ran `git diff --check` to catch whitespace/xml issues and it returned clean results.
- Attempted project build (`./gradlew assembleAlphaDebug` / `./gradlew assembleAlphaDebug --stacktrace`), but the build could not complete in this environment because the CI shell lacked an executable `gradlew.bat` and the host Java is OpenJDK 25 (the project requires JDK 21), so the APK build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50d5094ccc832c8b2dfc43e9f4f5dc)