### PR TITLE
fix(security): honor HTTP metadata opt-out for cached headers

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -2081,8 +2081,11 @@ class MainActivity : BaseActivity<MainDesign>() {
         val headersFresh = java.io.File(profileDir, com.github.kr328.clash.service.util.FetchHeadersFile.FILE_NAME)
             .takeIf { it.isFile }
             ?.let { System.currentTimeMillis() - it.lastModified() < cooldown * 1000L } == true
+        val allowCachedHeaders =
+            !url.substringBefore('#').startsWith("http://", ignoreCase = true) ||
+                uiStore.subscriptionMetadataAllowInsecureHttp
 
-        val (meta, brandManifest) = if (headersFile != null && headersFresh) {
+        val (meta, brandManifest) = if (headersFile != null && headersFresh && allowCachedHeaders) {
             com.github.kr328.clash.common.util.SubscriptionMetadataFetcher
                 .parseHeaders { key -> headersFile.get(key) } to
                 com.github.kr328.clash.common.branding.BrandManifestParser


### PR DESCRIPTION
### Motivation
- The screen-on metadata sync fast path trusted per-profile `fetch-headers.json` snapshots even for `http://` subscriptions, bypassing the `subscriptionMetadataAllowInsecureHttp` opt-out and allowing unauthenticated cleartext headers to alter UI/branding and metadata.

### Description
- Gate the cached-header fast path in `MainActivity.syncSubscriptionMetadata()` with an `allowCachedHeaders` check that rejects cached headers for `http://` subscription URLs unless `uiStore.subscriptionMetadataAllowInsecureHttp` is enabled, leaving the guarded network fallback unchanged.

### Testing
- Ran `git diff --check`, which passed. 
- Attempted `./gradlew assembleAlphaDebug`, which failed in this environment due to a JDK mismatch (Java 25.0.2 vs project-required JDK 21). 
- `./gradlew.bat assembleAlphaDebug` could not be executed in this Linux container (Windows batch file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52465e8748832cb73fa28b5f932ff3)