### PR TITLE
fix(build): remove mutable Maven mirror fallback

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,11 @@ buildscript {
         mavenCentral()
         google()
         // Vendored copy of the few kr328 artifacts (golang gradle-plugin, kaidl)
-        // that only exist in MetaCubeX/maven-backup — that repo is served from
-        // raw.githubusercontent.com, which rate-limits CI runners (HTTP 429
-        // killed two pipelines in a row). ~130 KB, byte-identical to the
-        // published files; the remote stays as a fallback for anything new.
+        // that only exist in MetaCubeX/maven-backup. Do not add the mutable
+        // raw.githubusercontent.com branch mirror here: buildscript artifacts
+        // execute during Gradle configuration, so they must come from this
+        // repository-controlled copy instead of an unpinned branch.
         maven(rootProject.projectDir.resolve("maven").toURI())
-        maven("https://raw.githubusercontent.com/MetaCubeX/maven-backup/main/releases")
     }
     dependencies {
         classpath(libs.build.android)
@@ -32,10 +31,10 @@ subprojects {
     repositories {
         mavenCentral()
         google()
-        // Same order as the buildscript block above: vendored maven/ first,
-        // rate-limited raw.githubusercontent as fallback.
+        // Same trust boundary as the buildscript block above: kr328 artifacts
+        // are resolved from the repository-controlled vendored Maven copy, not
+        // from the mutable raw.githubusercontent.com branch mirror.
         maven(rootProject.projectDir.resolve("maven").toURI())
-        maven("https://raw.githubusercontent.com/MetaCubeX/maven-backup/main/releases")
     }
 
     val isApp = name == "app"


### PR DESCRIPTION
### Motivation
- The build trusted an unpinned GitHub raw branch mirror (`https://raw.githubusercontent.com/MetaCubeX/maven-backup/main/releases`) for buildscript and subproject dependencies, which allows attacker-controlled artifacts to execute during Gradle configuration and creates a supply-chain risk.
- Buildscript/code-generation artifacts must come from a repository-controlled source or be pinned/verified to avoid arbitrary code execution during the build.

### Description
- Removed the raw GitHub branch mirror from `buildscript.repositories` and `subprojects.repositories` in `build.gradle.kts` so the build no longer trusts `https://raw.githubusercontent.com/MetaCubeX/maven-backup/main/releases`.
- Left resolution of required `kr328` artifacts to the repository-controlled vendored `maven/` directory via `maven(rootProject.projectDir.resolve("maven").toURI())` to preserve existing functionality.
- Updated inline comments to document the trust boundary and to warn that buildscript/code-generation artifacts must not be resolved from an unpinned branch mirror.

### Testing
- Ran `rg -n "raw.githubusercontent.com/MetaCubeX/maven-backup/main/releases" . -g '!**/.gradle/**'` and confirmed there are no remaining references after the change (success).
- Ran `./gradlew assembleAlphaDebug` in this environment which could not execute the Windows batch wrapper (`.bat`) here (not runnable on Linux), so build verification through that wrapper failed.
- Ran `./gradlew assembleAlphaDebug --stacktrace` which failed before configuration because the host Java is `25.0.2` while the project toolchain expects JDK 21, so a full build verification could not be completed in this environment (failure unrelated to the repository change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5124595064832c9c5271b6935b6f97)