### PR TITLE
fix(security): sanitize native git version metadata

### DIFF
--- a/core/src/main/cpp/CMakeLists.txt
+++ b/core/src/main/cpp/CMakeLists.txt
@@ -83,8 +83,8 @@ else ()
 endif ()
 message(STATUS "version info = ${GIT_VERSION}")
 
-# 去除空格
-string(REGEX REPLACE "[ ]+" "" GIT_VERSION "${GIT_VERSION}")
+# Keep Git metadata as inert preprocessor tokens before version.h stringifies it.
+string(REGEX REPLACE "[^A-Za-z0-9._-]+" "_" GIT_VERSION "${GIT_VERSION}")
 
 # 保存变量到文件
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h @ONLY)


### PR DESCRIPTION
### Motivation
- The configure-time build read a Git tag/branch into `GIT_VERSION` and emitted it as unquoted preprocessor tokens, which allowed attacker-controlled punctuation in tags to inject C code during stringification. 
- The prerelease workflow fetches remote tags for the core submodule, making remote tag names a build input that must be treated as data, not code.

### Description
- Sanitize `GIT_VERSION` in `core/src/main/cpp/CMakeLists.txt` by replacing any character outside the safe set `[A-Za-z0-9._-]` with an underscore before calling `configure_file`, so punctuation such as `)`, `;`, `(`, quotes, spaces and slashes cannot break out of the intended string literal. 
- The replacement uses CMake `string(REGEX REPLACE "[^A-Za-z0-9._-]+" "_" GIT_VERSION "${GIT_VERSION}")` to preserve normal tags like `v1.19.26` while neutering unsafe characters.

### Testing
- Ran the sanitizer check with `cmake -P /tmp/test_git_version_sanitize.cmake`, which produced the expected sanitized string and succeeded. 
- Ran `git diff --check` with no problems reported. 
- Attempted `./gradlew assembleAlphaDebug --stacktrace` to build the app, but the local container's Java (`openjdk 25.0.2`) is incompatible with the project's Gradle/Kotlin environment and the build failed for that unrelated reason; this change does not depend on the Android build completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510bccfa18832ca7da91ed03d293cd)