### PR TITLE
fix(security): apply runtime listener hardening before load

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -115,13 +115,7 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                 // fetch) still needs the engine-side key at load.
                 Clash.setAgeSecretKey(active.ageSecretKey?.takeIf { it.isNotBlank() })
 
-                suspend fun applyPostLoad() {
-                    val staleProviderKeySelections = SelectionDao().querySelections(active.uuid)
-                        .filter { it.selected.matches(Regex("^sub\\d+$", RegexOption.IGNORE_CASE)) }
-                    for (s in staleProviderKeySelections) {
-                        SelectionDao().removeSelected(s.uuid, s.proxy)
-                    }
-
+                suspend fun applyPreLoadHardening() {
                     val sessionOverride = Clash.queryOverride(Clash.OverrideSlot.Session)
                     val hardened = ProxyHardener.applyTo(
                         configuration = sessionOverride,
@@ -130,6 +124,14 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                     )
                     if (hardened) {
                         Clash.patchOverride(Clash.OverrideSlot.Session, sessionOverride)
+                    }
+                }
+
+                suspend fun applyPostLoad() {
+                    val staleProviderKeySelections = SelectionDao().querySelections(active.uuid)
+                        .filter { it.selected.matches(Regex("^sub\\d+$", RegexOption.IGNORE_CASE)) }
+                    for (s in staleProviderKeySelections) {
+                        SelectionDao().removeSelected(s.uuid, s.proxy)
                     }
 
                     val remove = SelectionDao().querySelections(active.uuid)
@@ -169,6 +171,7 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                     try {
                         GeoUrlSanitizer.sanitizeProfile(profileDir)
                         service.ensureBundledGeoAssets()
+                        applyPreLoadHardening()
                         Clash.load(profileDir).await()
                         applyPostLoad()
                         break


### PR DESCRIPTION
### Motivation
- Prevent a timing window where an imported malicious profile can cause mihomo to apply LAN-accessible listeners before runtime hardening (loopback bind and SOCKS auth) is written and consumed.
- Ensure the Session override containing hardened listener/auth settings is present when the native config processing (`patchOverride`/`ApplyConfig`) runs so the runtime never briefly exposes unauthenticated/listener surfaces.

### Description
- Moved session-level hardening into a pre-load step by adding `applyPreLoadHardening()` that queries, hardens via `ProxyHardener.applyTo(...)`, and writes the Session override when needed. (file: `service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt`).
- Call `applyPreLoadHardening()` immediately before `Clash.load(profileDir).await()` so the override is present during native processing and parsing. (same file).
- Kept post-load behavior (stale selector cleanup, selector patching, `StatusProvider` update, and `sendProfileLoaded`) in `applyPostLoad()` so runtime-only housekeeping still runs after a successful load. (same file).

### Testing
- Ran `git diff --check` to validate no whitespace/patch issues; this passed.
- Performed a source-order verification via a Python check confirming `applyPreLoadHardening()` runs before `Clash.load(profileDir).await()`; this check passed.
- Attempted unit test invocation via Gradle but could not run Android unit tests in this environment: `gradlew.bat` is not executable in this Linux shell and the available JDK (`25.0.2`) differs from the project-required JDK 21, so `:service:testDebugUnitTest` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510cf7fc14832cbce31de09240a707)