### PR TITLE
fix(update): verify APK updates before install

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -64,6 +64,7 @@ import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.util.RussianBypassDefaults
 import com.github.kr328.clash.util.GitHubReleaseUpdate
+import com.github.kr328.clash.util.UpdateApkVerifier
 import com.github.kr328.clash.util.AppUpdateChecker
 import com.github.kr328.clash.util.showProfileQuickEditSheet
 import com.github.kr328.clash.util.closeConnectionsAfterUserProxySwitchIfEnabled
@@ -1625,6 +1626,17 @@ class MainActivity : BaseActivity<MainDesign>() {
             Toast.makeText(this, R.string.about_download_failed, Toast.LENGTH_SHORT).show()
             return
         }
+
+        val query = DownloadManager.Query().setFilterById(downloadId)
+        dm.query(query)?.use { cursor ->
+            if (!cursor.moveToFirst()) return
+            val localUri = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI))
+            if (!UpdateApkVerifier.isTrustedDownloadedApk(this, localUri)) {
+                clearPendingDownloadState()
+                Toast.makeText(this, R.string.about_download_failed, Toast.LENGTH_SHORT).show()
+                return
+            }
+        } ?: return
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
             startActivity(

--- a/app/src/main/java/com/github/kr328/clash/UpdateActionReceiver.kt
+++ b/app/src/main/java/com/github/kr328/clash/UpdateActionReceiver.kt
@@ -3,15 +3,13 @@ package com.github.kr328.clash
 import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.util.GitHubReleaseUpdate
-import java.security.MessageDigest
+import com.github.kr328.clash.util.UpdateApkVerifier
 
 class UpdateActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
@@ -69,7 +67,7 @@ class UpdateActionReceiver : BroadcastReceiver() {
 
             val uri = dm.getUriForDownloadedFile(downloadId) ?: return
             val localUri = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI))
-            if (!isTrustedDownloadedApk(app, localUri)) {
+            if (!UpdateApkVerifier.isTrustedDownloadedApk(app, localUri)) {
                 Log.w("Reject update install: downloaded APK signature/package mismatch")
                 app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                     .edit()
@@ -108,66 +106,6 @@ class UpdateActionReceiver : BroadcastReceiver() {
             }.onFailure {
                 Log.w("Open APK installer failed: ${it.message}")
             }
-        }
-    }
-
-    private fun isTrustedDownloadedApk(app: Context, localUri: String?): Boolean {
-        if (localUri.isNullOrBlank()) return false
-        val apkPath = Uri.parse(localUri).path ?: return false
-        val pm = app.packageManager
-
-        val archiveInfo = getArchivePackageInfo(pm, apkPath) ?: return false
-        if (archiveInfo.packageName != app.packageName) return false
-
-        val installedInfo = getInstalledPackageInfo(pm, app.packageName) ?: return false
-        val installed = signaturesDigest(installedInfo)
-        val archive = signaturesDigest(archiveInfo)
-        return installed.isNotEmpty() && installed == archive
-    }
-
-    @Suppress("DEPRECATION")
-    private fun getArchivePackageInfo(pm: PackageManager, apkPath: String): PackageInfo? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            pm.getPackageArchiveInfo(
-                apkPath,
-                PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong()),
-            )
-        } else {
-            pm.getPackageArchiveInfo(apkPath, PackageManager.GET_SIGNATURES)
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun getInstalledPackageInfo(pm: PackageManager, packageName: String): PackageInfo? {
-        return runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                pm.getPackageInfo(
-                    packageName,
-                    PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong()),
-                )
-            } else {
-                pm.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
-            }
-        }.getOrNull()
-    }
-
-    @Suppress("DEPRECATION")
-    private fun signaturesDigest(info: PackageInfo): Set<String> {
-        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            val signingInfo = info.signingInfo ?: return emptySet()
-            val values = if (signingInfo.hasMultipleSigners()) {
-                signingInfo.apkContentsSigners
-            } else {
-                signingInfo.signingCertificateHistory
-            }
-            values?.toList().orEmpty()
-        } else {
-            info.signatures?.toList().orEmpty()
-        }
-
-        return signatures.mapTo(linkedSetOf()) {
-            val digest = MessageDigest.getInstance("SHA-256").digest(it.toByteArray())
-            digest.joinToString("") { b -> "%02x".format(b.toInt() and 0xff) }
         }
     }
 

--- a/app/src/main/java/com/github/kr328/clash/util/GitHubReleaseUpdate.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/GitHubReleaseUpdate.kt
@@ -47,7 +47,9 @@ object GitHubReleaseUpdate {
                     val item = assets.optJSONObject(i) ?: continue
                     val name = item.optString("name")
                     val url = item.optString("browser_download_url")
-                    if (name.endsWith(".apk", ignoreCase = true) && url.isNotBlank()) {
+                    if (name.endsWith(".apk", ignoreCase = true) &&
+                        UpdateApkVerifier.isTrustedDownloadUrl(url)
+                    ) {
                         candidates += item
                     }
                 }
@@ -93,6 +95,7 @@ object GitHubReleaseUpdate {
         apkUrl: String,
         apkName: String?,
     ): Long {
+        if (!UpdateApkVerifier.isTrustedDownloadUrl(apkUrl)) return -1L
         val dm = context.getSystemService(DownloadManager::class.java) ?: return -1L
         val fileName = (apkName ?: "clashfest-$tagName.apk")
             .replace(Regex("""[^A-Za-z0-9._-]"""), "_")

--- a/app/src/main/java/com/github/kr328/clash/util/UpdateApkVerifier.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/UpdateApkVerifier.kt
@@ -1,0 +1,105 @@
+package com.github.kr328.clash.util
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import java.net.URI
+import java.security.MessageDigest
+import java.util.Locale
+
+object UpdateApkVerifier {
+    private const val TRUSTED_SCHEME = "https"
+    private const val TRUSTED_HOST = "github.com"
+    private const val TRUSTED_OWNER = "Nemu-x"
+    private const val TRUSTED_REPO = "ClashFest"
+
+    fun isTrustedDownloadUrl(url: String?): Boolean {
+        if (url.isNullOrBlank()) return false
+        val uri = runCatching { URI(url) }.getOrNull() ?: return false
+        if (!uri.scheme.equals(TRUSTED_SCHEME, ignoreCase = true)) return false
+        if (!uri.host.equals(TRUSTED_HOST, ignoreCase = true)) return false
+
+        val segments = uri.path.orEmpty()
+            .split('/')
+            .filter { it.isNotBlank() }
+        if (segments.size < 5) return false
+        return segments[0].equals(TRUSTED_OWNER, ignoreCase = true) &&
+            segments[1].equals(TRUSTED_REPO, ignoreCase = true) &&
+            segments[2].equals("releases", ignoreCase = true) &&
+            segments[3].equals("download", ignoreCase = true) &&
+            segments.last().lowercase(Locale.ROOT).endsWith(".apk")
+    }
+
+    fun isTrustedDownloadedApk(context: Context, localUri: String?): Boolean {
+        if (localUri.isNullOrBlank()) return false
+        val apkPath = Uri.parse(localUri).path ?: return false
+        val pm = context.packageManager
+
+        val archiveInfo = getArchivePackageInfo(pm, apkPath) ?: return false
+        if (archiveInfo.packageName != context.packageName) return false
+
+        val installedInfo = getInstalledPackageInfo(pm, context.packageName) ?: return false
+        if (versionCode(archiveInfo) <= versionCode(installedInfo)) return false
+
+        val installed = signaturesDigest(installedInfo)
+        val archive = signaturesDigest(archiveInfo)
+        return installed.isNotEmpty() && installed == archive
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getArchivePackageInfo(pm: PackageManager, apkPath: String): PackageInfo? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getPackageArchiveInfo(
+                apkPath,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong()),
+            )
+        } else {
+            pm.getPackageArchiveInfo(apkPath, PackageManager.GET_SIGNATURES)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getInstalledPackageInfo(pm: PackageManager, packageName: String): PackageInfo? {
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getPackageInfo(
+                    packageName,
+                    PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong()),
+                )
+            } else {
+                pm.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+            }
+        }.getOrNull()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun versionCode(info: PackageInfo): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            info.versionCode.toLong()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun signaturesDigest(info: PackageInfo): Set<String> {
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signingInfo = info.signingInfo ?: return emptySet()
+            val values = if (signingInfo.hasMultipleSigners()) {
+                signingInfo.apkContentsSigners
+            } else {
+                signingInfo.signingCertificateHistory
+            }
+            values?.toList().orEmpty()
+        } else {
+            info.signatures?.toList().orEmpty()
+        }
+
+        return signatures.mapTo(linkedSetOf()) {
+            val digest = MessageDigest.getInstance("SHA-256").digest(it.toByteArray())
+            digest.joinToString("") { b -> "%02x".format(b.toInt() and 0xff) }
+        }
+    }
+}

--- a/app/src/test/java/com/github/kr328/clash/util/UpdateApkVerifierTest.kt
+++ b/app/src/test/java/com/github/kr328/clash/util/UpdateApkVerifierTest.kt
@@ -1,0 +1,36 @@
+package com.github.kr328.clash.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateApkVerifierTest {
+    @Test
+    fun acceptsOnlyClashFestGitHubReleaseApkUrls() {
+        assertTrue(
+            UpdateApkVerifier.isTrustedDownloadUrl(
+                "https://github.com/Nemu-x/ClashFest/releases/download/v1.2.3/clashfest-alpha-universal.apk",
+            ),
+        )
+        assertFalse(
+            UpdateApkVerifier.isTrustedDownloadUrl(
+                "http://github.com/Nemu-x/ClashFest/releases/download/v1.2.3/clashfest.apk",
+            ),
+        )
+        assertFalse(
+            UpdateApkVerifier.isTrustedDownloadUrl(
+                "https://evil.example/Nemu-x/ClashFest/releases/download/v1.2.3/clashfest.apk",
+            ),
+        )
+        assertFalse(
+            UpdateApkVerifier.isTrustedDownloadUrl(
+                "https://github.com/Other/ClashFest/releases/download/v1.2.3/clashfest.apk",
+            ),
+        )
+        assertFalse(
+            UpdateApkVerifier.isTrustedDownloadUrl(
+                "https://github.com/Nemu-x/ClashFest/releases/download/v1.2.3/checksum.txt",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- The update notification/action flow previously enqueued and launched arbitrary APK URLs from release metadata without validating origin, package identity, signer, or version, which could lead to installing attacker-controlled APKs when update metadata or TLS is compromised.
- The change closes this gap by enforcing a trusted-origin policy for release assets and validating downloaded APKs before invoking the system installer.

### Description
- Add `UpdateApkVerifier` with `isTrustedDownloadUrl` to allow only HTTPS GitHub release asset URLs for `Nemu-x/ClashFest`, and `isTrustedDownloadedApk` to verify archive package name, signer digest equality and that the archive version is newer than the installed app.
- Restrict `GitHubReleaseUpdate.fetchLatest` and `enqueueApkDownload` to only consider/enqueue APK assets that pass `UpdateApkVerifier.isTrustedDownloadUrl`.
- Validate the downloaded APK before installing in the background receiver `UpdateActionReceiver` by calling `UpdateApkVerifier.isTrustedDownloadedApk`, and reuse the same verification in the in-app flow in `MainActivity` before opening the installer.
- Add unit test `UpdateApkVerifierTest` to cover the URL allowlist behavior.

### Testing
- Ran a whitespace/patch check (`git diff --check`) which reported no issues.
- Attempted a local assemble (`./gradlew assembleAlphaDebug` / `./gradlew.bat`) but the build was blocked by the environment (Gradle/Java toolchain mismatch and Windows batch wrapper execution in this shell), so full integration build was not executed.
- Added a unit test (`UpdateApkVerifierTest`) but running `:app:testDebugUnitTest` was blocked by the container Java version (repo requires JDK 21), so the test file is present but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50fca1bafc832cadbdcfdfa1c5f4ed)