### PR TITLE
fix(ci): keep production signing out of dev builds

### DIFF
--- a/.github/workflows/prerelease-dev.yml
+++ b/.github/workflows/prerelease-dev.yml
@@ -37,24 +37,6 @@ jobs:
       - name: Grant gradlew execute permission
         run: chmod +x gradlew
 
-      - name: Restore Android signing files
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: |
-          if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ] || [ -z "$ANDROID_KEY_PASSWORD" ]; then
-            echo "Signing secrets are missing. Configure ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS / ANDROID_KEY_PASSWORD."
-            exit 1
-          fi
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > release.keystore
-          cat > signing.properties <<EOF
-          keystore.password=$ANDROID_KEYSTORE_PASSWORD
-          key.alias=$ANDROID_KEY_ALIAS
-          key.password=$ANDROID_KEY_PASSWORD
-          EOF
-
       - name: Guard - HandlerService must not exist
         run: |
           if grep -R --line-number --fixed-strings "HandlerService" app/src/main service/src/main core/src/main; then
@@ -63,8 +45,8 @@ jobs:
           fi
           echo "HandlerService guard passed."
 
-      - name: Build Alpha Release APK
-        run: ./gradlew assembleAlphaRelease
+      - name: Build Alpha Debug APK
+        run: ./gradlew assembleAlphaDebug
 
       - name: Collect APKs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: production-release
 
     steps:
       - name: Checkout
@@ -82,6 +83,10 @@ jobs:
             cp "$apk" "release-artifacts/$out"
           done
           ls -la release-artifacts
+
+      - name: Remove signing files before publishing
+        if: always()
+        run: rm -f release.keystore signing.properties
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Motivation
- Prevent production Android signing material from being exposed to the automatic `dev` CI pipeline so build logic and third-party actions running on `dev` cannot read release keystore or passwords.
- Ensure production signing is only used in a gated release path and is removed from the workspace before third-party publish steps.

### Description
- Removed the `Restore Android signing files` step from `.github/workflows/prerelease-dev.yml` to stop writing `release.keystore` and `signing.properties` into the dev workflow workspace.
- Reverted the dev pre-release build to the debug variant by changing `./gradlew assembleAlphaRelease` to `./gradlew assembleAlphaDebug` in `.github/workflows/prerelease-dev.yml` so branch builds do not need production signing material.
- Added `environment: production-release` to `.github/workflows/release.yml` to gate production signing behind a protected environment and added a step to `rm -f release.keystore signing.properties` before publishing artifacts to ensure signing files are removed from the workspace.

### Testing
- Executed `python3` assertions that verify the dev workflow no longer references production signing files and that the release workflow has environment gating and the signing-file cleanup, and the assertions passed.
- Ran `git diff --check` and committed the changes with message `fix(ci): keep production signing out of dev builds` with no diff warnings.
- Attempted `./gradlew assembleAlphaDebug` locally but the build failed in this container due to an incompatible Java runtime (CI requires JDK 21) and `./gradlew.bat` was not executable on Linux, so full Gradle build verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51097053c8832c902bb53c3819a520)