### PR TITLE
fix(security): apply runtime auth before profile load

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -115,13 +115,7 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                 // fetch) still needs the engine-side key at load.
                 Clash.setAgeSecretKey(active.ageSecretKey?.takeIf { it.isNotBlank() })
 
-                suspend fun applyPostLoad() {
-                    val staleProviderKeySelections = SelectionDao().querySelections(active.uuid)
-                        .filter { it.selected.matches(Regex("^sub\\d+$", RegexOption.IGNORE_CASE)) }
-                    for (s in staleProviderKeySelections) {
-                        SelectionDao().removeSelected(s.uuid, s.proxy)
-                    }
-
+                fun applySessionOverrideBeforeLoad() {
                     val sessionOverride = Clash.queryOverride(Clash.OverrideSlot.Session)
                     val hardened = ProxyHardener.applyTo(
                         configuration = sessionOverride,
@@ -130,6 +124,14 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                     )
                     if (hardened) {
                         Clash.patchOverride(Clash.OverrideSlot.Session, sessionOverride)
+                    }
+                }
+
+                suspend fun applyPostLoad() {
+                    val staleProviderKeySelections = SelectionDao().querySelections(active.uuid)
+                        .filter { it.selected.matches(Regex("^sub\\d+$", RegexOption.IGNORE_CASE)) }
+                    for (s in staleProviderKeySelections) {
+                        SelectionDao().removeSelected(s.uuid, s.proxy)
                     }
 
                     val remove = SelectionDao().querySelections(active.uuid)
@@ -169,6 +171,7 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                     try {
                         GeoUrlSanitizer.sanitizeProfile(profileDir)
                         service.ensureBundledGeoAssets()
+                        applySessionOverrideBeforeLoad()
                         Clash.load(profileDir).await()
                         applyPostLoad()
                         break

--- a/service/src/test/java/com/github/kr328/clash/service/clash/module/ConfigurationModuleSourceGuardTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/clash/module/ConfigurationModuleSourceGuardTest.kt
@@ -1,0 +1,32 @@
+package com.github.kr328.clash.service.clash.module
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ConfigurationModuleSourceGuardTest {
+    @Test
+    fun sessionOverrideIsPatchedBeforeProfileLoad() {
+        val source = findRepoRoot()
+            .resolve("service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt")
+            .readText()
+
+        val overrideIndex = source.indexOf("applySessionOverrideBeforeLoad()\n                        Clash.load(profileDir).await()")
+        val loadIndex = source.indexOf("Clash.load(profileDir).await()")
+
+        assertTrue("ConfigurationModule must patch the session override immediately before Clash.load", overrideIndex >= 0)
+        assertTrue("ConfigurationModule must load the profile", loadIndex >= 0)
+        assertTrue(
+            "Runtime auth/session hardening must be present before Mihomo parses and applies the profile",
+            overrideIndex < loadIndex,
+        )
+    }
+
+    private fun findRepoRoot(): File {
+        var current = File(System.getProperty("user.dir")).absoluteFile
+        while (true) {
+            if (current.resolve("settings.gradle.kts").isFile) return current
+            current = current.parentFile ?: error("Unable to find repository root")
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent a timing window where an attacker-controlled subscription can expose local/LAN proxy listeners without the generated runtime credentials because session auth was written only after Mihomo parsed and applied the profile.
- Ensure runtime-only credentials and other hardening from `RuntimeSocksAuth` / `ProxyHardener` are consumed by the engine during the initial `Clash.load` so protections are effective immediately.

### Description
- Add `applySessionOverrideBeforeLoad()` that queries the session override, applies `ProxyHardener` (which invokes `RuntimeSocksAuth`) and writes the session override back via `Clash.patchOverride` if mutated.
- Call `applySessionOverrideBeforeLoad()` immediately before `Clash.load(profileDir).await()` so Mihomo sees the hardened/session override on first load; leave existing post-load cleanup and notifications unchanged.
- Add a source-guard unit test `ConfigurationModuleSourceGuardTest` that asserts the session-override patch call appears immediately before the `Clash.load` call in `ConfigurationModule.kt`.
- Files changed: `service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt` and added `service/src/test/java/com/github/kr328/clash/service/clash/module/ConfigurationModuleSourceGuardTest.kt`.

### Testing
- Ran a local source-order check via `python3` that looks for the `applySessionOverrideBeforeLoad()` call immediately before `Clash.load(profileDir).await()`, and it succeeded.
- Attempted to run the new unit test via Gradle (`./gradlew :service:testDebugUnitTest --tests com.github.kr328.clash.service.clash.module.ConfigurationModuleSourceGuardTest`), but the container environment uses Java `25.0.2` which causes Gradle to fail before tests run, so the unit test could not be executed here (environment failure).
- Attempted an overall build (`./gradlew assembleAlphaDebug`), but it also failed in this environment for the same Java/Gradle toolchain issue, so a full CI build was not run locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510c8492d4832cb63a1ca97895acc2)