### PR TITLE
fix(security): handle quoted top-level YAML keys in hardener

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
@@ -113,7 +113,7 @@ class MihomoConfigDocument private constructor(
 }
 
 private object TopLevelYamlBlockPatcher {
-    private val topLevelKeyPattern = Regex("^[A-Za-z0-9_.-]+\\s*:.*$")
+    private val topLevelKeyPattern = Regex("""^(?:[A-Za-z0-9_.-]+|"(?:[^"\\]|\\.)+"|'(?:[^']|'')+')\s*:.*$""")
 
     fun replace(text: String, key: String, value: Any?): String {
         val replacement = YamlFormatting.blockYaml()
@@ -184,7 +184,8 @@ private object TopLevelYamlBlockPatcher {
 
     private fun isTopLevelKey(line: String, key: String): Boolean {
         if (line.startsWith(' ') || line.startsWith('\t')) return false
-        return line == "$key:" || line.startsWith("$key:")
+        val escapedKey = Regex.escape(key)
+        return Regex("^(?:$escapedKey|\"$escapedKey\"|'$escapedKey')\\s*:.*$").matches(line)
     }
 
     private fun isAnyTopLevelKey(line: String): Boolean {

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt
@@ -38,6 +38,24 @@ class YamlHardenerTest {
     }
 
     @Test
+    fun strict_dropsQuotedListenersBlock() {
+        val input = """
+            "listeners":
+              - name: leaky
+                type: socks
+                listen: 0.0.0.0
+                port: 1080
+            'proxies': []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        val root = parse(hardened!!)
+        assertNull("Strict must remove quoted listeners blocks", root["listeners"])
+        assertFalse("Strict must strip the quoted listeners source text", hardened.contains("listen: 0.0.0.0"))
+        assertTrue("following quoted top-level keys must survive", root.containsKey("proxies"))
+    }
+
+    @Test
     fun compat_rebindsListenersToLoopback() {
         val input = """
             listeners:
@@ -163,6 +181,22 @@ class YamlHardenerTest {
         }
         // unrelated keys survive
         assertTrue(root.containsKey("proxies"))
+    }
+
+    @Test
+    fun strict_stripsQuotedGlobalProxyPorts() {
+        val input = """
+            "mixed-port": 7890
+            'socks-port': 7891
+            proxies: []
+        """.trimIndent()
+        val hardened = YamlHardener.hardenYaml(input, ProxyHardeningMode.Strict)
+        assertNotNull(hardened)
+        val root = parse(hardened!!)
+        assertNull(root["mixed-port"])
+        assertNull(root["socks-port"])
+        assertFalse(hardened.contains("mixed-port"))
+        assertFalse(hardened.contains("socks-port"))
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- A semantic/textual mismatch allowed quoted top-level YAML keys (for example `"listeners":`) to bypass Strict hardening because the source-level block remover only recognized unquoted literal keys. 
- The change ensures that any top-level blocks or global port keys detected by the YAML parser are also removed from the original source text regardless of quoting style to prevent exposure of unauthenticated listeners or ports.

### Description
- Updated the top-level YAML block patcher to recognize unquoted, double-quoted, and single-quoted keys by expanding `topLevelKeyPattern` and changing `isTopLevelKey` to match `"key":`, `'key':` and unquoted `key:` forms in `service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt`.
- The `isTopLevelKey` matcher now safely escapes the searched key (`Regex.escape(key)`) and matches quoted variants so `remove`/`replace` can find and strip blocks that were previously missed.
- Added regression unit tests `strict_dropsQuotedListenersBlock` and `strict_stripsQuotedGlobalProxyPorts` to `service/src/test/java/com/github/kr328/clash/service/util/YamlHardenerTest.kt` to validate that quoted `listeners` and quoted global proxy port keys are stripped under `ProxyHardeningMode.Strict`.

### Testing
- Ran `git diff --check` which reported no whitespace or simple-diff issues and passed locally.
- Attempted to run the unit test task `:service:testDebugUnitTest` and the full assemble `assembleAlphaDebug` via `./gradlew`, but automated test execution was blocked by Gradle dependency resolution failures (HTTP 403 from configured Maven repositories) in this environment so JVM/Kotlin/Gradle integration tests could not be completed. 
- The added unit tests are present and should pass when run in an environment with network access to the configured Maven repositories and a compatible JDK (`JAVA_HOME` set to JDK 21 as required by project).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e9d6c8e4832cbf3d2796a306388a)