### PR TITLE
fix(ci): avoid running third-party actions after exposing signing material

### DIFF
--- a/.github/workflows/prerelease-dev.yml
+++ b/.github/workflows/prerelease-dev.yml
@@ -66,6 +66,10 @@ jobs:
       - name: Build Alpha Release APK
         run: ./gradlew assembleAlphaRelease
 
+      - name: Remove Android signing files
+        if: always()
+        run: rm -f signing.properties release.keystore
+
       - name: Collect APKs
         run: |
           mkdir -p release-artifacts
@@ -144,13 +148,23 @@ jobs:
           done
 
       - name: Publish/Update Dev Pre-Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: dev-latest
-          name: ClashFest Dev Build
-          prerelease: true
-          make_latest: false
-          target_commitish: dev
-          body_path: RELEASE_BODY.md
-          overwrite_files: true
-          files: release-artifacts/*.apk
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view dev-latest >/dev/null 2>&1; then
+            gh release edit dev-latest \
+              --title "ClashFest Dev Build" \
+              --notes-file RELEASE_BODY.md \
+              --prerelease \
+              --target dev \
+              --latest=false
+          else
+            gh release create dev-latest \
+              --title "ClashFest Dev Build" \
+              --notes-file RELEASE_BODY.md \
+              --prerelease \
+              --target dev \
+              --latest=false
+          fi
+
+          gh release upload dev-latest release-artifacts/*.apk --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Build Alpha Release APK
         run: ./gradlew assembleAlphaRelease
 
+      - name: Remove Android signing files
+        if: always()
+        run: rm -f signing.properties release.keystore
+
       - name: Collect APKs
         run: |
           mkdir -p release-artifacts
@@ -84,7 +88,11 @@ jobs:
           ls -la release-artifacts
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: release-artifacts/*.apk
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" release-artifacts/*.apk --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" release-artifacts/*.apk --generate-notes
+          fi


### PR DESCRIPTION
### Motivation
- Prevent mutable third-party GitHub Actions from accessing Android signing material placed into the shared Actions workspace, which creates a CI supply-chain risk when unpinned actions run after signing files are created.

### Description
- Add a post-build cleanup step that removes `signing.properties` and `release.keystore` immediately after APK signing with `if: always()` in both `.github/workflows/prerelease-dev.yml` and `.github/workflows/release.yml`.
- Replace the `softprops/action-gh-release@v2` step in the dev pre-release workflow with explicit `gh` CLI commands that run in-process (using `GH_TOKEN`) so no third-party action executes after signing material is present.
- Replace the `softprops/action-gh-release@v2` step in the tagged release workflow with `gh` CLI commands that create or upload the release, avoiding third-party action execution post-signing.

### Testing
- Ran `git diff --check` and found no whitespace or syntax errors in modified files, which succeeded. 
- Parsed the workflows with Ruby/YAML to ensure the YAML remained valid, which succeeded. 
- Searched workflows for remaining unpinned release actions with `rg`, which showed the replaced steps no longer use `softprops/action-gh-release`. 
- Attempted `./gradlew assembleAlphaDebug --stacktrace` to exercise the build step but the local container failed the build due to an incompatible Java runtime version (`25.0.2`) in the environment, so full build verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5123c03afc832c8bd43157553e1b8a)