### PR TITLE
fix(security): bound untrusted profile processing

### DIFF
--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionNameGuesser.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLDecoder
@@ -15,6 +16,8 @@ import kotlin.text.Charsets
  * Uses response headers (incl. subscription-userinfo) and structured fields in the body.
  */
 object SubscriptionNameGuesser {
+    internal const val MAX_BODY_BYTES = 256 * 1024
+
     fun guessFast(urlString: String): String {
         val trimmed = urlString.trim()
         if (isMierusLinkForSubscriptionTitle(trimmed)) {
@@ -77,9 +80,14 @@ object SubscriptionNameGuesser {
                     conn.getHeaderField("Subscription-Userinfo")?.let(::parseSubscriptionUserinfo)
                         ?.let(::sanitizeName)?.takeIf { it.isNotBlank() }?.let { return@withContext it }
 
-                    val raw = conn.inputStream.use { it.readBytes() }
-                    val max = 256 * 1024
-                    val body = if (raw.size <= max) raw else raw.copyOfRange(0, max)
+                    val contentLength = conn.getHeaderField("Content-Length")
+                        ?.trim()
+                        ?.toLongOrNull()
+                    if (contentLength != null && contentLength > MAX_BODY_BYTES) {
+                        return@withContext fallbackName(requestUrl)
+                    }
+                    val body = conn.inputStream.use { readBoundedBody(it, contentLength) }
+                        ?: return@withContext fallbackName(requestUrl)
                     val text = decodeResponseText(body)
                     parseNameFromSubscriptionBody(text)?.let(::sanitizeName)?.takeIf { it.isNotBlank() }
                         ?.let { return@withContext it }
@@ -91,6 +99,25 @@ object SubscriptionNameGuesser {
             }
             fallbackName(requestUrl)
         }
+
+    internal fun readBoundedBody(input: InputStream, contentLength: Long?): ByteArray? {
+        if (contentLength != null && contentLength > MAX_BODY_BYTES) return null
+
+        val bytes = ByteArray(MAX_BODY_BYTES + 1)
+        var total = 0
+        while (total < bytes.size) {
+            val read = input.read(bytes, total, bytes.size - total)
+            if (read < 0) break
+            if (read == 0) {
+                val one = input.read()
+                if (one < 0) break
+                bytes[total++] = one.toByte()
+            } else {
+                total += read
+            }
+        }
+        return if (total > MAX_BODY_BYTES) null else bytes.copyOf(total)
+    }
 
     /**
      * Resolve a subscription display title from ALREADY-FETCHED response headers, using the SAME

--- a/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
+++ b/common/src/test/java/com/github/kr328/clash/common/util/SubscriptionNameGuesserTest.kt
@@ -1,10 +1,31 @@
 package com.github.kr328.clash.common.util
 
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class SubscriptionNameGuesserTest {
+    private class CountingInputStream(private val size: Int) : InputStream() {
+        var bytesRead = 0
+
+        override fun read(): Int {
+            if (bytesRead >= size) return -1
+            bytesRead++
+            return 'x'.code
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (bytesRead >= size) return -1
+            val count = minOf(length, size - bytesRead)
+            buffer.fill('x'.code.toByte(), offset, offset + count)
+            bytesRead += count
+            return count
+        }
+    }
+
     @Test
     fun opaque_token_path_falls_back_to_host_brand() {
         // Regression: the subscription token was used as the profile name.
@@ -115,5 +136,46 @@ class SubscriptionNameGuesserTest {
         assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("Premium Plan")) // no digit
         assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("PREMIUM123"))   // no lowercase
         assertFalse(SubscriptionNameGuesser.looksLikeOpaqueToken("short1A"))      // core < 8
+    }
+
+    @Test
+    fun body_read_stops_after_limit_plus_one_byte() {
+        val input = CountingInputStream(SubscriptionNameGuesser.MAX_BODY_BYTES * 2)
+
+        assertNull(SubscriptionNameGuesser.readBoundedBody(input, null))
+        assertEquals(SubscriptionNameGuesser.MAX_BODY_BYTES + 1, input.bytesRead)
+    }
+
+    @Test
+    fun oversized_content_length_is_rejected_before_stream_read() {
+        val input = CountingInputStream(SubscriptionNameGuesser.MAX_BODY_BYTES * 2)
+
+        assertNull(
+            SubscriptionNameGuesser.readBoundedBody(
+                input,
+                SubscriptionNameGuesser.MAX_BODY_BYTES.toLong() + 1,
+            ),
+        )
+        assertEquals(0, input.bytesRead)
+    }
+
+    @Test
+    fun lying_content_length_cannot_bypass_stream_limit() {
+        val input = CountingInputStream(SubscriptionNameGuesser.MAX_BODY_BYTES * 2)
+
+        assertNull(SubscriptionNameGuesser.readBoundedBody(input, 1))
+        assertEquals(SubscriptionNameGuesser.MAX_BODY_BYTES + 1, input.bytesRead)
+    }
+
+    @Test
+    fun body_at_limit_is_accepted() {
+        val expected = ByteArray(SubscriptionNameGuesser.MAX_BODY_BYTES) { 'x'.code.toByte() }
+
+        val actual = SubscriptionNameGuesser.readBoundedBody(
+            ByteArrayInputStream(expected),
+            expected.size.toLong(),
+        )
+
+        assertEquals(expected.size, actual?.size)
     }
 }

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"cfa/native/app"
+	"cfa/native/config/fetchheaders"
 
 	clashHttp "github.com/metacubex/mihomo/component/http"
 	"github.com/metacubex/mihomo/config"
@@ -34,9 +35,12 @@ type providerFetchTask struct {
 	path string
 }
 
-func openUrl(ctx context.Context, url string) (io.ReadCloser, map[string][]string, error) {
+func openUrl(ctx context.Context, url string, includeSubscriptionHeaders bool) (io.ReadCloser, map[string][]string, error) {
 	base := http.Header{"User-Agent": {"ClashMetaForAndroid/" + app.VersionName()}}
-	hdr := app.MergeSubscriptionFetchHeaders(base)
+	hdr := base
+	if includeSubscriptionHeaders {
+		hdr = app.MergeSubscriptionFetchHeaders(base)
+	}
 	response, err := clashHttp.HttpRequest(ctx, url, http.MethodGet, hdr, nil)
 
 	if err != nil {
@@ -72,7 +76,7 @@ const (
 // and on error) — the subscription fetch persists them via [writeFetchHeaders]
 // so the Kotlin side can read subscription-userinfo / X-Brand-* / naming
 // headers without issuing a second GET of its own.
-func fetch(url *U.URL, file string, timeout time.Duration) (map[string][]string, error) {
+func fetch(url *U.URL, file string, timeout time.Duration, includeSubscriptionHeaders bool) (map[string][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -82,7 +86,7 @@ func fetch(url *U.URL, file string, timeout time.Duration) (map[string][]string,
 
 	switch url.Scheme {
 	case "http", "https":
-		reader, header, err = openUrl(ctx, url.String())
+		reader, header, err = openUrl(ctx, url.String(), includeSubscriptionHeaders)
 	case "content":
 		reader, err = openContent(url.String())
 	default:
@@ -133,13 +137,7 @@ func writeFetchHeaders(profilePath string, header map[string][]string) {
 		return
 	}
 
-	flat := make(map[string]string, len(header))
-	for key, values := range header {
-		if len(values) == 0 {
-			continue
-		}
-		flat[strings.ToLower(key)] = strings.Join(values, ", ")
-	}
+	flat := fetchheaders.Filter(header)
 
 	bytes, err := json.Marshal(flat)
 	if err != nil {
@@ -189,7 +187,7 @@ func FetchAndValid(
 
 		reportStatus(string(bytes))
 
-		header, err := fetch(parsed, configPath, subscriptionFetchTimeout)
+		header, err := fetch(parsed, configPath, subscriptionFetchTimeout, true)
 		if err != nil {
 			return err
 		}
@@ -364,7 +362,9 @@ func fetchProviders(rawCfg *config.RawConfig, force bool, reportStatus func(stri
 			// provider re-fetches on the next FetchProvidersAndValid pass.
 			// Provider response headers are irrelevant (only the subscription
 			// fetch persists them, see writeFetchHeaders).
-			_, _ = fetch(t.url, t.path, providerFetchTimeout)
+			// Device-identifying subscription headers are scoped to the subscription
+			// origin. Providers may be controlled by unrelated third parties.
+			_, _ = fetch(t.url, t.path, providerFetchTimeout, false)
 
 			current := atomic.AddInt32(&done, 1)
 			bytes, _ := json.Marshal(&Status{

--- a/core/src/main/golang/native/config/fetch_headers_source_test.go
+++ b/core/src/main/golang/native/config/fetch_headers_source_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestProviderFetchDoesNotReceiveSubscriptionHeaders(t *testing.T) {
+	source, err := os.ReadFile("fetch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	if !strings.Contains(text, "fetch(t.url, t.path, providerFetchTimeout, false)") {
+		t.Fatal("provider fetch must explicitly exclude subscription headers")
+	}
+	if !strings.Contains(text, "fetch(parsed, configPath, subscriptionFetchTimeout, true)") {
+		t.Fatal("subscription fetch must retain its scoped headers")
+	}
+}

--- a/core/src/main/golang/native/config/fetchheaders/filter.go
+++ b/core/src/main/golang/native/config/fetchheaders/filter.go
@@ -1,0 +1,38 @@
+package fetchheaders
+
+import "strings"
+
+var allowlist = map[string]struct{}{
+	"support-url": {}, "x-support-url": {}, "support_url": {},
+	"profile-support-url": {}, "subscription-support-url": {}, "support": {},
+	"profile-title": {}, "subscription-title": {}, "x-subscription-title": {},
+	"display-name": {}, "x-display-name": {}, "subscription-display-name": {},
+	"content-disposition":  {},
+	"profile-web-page-url": {}, "subscription-web-page": {}, "x-subscription-web-page": {},
+	"profile-update-interval": {}, "update-interval": {}, "x-profile-update-interval": {},
+	"announce": {}, "announcement": {}, "x-announce": {}, "x-announcement": {},
+	"announce-url": {}, "announcement-url": {}, "x-announce-url": {}, "x-announcement-url": {},
+	"subscription-userinfo": {},
+	"share-links":           {}, "share_links": {}, "x-share-links": {}, "x-share-links-policy": {},
+	"x-hwid-active": {}, "x-hwid-not-supported": {}, "x-hwid-max-devices-reached": {}, "x-hwid-limit": {},
+	"x-branding-enabled": {},
+	"x-brand-name":       {}, "x-brand-tagline": {}, "x-brand-logo-url": {}, "x-brand-logo-light-url": {},
+	"x-brand-accent-color": {}, "x-brand-website-url": {}, "x-brand-support-url": {},
+	"x-brand-telegram-url": {}, "x-brand-bot-url": {}, "x-brand-privacy-url": {},
+	"x-brand-terms-url": {}, "x-brand-help-url": {}, "x-brand-status-url": {},
+	"x-brand-renew-url": {}, "x-brand-cabinet-url": {}, "x-brand-user-display-name": {},
+	"x-brand-greeting": {}, "x-brand-hide-routing": {}, "x-brand-hide-global-mode": {},
+	"x-brand-show-operator-tab": {},
+}
+
+func Filter(header map[string][]string) map[string]string {
+	flat := make(map[string]string)
+	for key, values := range header {
+		lowerKey := strings.ToLower(key)
+		if _, allowed := allowlist[lowerKey]; !allowed || len(values) == 0 {
+			continue
+		}
+		flat[lowerKey] = strings.Join(values, ", ")
+	}
+	return flat
+}

--- a/core/src/main/golang/native/config/fetchheaders/filter_test.go
+++ b/core/src/main/golang/native/config/fetchheaders/filter_test.go
@@ -1,0 +1,31 @@
+package fetchheaders
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterPersistsOnlyConsumerAllowlist(t *testing.T) {
+	got := Filter(map[string][]string{
+		"Subscription-Userinfo": {"upload=1; download=2; total=3"},
+		"X-Brand-Name":          {"Example VPN"},
+		"Profile-Title":         {"Premium"},
+		"Content-Disposition":   {"attachment; filename=example.yaml"},
+		"Set-Cookie":            {"session=secret"},
+		"Authorization":         {"Bearer secret"},
+		"X-Backend-Trace":       {"account-123"},
+	})
+
+	want := map[string]string{
+		"subscription-userinfo": "upload=1; download=2; total=3",
+		"x-brand-name":          "Example VPN",
+		"profile-title":         "Premium",
+		"content-disposition":   "attachment; filename=example.yaml",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected persisted headers: %#v", got)
+	}
+	if _, exists := got["set-cookie"]; exists {
+		t.Fatal("Set-Cookie must never be persisted")
+	}
+}

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -34,6 +34,7 @@ import com.github.kr328.clash.service.util.generateProfileUUID
 import com.github.kr328.clash.service.util.ProfileComposer
 import com.github.kr328.clash.service.util.ProfileMigration
 import com.github.kr328.clash.service.util.ProfileOverlay
+import com.github.kr328.clash.service.util.PreviewResourceLimits
 import com.github.kr328.clash.service.util.UserLayerStore
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.sendProfileUpdateCompleted
@@ -137,6 +138,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
         val relativePath: String,
         val sourceHash: String,
         val proposedYaml: String,
+        val providerFile: Boolean = false,
     )
 
     private data class CachedPreview(
@@ -594,7 +596,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 return@withContext emptyMap()
             }
             val file = File(context.importedDir, "$uuid/config.yaml")
-            if (!file.isFile) {
+            if (!file.isFile || file.length() > PreviewResourceLimits.MAX_CONFIG_BYTES) {
                 return@withContext emptyMap()
             }
             try {
@@ -623,7 +625,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 return@withContext emptyMap()
             }
             val file = File(context.importedDir, "$uuid/config.yaml")
-            if (!file.isFile) {
+            if (!file.isFile || file.length() > PreviewResourceLimits.MAX_CONFIG_BYTES) {
                 return@withContext emptyMap()
             }
             try {
@@ -897,7 +899,15 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 createPreview(
                     uuid = uuid,
                     title = "Proxy chain",
-                    files = listOf(filePreview(dir, patch.relativePath, patch.currentYaml, patch.proposedYaml)),
+                    files = listOf(
+                        filePreview(
+                            dir,
+                            patch.relativePath,
+                            patch.currentYaml,
+                            patch.proposedYaml,
+                            patch.providerFile,
+                        ),
+                    ),
                     // E-01/E-05: the proxy-chain UI applies via preview->commit, so the chain intent
                     // must be recorded on the layer here (same {target: dialer} map compose expects),
                     // otherwise it's lost on recompose now that config.yaml extraction is gone.
@@ -961,7 +971,9 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 createPreview(
                     uuid = uuid,
                     title = "Proxy chains",
-                    files = patches.map { filePreview(dir, it.relativePath, it.currentYaml, it.proposedYaml) },
+                    files = patches.map {
+                        filePreview(dir, it.relativePath, it.currentYaml, it.proposedYaml, it.providerFile)
+                    },
                     // E-01/E-05: clearing all chains must clear the layer intent too, else compose
                     // re-applies them from the store on recompose.
                     layerMutation = { it.copy(proxyChain = emptyMap()) },
@@ -1107,18 +1119,20 @@ class ProfileManager(private val context: Context) : IProfileManager,
             // single-file write is atomic on the local FS even if the process is killed
             // mid-flight.
             val originals = LinkedHashMap<File, String>()
+            val targets = LinkedHashMap<CachedFile, File>()
             for (file in cached.files) {
-                val target = File(dir, file.relativePath)
+                val target = resolveCachedFile(dir, file) ?: return@withContext false
                 if (!target.isFile) return@withContext false
                 val current = target.readText()
                 if (YamlPreviewSupport.sha256(current) != file.sourceHash) return@withContext false
                 originals[target] = current
+                targets[file] = target
             }
 
             val written = ArrayList<File>(cached.files.size)
             try {
                 for (file in cached.files) {
-                    val target = File(dir, file.relativePath)
+                    val target = targets.getValue(file)
                     atomicWriteText(target, file.proposedYaml)
                     written += target
                 }
@@ -1272,13 +1286,31 @@ class ProfileManager(private val context: Context) : IProfileManager,
         }
     }
 
-    private fun filePreview(dir: File, relativePath: String, current: String, proposed: String): CachedFile {
+    private fun filePreview(
+        dir: File,
+        relativePath: String,
+        current: String,
+        proposed: String,
+        providerFile: Boolean = false,
+    ): CachedFile {
         YamlPreviewSupport.validateConfigYaml(proposed)
-        return CachedFile(
+        val cached = CachedFile(
             relativePath = relativePath,
             sourceHash = YamlPreviewSupport.sha256(current),
             proposedYaml = proposed,
+            providerFile = providerFile,
         )
+        require(resolveCachedFile(dir, cached) != null) { "Unsafe preview file path" }
+        return cached
+    }
+
+    private fun resolveCachedFile(dir: File, file: CachedFile): File? {
+        if (file.providerFile) return ProxyDialerYamlEdit.resolveProviderPath(dir, file.relativePath)
+        if (file.relativePath != "config.yaml") return null
+        return runCatching {
+            val profileRoot = dir.canonicalFile
+            File(profileRoot, "config.yaml").canonicalFile.takeIf { it.parentFile == profileRoot }
+        }.getOrNull()
     }
 
     private fun createPreview(
@@ -1309,8 +1341,8 @@ class ProfileManager(private val context: Context) : IProfileManager,
             YamlPreview(
                 id = id,
                 title = title,
-                currentYaml = currentYaml,
-                proposedYaml = proposedYaml,
+                currentYaml = YamlPreviewSupport.boundedPreviewText(currentYaml),
+                proposedYaml = YamlPreviewSupport.boundedPreviewText(proposedYaml),
                 diff = YamlPreviewSupport.unifiedDiff(currentYaml, proposedYaml),
                 valid = true,
             )
@@ -1322,8 +1354,8 @@ class ProfileManager(private val context: Context) : IProfileManager,
             YamlPreview(
                 id = "",
                 title = title,
-                currentYaml = current,
-                proposedYaml = proposed,
+                currentYaml = YamlPreviewSupport.boundedPreviewText(current),
+                proposedYaml = YamlPreviewSupport.boundedPreviewText(proposed),
                 diff = YamlPreviewSupport.unifiedDiff(current, proposed),
                 valid = false,
                 error = error.message ?: error.toString(),
@@ -1336,7 +1368,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
             val body = if (useProposed) {
                 file.proposedYaml
             } else {
-                File(dir, file.relativePath).readText()
+                requireNotNull(resolveCachedFile(dir, file)) { "Unsafe preview file path" }.readText()
             }
             "# ${file.relativePath}\n$body"
         }

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -345,7 +345,7 @@ object ProfileProcessor {
                     Clash.fetchProvidersAndValid(
                         context.processingDir,
                         false,
-                        SubscriptionRequestHeaders.toNativeFetchJson(context, effectiveUserAgentOverride),
+                        "{}",
                     ) {
                         try {
                             cb?.updateStatus(it)

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
@@ -23,6 +23,7 @@ import java.net.UnknownHostException
  */
 object FetchErrorClassifier {
     internal const val MAX_CLASSIFICATION_BYTES = 64 * 1024
+    private data class BodySample(val text: String, val complete: Boolean)
 
     fun clarify(processingDir: File, original: Throwable): Throwable {
         val file = File(processingDir, "config.yaml")
@@ -38,10 +39,11 @@ object FetchErrorClassifier {
             }
             return original
         }
-        val body = readBoundedText(file) ?: return original
+        val sample = readBoundedText(file) ?: return original
+        val body = sample.text
 
         val reason = when {
-            body.isBlank() ->
+            sample.complete && body.isBlank() ->
                 "the subscription server returned an empty response — try again later. [E-10]"
             looksLikeHtml(body) ->
                 "the subscription server returned a web page, not a config " +
@@ -55,8 +57,7 @@ object FetchErrorClassifier {
         return IllegalStateException(reason, original)
     }
 
-    private fun readBoundedText(file: File): String? {
-        if (file.length() > MAX_CLASSIFICATION_BYTES) return null
+    private fun readBoundedText(file: File): BodySample? {
         return runCatching {
             file.inputStream().buffered().use { input ->
                 val bytes = ByteArray(MAX_CLASSIFICATION_BYTES + 1)
@@ -72,8 +73,10 @@ object FetchErrorClassifier {
                         total += read
                     }
                 }
-                if (total > MAX_CLASSIFICATION_BYTES) null
-                else bytes.copyOf(total).toString(Charsets.UTF_8)
+                BodySample(
+                    text = bytes.copyOf(minOf(total, MAX_CLASSIFICATION_BYTES)).toString(Charsets.UTF_8),
+                    complete = total <= MAX_CLASSIFICATION_BYTES,
+                )
             }
         }.getOrNull()
     }

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
@@ -22,6 +22,8 @@ import java.net.UnknownHostException
  * Layer 3. Codes are stable so support/wiki can key troubleshooting to them.
  */
 object FetchErrorClassifier {
+    internal const val MAX_CLASSIFICATION_BYTES = 64 * 1024
+
     fun clarify(processingDir: File, original: Throwable): Throwable {
         val file = File(processingDir, "config.yaml")
         // No body downloaded → network reachability failure (or an unrelated error we
@@ -36,7 +38,7 @@ object FetchErrorClassifier {
             }
             return original
         }
-        val body = runCatching { file.readText() }.getOrNull() ?: return original
+        val body = readBoundedText(file) ?: return original
 
         val reason = when {
             body.isBlank() ->
@@ -51,6 +53,29 @@ object FetchErrorClassifier {
             else -> return original // valid-looking config body → keep the engine's precise error
         }
         return IllegalStateException(reason, original)
+    }
+
+    private fun readBoundedText(file: File): String? {
+        if (file.length() > MAX_CLASSIFICATION_BYTES) return null
+        return runCatching {
+            file.inputStream().buffered().use { input ->
+                val bytes = ByteArray(MAX_CLASSIFICATION_BYTES + 1)
+                var total = 0
+                while (total < bytes.size) {
+                    val read = input.read(bytes, total, bytes.size - total)
+                    if (read < 0) break
+                    if (read == 0) {
+                        val one = input.read()
+                        if (one < 0) break
+                        bytes[total++] = one.toByte()
+                    } else {
+                        total += read
+                    }
+                }
+                if (total > MAX_CLASSIFICATION_BYTES) null
+                else bytes.copyOf(total).toString(Charsets.UTF_8)
+            }
+        }.getOrNull()
     }
 
     /**

--- a/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/MihomoConfigDocument.kt
@@ -166,20 +166,22 @@ private object TopLevelYamlBlockPatcher {
         val start = lines.indexOfFirst { isTopLevelKey(it, key) }
         if (start < 0) return null
         var end = start + 1
+        var preambleStart = -1
         while (end < lines.size) {
-            if (isAnyTopLevelKey(lines[end])) break
-            if (startsNextTopLevelBlockPreamble(lines, end)) break
+            val line = lines[end]
+            if (isAnyTopLevelKey(line)) {
+                return BlockRange(start, if (preambleStart >= 0) preambleStart else end)
+            }
+            if (line.isBlank() || line.startsWith('#')) {
+                if (preambleStart < 0) preambleStart = end
+            } else {
+                // An indented/content line means preceding comments belong to
+                // the current block, not to a future top-level key.
+                preambleStart = -1
+            }
             end++
         }
         return BlockRange(start, end)
-    }
-
-    private fun startsNextTopLevelBlockPreamble(lines: List<String>, index: Int): Boolean {
-        val line = lines[index]
-        if (line.isNotBlank() && !line.startsWith('#')) return false
-        val next = lines.drop(index + 1).firstOrNull { it.isNotBlank() && !it.startsWith('#') }
-            ?: return false
-        return isAnyTopLevelKey(next)
     }
 
     private fun isTopLevelKey(line: String, key: String): Boolean {

--- a/service/src/main/java/com/github/kr328/clash/service/util/PreviewResourceLimits.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/PreviewResourceLimits.kt
@@ -1,0 +1,76 @@
+package com.github.kr328.clash.service.util
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/** Resource ceilings for data derived from an imported profile and returned to the UI. */
+internal object PreviewResourceLimits {
+    const val MAX_CONFIG_BYTES = 8L * 1024 * 1024
+    const val MAX_PROVIDER_FILES = 64
+    const val MAX_PROVIDER_FILE_BYTES = 2 * 1024 * 1024
+    const val MAX_PROVIDER_TOTAL_BYTES = 8 * 1024 * 1024
+    const val MAX_PROXY_ENTRIES_SCANNED = 8_192
+    const val MAX_NAME_CHARS = 256
+    const val MAX_GROUPS = 256
+    const val MAX_MEMBERS_PER_GROUP = 1_024
+    const val MAX_TOTAL_MEMBERS = 4_096
+    const val MAX_TRANSPORTS = 2_048
+    const val MAX_OUTPUT_CHARS = 128 * 1024
+}
+
+/** Per-preview budget. A skipped file degrades only UI metadata; the engine remains authoritative. */
+internal class ProviderFileReadBudget {
+    private var filesRead = 0
+    private var bytesRead = 0
+
+    fun readUtf8(file: File): String? {
+        if (!file.isFile || filesRead >= PreviewResourceLimits.MAX_PROVIDER_FILES) return null
+        val declaredSize = file.length()
+        if (
+            declaredSize < 0 ||
+            declaredSize > PreviewResourceLimits.MAX_PROVIDER_FILE_BYTES ||
+            declaredSize > PreviewResourceLimits.MAX_PROVIDER_TOTAL_BYTES - bytesRead
+        ) return null
+
+        val remaining = minOf(
+            PreviewResourceLimits.MAX_PROVIDER_FILE_BYTES,
+            PreviewResourceLimits.MAX_PROVIDER_TOTAL_BYTES - bytesRead,
+        )
+        val bytes = readAtMost(file, remaining) ?: return null
+        filesRead++
+        bytesRead += bytes.size
+        return bytes.toString(Charsets.UTF_8)
+    }
+
+    private fun readAtMost(file: File, maxBytes: Int): ByteArray? {
+        return runCatching {
+            file.inputStream().buffered().use { input ->
+                val output = ByteArrayOutputStream(minOf(file.length().coerceAtLeast(0).toInt(), maxBytes))
+                val buffer = ByteArray(16 * 1024)
+                var total = 0
+                while (true) {
+                    val read = input.read(buffer, 0, minOf(buffer.size, maxBytes + 1 - total))
+                    if (read < 0) break
+                    total += read
+                    if (total > maxBytes) return null
+                    output.write(buffer, 0, read)
+                }
+                output.toByteArray()
+            }
+        }.getOrNull()
+    }
+}
+
+internal class PreviewOutputBudget {
+    private var chars = 0
+
+    fun accept(value: String): Boolean = acceptAll(value)
+
+    fun acceptAll(vararg values: String): Boolean {
+        if (values.any { it.length > PreviewResourceLimits.MAX_NAME_CHARS }) return false
+        val added = values.sumOf { it.length }
+        if (added > PreviewResourceLimits.MAX_OUTPUT_CHARS - chars) return false
+        chars += added
+        return true
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
@@ -17,6 +17,7 @@ object ProxyDialerYamlEdit {
         val relativePath: String,
         val currentYaml: String,
         val proposedYaml: String,
+        val providerFile: Boolean = false,
     )
 
     /** One row from `proxies:` on disk that has `dialer-proxy` set. */
@@ -43,7 +44,7 @@ object ProxyDialerYamlEdit {
         for ((_, v) in pp) {
             val prov = v as? Map<*, *> ?: continue
             val pathStr = prov["path"] as? String ?: continue
-            val f = resolveProviderPath(profileDir, pathStr)
+            val f = resolveProviderPath(profileDir, pathStr) ?: continue
             if (!f.isFile) continue
             val pRoot = YamlFormatting.parseRootMap(f.readText()) ?: continue
             val rel = pathStr.trim().removePrefix("./")
@@ -59,7 +60,7 @@ object ProxyDialerYamlEdit {
     fun clearAllDialerProxies(profileDir: File): Boolean {
         val patches = previewClearAllDialerProxies(profileDir)
         for (patch in patches) {
-            resolveProviderPath(profileDir, patch.relativePath).writeText(patch.proposedYaml)
+            resolvePatchPath(profileDir, patch)?.writeText(patch.proposedYaml)
         }
         return patches.isNotEmpty()
     }
@@ -78,13 +79,13 @@ object ProxyDialerYamlEdit {
         for ((_, v) in pp) {
             val prov = v as? Map<*, *> ?: continue
             val pathStr = prov["path"] as? String ?: continue
-            val f = resolveProviderPath(profileDir, pathStr)
+            val f = resolveProviderPath(profileDir, pathStr) ?: continue
             if (!f.isFile) continue
             val rel = pathStr.trim().removePrefix("./")
             val pText = f.readText()
             val pRoot = YamlFormatting.parseRootMap(pText) ?: continue
             if (stripDialerFromProxiesInRoot(pRoot)) {
-                patches.add(FilePatch(rel, pText, dumpYaml.dump(pRoot)))
+                patches.add(FilePatch(rel, pText, dumpYaml.dump(pRoot), providerFile = true))
             }
         }
         return patches
@@ -158,7 +159,8 @@ object ProxyDialerYamlEdit {
      */
     fun applyDialerProxy(profileDir: File, targetProxyName: String, dialerProxyName: String?): Boolean {
         val patch = previewDialerProxy(profileDir, targetProxyName, dialerProxyName) ?: return false
-        resolveProviderPath(profileDir, patch.relativePath).writeText(patch.proposedYaml)
+        val target = resolvePatchPath(profileDir, patch) ?: return false
+        target.writeText(patch.proposedYaml)
         return true
     }
 
@@ -182,7 +184,7 @@ object ProxyDialerYamlEdit {
         for ((_, v) in pp) {
             val prov = v as? Map<*, *> ?: continue
             val pathStr = prov["path"] as? String ?: continue
-            val f = resolveProviderPath(profileDir, pathStr)
+            val f = resolveProviderPath(profileDir, pathStr) ?: continue
             if (!f.isFile) continue
             val pText = try {
                 f.readText()
@@ -191,17 +193,40 @@ object ProxyDialerYamlEdit {
             }
             val pRoot = YamlFormatting.parseRootMap(pText) ?: continue
             if (patchProxiesList(pRoot, trimmedTarget, dialerProxyName)) {
-                return FilePatch(pathStr.trim().removePrefix("./"), pText, dumpYaml.dump(pRoot))
+                return FilePatch(
+                    pathStr.trim().removePrefix("./"),
+                    pText,
+                    dumpYaml.dump(pRoot),
+                    providerFile = true,
+                )
             }
         }
         return null
     }
 
-    /** [proxy-providers] entry `path` relative to [profileDir]. */
-    internal fun resolveProviderPath(profileDir: File, path: String): File {
-        val n = path.trim().removePrefix("./")
-        return File(profileDir, n)
+    /** Resolve a provider path exactly inside this profile's native `providers/` sandbox. */
+    internal fun resolveProviderPath(profileDir: File, path: String): File? {
+        val raw = path.trim()
+        if (raw.isEmpty()) return null
+        return runCatching {
+            val profileRoot = profileDir.canonicalFile
+            val providerRoot = File(profileRoot, "providers").canonicalFile
+            if (providerRoot.parentFile != profileRoot) return@runCatching null
+            val supplied = File(raw)
+            val candidate = if (supplied.isAbsolute) supplied else File(providerRoot, raw.removePrefix("./"))
+            val resolved = candidate.canonicalFile
+            if (resolved.toPath().startsWith(providerRoot.toPath())) resolved else null
+        }.getOrNull()
     }
+
+    private fun resolvePatchPath(profileDir: File, patch: FilePatch): File? =
+        if (patch.providerFile) resolveProviderPath(profileDir, patch.relativePath)
+        else resolveConfigPath(profileDir)
+
+    private fun resolveConfigPath(profileDir: File): File? = runCatching {
+        val profileRoot = profileDir.canonicalFile
+        File(profileRoot, "config.yaml").canonicalFile.takeIf { it.parentFile == profileRoot }
+    }.getOrNull()
 
     private fun proxyNameMatches(yamlName: String, uiName: String): Boolean {
         if (yamlName == uiName) return true

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyDialerYamlEdit.kt
@@ -212,11 +212,23 @@ object ProxyDialerYamlEdit {
             val profileRoot = profileDir.canonicalFile
             val providerRoot = File(profileRoot, "providers").canonicalFile
             if (providerRoot.parentFile != profileRoot) return@runCatching null
-            val supplied = File(raw)
-            val candidate = if (supplied.isAbsolute) supplied else File(providerRoot, raw.removePrefix("./"))
+            val candidate = File(providerRoot, resolveAsRoot(raw))
             val resolved = candidate.canonicalFile
             if (resolved.toPath().startsWith(providerRoot.toPath())) resolved else null
         }.getOrNull()
+    }
+
+    /** Mirrors native common.ResolveAsRoot before mihomo prefixes `<profile>/providers/`. */
+    internal fun resolveAsRoot(path: String): String {
+        val result = ArrayDeque<String>()
+        for (directory in path.split('/')) {
+            when (directory) {
+                "", "." -> Unit
+                ".." -> if (result.isNotEmpty()) result.removeLast()
+                else -> result.addLast(directory)
+            }
+        }
+        return result.joinToString("/")
     }
 
     private fun resolvePatchPath(profileDir: File, patch: FilePatch): File? =

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreview.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreview.kt
@@ -19,6 +19,8 @@ import java.io.File
  * full mihomo configs, so the engine snapshot does not load them.
  */
 object ProxyGroupsYamlPreview {
+    private const val MAX_FILTER_PATTERN_CHARS = 256
+
     private fun truthyHidden(value: Any?): Boolean = when (value) {
         is Boolean -> value
         is Number -> value.toInt() != 0
@@ -48,7 +50,11 @@ object ProxyGroupsYamlPreview {
 
     private fun JsonObject.stringList(key: String): List<String> {
         val arr = this[key] as? JsonArray ?: return emptyList()
-        return arr.mapNotNull { runCatching { it.jsonPrimitive.content.trim() }.getOrNull()?.takeIf { it.isNotEmpty() } }
+        return arr.asSequence()
+            .mapNotNull { runCatching { it.jsonPrimitive.content.trim() }.getOrNull() }
+            .filter { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
+            .take(PreviewResourceLimits.MAX_MEMBERS_PER_GROUP)
+            .toList()
     }
 
     /** Mihomo expands membership at runtime (`include-all-proxies`, etc.). */
@@ -68,23 +74,33 @@ object ProxyGroupsYamlPreview {
         profileDir: File?,
     ): LinkedHashSet<String> {
         val names = LinkedHashSet<String>()
-        for (entry in snapshot.proxies) {
-            entry.stringField("name")?.trim()?.takeIf { it.isNotEmpty() }?.let { names.add(it) }
+        for (entry in snapshot.proxies.take(PreviewResourceLimits.MAX_PROXY_ENTRIES_SCANNED)) {
+            if (names.size >= PreviewResourceLimits.MAX_TOTAL_MEMBERS) break
+            entry.stringField("name")?.trim()
+                ?.takeIf { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
+                ?.let { names.add(it) }
         }
         val dir = profileDir?.takeIf { it.isDirectory } ?: return names
-        for ((_, prov) in snapshot.proxyProviders) {
+        val readBudget = ProviderFileReadBudget()
+        var remainingEntries = PreviewResourceLimits.MAX_PROXY_ENTRIES_SCANNED
+        for ((_, prov) in snapshot.proxyProviders.entries.take(PreviewResourceLimits.MAX_PROVIDER_FILES)) {
+            if (names.size >= PreviewResourceLimits.MAX_TOTAL_MEMBERS || remainingEntries <= 0) break
             val pathStr = prov.stringField("path")
             val providerUrl = prov.stringField("url")
             val providerFile = if (!pathStr.isNullOrBlank()) {
                 ProxyDialerYamlEdit.resolveProviderPath(dir, pathStr)
             } else {
                 resolveDefaultProviderFile(dir, providerUrl) ?: continue
-            }
+            } ?: continue
             if (!providerFile.isFile) continue
-            val pRoot = runCatching { YamlFormatting.parseRootMap(providerFile.readText()) }
+            val providerText = readBudget.readUtf8(providerFile) ?: continue
+            val pRoot = runCatching { YamlFormatting.parseRootMap(providerText) }
                 .getOrNull() ?: continue
-            (pRoot["proxies"] as? List<*>)?.forEach { pr ->
-                val n = (pr as? Map<*, *>)?.get("name")?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+            for (pr in (pRoot["proxies"] as? List<*>).orEmpty().take(remainingEntries)) {
+                remainingEntries--
+                if (names.size >= PreviewResourceLimits.MAX_TOTAL_MEMBERS) break
+                val n = (pr as? Map<*, *>)?.get("name")?.toString()?.trim()
+                    ?.takeIf { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
                 if (n != null) names.add(n)
             }
         }
@@ -119,24 +135,80 @@ object ProxyGroupsYamlPreview {
     /**
      * Mihomo splits [filter] on `` ` `` and ORs patterns ([outboundgroup.ParseProxyGroup]).
      */
-    private fun compileFilterPatterns(filterRaw: String): List<Regex> {
+    /** null means the filter cannot be evaluated safely in the offline JVM preview. */
+    private fun compileFilterPatterns(filterRaw: String): List<Regex>? {
         val parts = filterRaw.split('`').map { it.trim() }.filter { it.isNotEmpty() }
-        return parts.mapNotNull { runCatching { Regex(it) }.getOrNull() }
+        if (parts.isEmpty()) return null
+        val compiled = ArrayList<Regex>(parts.size)
+        for (pattern in parts) {
+            if (!isSafeFilterPattern(pattern)) return null
+            compiled += runCatching { Regex(pattern) }.getOrNull() ?: return null
+        }
+        return compiled
+    }
+
+    /**
+     * JVM Regex is a backtracking engine. Keep the accepted provider-filter
+     * dialect deliberately small: bounded patterns, no backreferences,
+     * lookarounds or repetition operators. Literal alternation, anchors and
+     * character classes remain supported, and matching time is bounded by
+     * pattern length times the already-capped proxy-name length.
+     */
+    internal fun isSafeFilterPattern(pattern: String): Boolean {
+        if (pattern.isEmpty() || pattern.length > MAX_FILTER_PATTERN_CHARS) return false
+        var escaped = false
+        var inClass = false
+        var groupDepth = 0
+        var i = 0
+        while (i < pattern.length) {
+            val c = pattern[i]
+            if (escaped) {
+                if (c in '1'..'9') return false
+                escaped = false
+                i++
+                continue
+            }
+            if (c == '\\') {
+                escaped = true
+                i++
+                continue
+            }
+            if (inClass) {
+                if (c == ']') inClass = false
+                i++
+                continue
+            }
+            when (c) {
+                '[' -> inClass = true
+                '*', '+', '?', '{' -> return false
+                '(' -> {
+                    if (i + 1 < pattern.length && pattern[i + 1] == '?') {
+                        if (!pattern.startsWith("(?:", i)) return false
+                    }
+                    groupDepth++
+                }
+                ')' -> {
+                    if (groupDepth == 0) return false
+                    groupDepth--
+                }
+            }
+            i++
+        }
+        return !escaped && !inClass && groupDepth == 0
     }
 
     private fun membersForIncludeAllProxiesPreview(
         snapshot: ProfileSnapshot,
         g: JsonObject,
         profileDir: File?,
-    ): List<String> {
+    ): List<String>? {
         if (!hasDynamicMembership(g)) return emptyList()
         val universe = collectAllLeafProxyNames(snapshot, profileDir).sorted()
         val filterRaw = g.stringField("filter")?.trim().orEmpty()
         val included = if (filterRaw.isEmpty()) {
             universe
         } else {
-            val patterns = compileFilterPatterns(filterRaw)
-            if (patterns.isEmpty()) return emptyList()
+            val patterns = compileFilterPatterns(filterRaw) ?: return null
             universe.filter { name -> patterns.any { it.containsMatchIn(name) } }
         }
         // Mirror the engine ([outboundgroup.GroupBase.getProxies]): `exclude-filter` drops any member
@@ -146,8 +218,7 @@ object ProxyGroupsYamlPreview {
         // exclusions diverged.
         val excludeRaw = g.stringField("exclude-filter")?.trim().orEmpty()
         if (excludeRaw.isEmpty()) return included
-        val excludePatterns = compileFilterPatterns(excludeRaw)
-        if (excludePatterns.isEmpty()) return included
+        val excludePatterns = compileFilterPatterns(excludeRaw) ?: return null
         return included.filterNot { name -> excludePatterns.any { it.containsMatchIn(name) } }
     }
 
@@ -179,10 +250,14 @@ object ProxyGroupsYamlPreview {
         includeHidden: Boolean = false,
     ): Map<String, ProxyGroupPreviewRow> {
         val out = linkedMapOf<String, ProxyGroupPreviewRow>()
-        for (g in snapshot.proxyGroups) {
+        val outputBudget = PreviewOutputBudget()
+        var totalMembers = 0
+        for (g in snapshot.proxyGroups.take(PreviewResourceLimits.MAX_GROUPS)) {
             val hidden = g.booleanFlag("hidden")
             if (!includeHidden && hidden) continue
-            val name = g.stringField("name") ?: continue
+            val name = g.stringField("name")?.trim()
+                ?.takeIf { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
+                ?: continue
             val type = yamlGroupType(g)
             val fromProxies = g.stringList("proxies")
             val useList = g.stringList("use")
@@ -194,17 +269,38 @@ object ProxyGroupsYamlPreview {
             } else {
                 emptyList()
             }
+            val dynamicPreviewUnavailable = dynamicMembers == null
             val combined = LinkedHashSet<String>().apply {
                 addAll(fromProxies)
-                addAll(dynamicMembers)
-            }.toList()
+                addAll(dynamicMembers.orEmpty())
+            }
+            val remainingMembers = PreviewResourceLimits.MAX_TOTAL_MEMBERS - totalMembers
+            val members = ArrayList<String>(minOf(combined.size, remainingMembers))
+            if (!outputBudget.accept(name)) break
+            for (member in combined) {
+                if (
+                    members.size >= PreviewResourceLimits.MAX_MEMBERS_PER_GROUP ||
+                    members.size >= remainingMembers ||
+                    !outputBudget.accept(member)
+                ) break
+                members.add(member)
+            }
+            val staticProxies = fromProxies.asSequence()
+                .take(PreviewResourceLimits.MAX_MEMBERS_PER_GROUP)
+                .filter { outputBudget.accept(it) }
+                .toList()
             when {
-                combined.isNotEmpty() ->
-                    out[name] = ProxyGroupPreviewRow(type, combined, hidden, fromProxies)
+                members.isNotEmpty() -> {
+                    out[name] = ProxyGroupPreviewRow(type, members, hidden, staticProxies)
+                    totalMembers += members.size
+                }
+                dynamicPreviewUnavailable ->
+                    out[name] = ProxyGroupPreviewRow(type, emptyList(), hidden, staticProxies)
                 useList.isNotEmpty() ->
-                    out[name] = ProxyGroupPreviewRow(type, emptyList(), hidden, fromProxies)
+                    out[name] = ProxyGroupPreviewRow(type, emptyList(), hidden, staticProxies)
                 else -> Unit
             }
+            if (totalMembers >= PreviewResourceLimits.MAX_TOTAL_MEMBERS) break
         }
         return out
     }

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreview.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreview.kt
@@ -19,11 +19,17 @@ object ProxyTransportYamlPreview {
     /** name -> transport info. */
     fun parse(snapshot: ProfileSnapshot, profileDir: File? = null): Map<String, ProxyTransportInfo> {
         val out = linkedMapOf<String, ProxyTransportInfo>()
-        for (entry in snapshot.proxies) {
-            val name = entry.stringField("name")?.takeIf { it.isNotEmpty() } ?: continue
-            out[name] = extractTransportInfo(entry)
+        val outputBudget = PreviewOutputBudget()
+        for (entry in snapshot.proxies.take(PreviewResourceLimits.MAX_PROXY_ENTRIES_SCANNED)) {
+            if (out.size >= PreviewResourceLimits.MAX_TRANSPORTS) break
+            val name = entry.stringField("name")?.trim()
+                ?.takeIf { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
+                ?: continue
+            val info = extractTransportInfo(entry)
+            if (!outputBudget.acceptAll(name, info.network, info.type)) break
+            out[name] = info
         }
-        collectProviderProxies(snapshot, profileDir, out)
+        collectProviderProxies(snapshot, profileDir, out, outputBudget)
         return out
     }
 
@@ -36,33 +42,48 @@ object ProxyTransportYamlPreview {
         snapshot: ProfileSnapshot,
         profileDir: File?,
         out: MutableMap<String, ProxyTransportInfo>,
+        outputBudget: PreviewOutputBudget,
     ) {
         val dir = profileDir?.takeIf { it.isDirectory } ?: return
-        for ((_, prov) in snapshot.proxyProviders) {
+        val readBudget = ProviderFileReadBudget()
+        var remainingEntries = PreviewResourceLimits.MAX_PROXY_ENTRIES_SCANNED
+        for ((_, prov) in snapshot.proxyProviders.entries.take(PreviewResourceLimits.MAX_PROVIDER_FILES)) {
+            if (out.size >= PreviewResourceLimits.MAX_TRANSPORTS || remainingEntries <= 0) break
             val pathStr = prov.stringField("path")
             val providerUrl = prov.stringField("url")
             val providerFile = if (!pathStr.isNullOrBlank()) {
                 ProxyDialerYamlEdit.resolveProviderPath(dir, pathStr)
             } else {
                 resolveDefaultProviderFile(dir, providerUrl) ?: continue
-            }
+            } ?: continue
             if (!providerFile.isFile) continue
-            val pRoot = runCatching { YamlFormatting.parseRootMap(providerFile.readText()) }
+            val providerText = readBudget.readUtf8(providerFile) ?: continue
+            val pRoot = runCatching { YamlFormatting.parseRootMap(providerText) }
                 .getOrNull() ?: continue
-            collectFromRawMap(pRoot, out)
+            remainingEntries -= collectFromRawMap(pRoot, out, outputBudget, remainingEntries)
         }
     }
 
     private fun collectFromRawMap(
         root: Map<String, Any?>,
         out: MutableMap<String, ProxyTransportInfo>,
-    ) {
-        val proxies = root["proxies"] as? List<*> ?: return
-        for (raw in proxies) {
+        outputBudget: PreviewOutputBudget,
+        maxEntries: Int,
+    ): Int {
+        val proxies = root["proxies"] as? List<*> ?: return 0
+        var scanned = 0
+        for (raw in proxies.take(maxEntries)) {
+            scanned++
+            if (out.size >= PreviewResourceLimits.MAX_TRANSPORTS) break
             val p = raw as? Map<*, *> ?: continue
-            val name = p["name"]?.toString()?.trim()?.takeIf { it.isNotEmpty() } ?: continue
-            out[name] = extractTransportInfoFromRaw(p)
+            val name = p["name"]?.toString()?.trim()
+                ?.takeIf { it.isNotEmpty() && it.length <= PreviewResourceLimits.MAX_NAME_CHARS }
+                ?: continue
+            val info = extractTransportInfoFromRaw(p)
+            if (!outputBudget.acceptAll(name, info.network, info.type)) break
+            out[name] = info
         }
+        return scanned
     }
 
     /**
@@ -89,13 +110,13 @@ object ProxyTransportYamlPreview {
     private val HEX_CHARS = "0123456789abcdef".toCharArray()
 
     private fun extractTransportInfo(p: JsonObject): ProxyTransportInfo {
-        val network = p.stringField("network")?.trim()?.lowercase().orEmpty()
+        val network = boundedMetadata(p.stringField("network"))
         val tls = p.booleanField("tls")
         // Reality is signalled by a non-empty reality-opts map, with or without
         // explicit tls: true. Mihomo accepts both forms.
         val realityOpts = p["reality-opts"] as? JsonObject
         val reality = realityOpts != null && realityOpts.isNotEmpty()
-        val type = p.stringField("type")?.trim()?.lowercase().orEmpty()
+        val type = boundedMetadata(p.stringField("type"))
         return ProxyTransportInfo(
             network = network,
             tls = tls,
@@ -105,11 +126,11 @@ object ProxyTransportYamlPreview {
     }
 
     private fun extractTransportInfoFromRaw(p: Map<*, *>): ProxyTransportInfo {
-        val network = (p["network"] as? String)?.trim()?.lowercase().orEmpty()
+        val network = boundedMetadata(p["network"] as? String)
         val tls = truthy(p["tls"])
         val realityOpts = p["reality-opts"] as? Map<*, *>
         val reality = realityOpts != null && realityOpts.isNotEmpty()
-        val type = (p["type"] as? String)?.trim()?.lowercase().orEmpty()
+        val type = boundedMetadata(p["type"] as? String)
         return ProxyTransportInfo(
             network = network,
             tls = tls,
@@ -121,6 +142,9 @@ object ProxyTransportYamlPreview {
     private fun JsonObject.stringField(key: String): String? = runCatching {
         this[key]?.jsonPrimitive?.content
     }.getOrNull()
+
+    private fun boundedMetadata(value: String?): String =
+        value?.trim()?.lowercase()?.take(MAX_METADATA_CHARS).orEmpty()
 
     private fun JsonObject.booleanField(key: String): Boolean {
         val element = this[key] ?: return false
@@ -148,4 +172,6 @@ object ProxyTransportYamlPreview {
         }
         else -> false
     }
+
+    private const val MAX_METADATA_CHARS = 64
 }

--- a/service/src/main/java/com/github/kr328/clash/service/util/YamlPreviewSupport.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/YamlPreviewSupport.kt
@@ -3,6 +3,10 @@ package com.github.kr328.clash.service.util
 import java.security.MessageDigest
 
 object YamlPreviewSupport {
+    private const val MAX_DIFF_LINES_PER_SIDE = 160
+    private const val MAX_DIFF_CHARS = 32 * 1024
+    private const val MAX_PREVIEW_TEXT_CHARS = 64 * 1024
+
     fun sha256(text: String): String {
         val md = MessageDigest.getInstance("SHA-256")
         val bytes = md.digest(text.toByteArray(Charsets.UTF_8))
@@ -19,61 +23,59 @@ object YamlPreviewSupport {
         if (oldText == newText) return "No changes"
         val oldLines = oldText.lines()
         val newLines = newText.lines()
-        val lcs = Array(oldLines.size + 1) { IntArray(newLines.size + 1) }
-        for (i in oldLines.indices.reversed()) {
-            for (j in newLines.indices.reversed()) {
-                lcs[i][j] = if (oldLines[i] == newLines[j]) {
-                    lcs[i + 1][j + 1] + 1
-                } else {
-                    maxOf(lcs[i + 1][j], lcs[i][j + 1])
-                }
-            }
+        var commonPrefix = 0
+        val sharedSize = minOf(oldLines.size, newLines.size)
+        while (commonPrefix < sharedSize && oldLines[commonPrefix] == newLines[commonPrefix]) {
+            commonPrefix++
+        }
+        var commonSuffix = 0
+        while (
+            commonSuffix < sharedSize - commonPrefix &&
+            oldLines[oldLines.lastIndex - commonSuffix] == newLines[newLines.lastIndex - commonSuffix]
+        ) {
+            commonSuffix++
         }
 
-        data class Op(val prefix: Char, val line: String)
-        val ops = ArrayList<Op>()
-        var i = 0
-        var j = 0
-        while (i < oldLines.size && j < newLines.size) {
-            when {
-                oldLines[i] == newLines[j] -> {
-                    ops.add(Op(' ', oldLines[i]))
-                    i++
-                    j++
-                }
-                lcs[i + 1][j] >= lcs[i][j + 1] -> {
-                    ops.add(Op('-', oldLines[i]))
-                    i++
-                }
-                else -> {
-                    ops.add(Op('+', newLines[j]))
-                    j++
-                }
-            }
+        val out = StringBuilder(minOf(MAX_DIFF_CHARS, oldText.length + newText.length))
+        fun appendLine(prefix: Char, line: String): Boolean {
+            if (out.length >= MAX_DIFF_CHARS) return false
+            val remaining = MAX_DIFF_CHARS - out.length
+            if (remaining <= 2) return false
+            out.append(prefix)
+            val allowed = minOf(line.length, remaining - 2)
+            out.append(line, 0, allowed).append('\n')
+            return allowed == line.length
         }
-        while (i < oldLines.size) ops.add(Op('-', oldLines[i++]))
-        while (j < newLines.size) ops.add(Op('+', newLines[j++]))
-
-        val changed = ops.indices.filter { ops[it].prefix != ' ' }
-        if (changed.isEmpty()) return "No changes"
-        val include = BooleanArray(ops.size)
-        for (idx in changed) {
-            val start = (idx - context).coerceAtLeast(0)
-            val end = (idx + context).coerceAtMost(ops.lastIndex)
-            for (k in start..end) include[k] = true
+        fun appendRange(prefix: Char, lines: List<String>, start: Int, end: Int) {
+            val count = end - start
+            if (count <= 0 || out.length >= MAX_DIFF_CHARS) return
+            val shown = minOf(count, MAX_DIFF_LINES_PER_SIDE)
+            for (idx in start until start + shown) {
+                if (!appendLine(prefix, lines[idx])) return
+            }
+            if (shown < count) appendLine(' ', "... ${count - shown} lines omitted ...")
         }
 
-        return buildString {
-            appendLine("--- current")
-            appendLine("+++ proposed")
-            var last = -2
-            for (idx in ops.indices) {
-                if (!include[idx]) continue
-                if (last != idx - 1) appendLine("@@")
-                append(ops[idx].prefix)
-                appendLine(ops[idx].line)
-                last = idx
-            }
-        }.trimEnd()
+        out.append("--- current\n+++ proposed\n@@\n")
+        val prefixStart = (commonPrefix - context.coerceAtLeast(0)).coerceAtLeast(0)
+        appendRange(' ', oldLines, prefixStart, commonPrefix)
+        appendRange('-', oldLines, commonPrefix, oldLines.size - commonSuffix)
+        appendRange('+', newLines, commonPrefix, newLines.size - commonSuffix)
+        appendRange(' ', oldLines, oldLines.size - commonSuffix, minOf(oldLines.size, oldLines.size - commonSuffix + context.coerceAtLeast(0)))
+        if (out.length >= MAX_DIFF_CHARS) {
+            out.setLength((MAX_DIFF_CHARS - 24).coerceAtLeast(0))
+            out.append("\n ... diff truncated ...")
+        }
+        return out.toString().trimEnd()
+    }
+
+    /** Bound JSON/Binder preview payloads; the full proposal remains in the server-side cache. */
+    fun boundedPreviewText(text: String): String {
+        if (text.length <= MAX_PREVIEW_TEXT_CHARS) return text
+        val marker = "\n... ${text.length - MAX_PREVIEW_TEXT_CHARS} characters omitted ...\n"
+        val available = MAX_PREVIEW_TEXT_CHARS - marker.length
+        val head = available / 2
+        val tail = available - head
+        return text.take(head) + marker + text.takeLast(tail)
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
@@ -45,9 +45,25 @@ class FetchErrorClassifierTest {
         assertSame(original, FetchErrorClassifier.clarify(dirWith("proxies: []\nrules:\n  - MATCH,DIRECT\n"), original))
     }
 
-    @Test fun oversized_body_is_not_classified_or_fully_reread() {
+    @Test fun oversized_html_is_classified_from_bounded_prefix() {
         val oversized = "<!DOCTYPE html>" + " ".repeat(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES)
-        assertSame(original, FetchErrorClassifier.clarify(dirWith(oversized), original))
+        val out = FetchErrorClassifier.clarify(dirWith(oversized), original)
+        assertTrue(out.message!!.contains("[E-11]"), out.message)
+    }
+
+    @Test fun oversized_age_armor_is_classified_from_bounded_prefix() {
+        val oversized = "-----BEGIN AGE ENCRYPTED FILE-----\n" +
+            "A".repeat(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES)
+        val out = FetchErrorClassifier.clarify(dirWith(oversized), original)
+        assertTrue(out.message!!.contains("[E-30]"), out.message)
+    }
+
+    @Test fun oversized_blank_or_yaml_prefix_keeps_original() {
+        val blank = " ".repeat(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES + 1)
+        assertSame(original, FetchErrorClassifier.clarify(dirWith(blank), original))
+
+        val yaml = "proxies: []\n" + "#".repeat(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES)
+        assertSame(original, FetchErrorClassifier.clarify(dirWith(yaml), original))
     }
 
     @Test fun body_at_inspection_limit_is_still_classified() {

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
@@ -45,6 +45,17 @@ class FetchErrorClassifierTest {
         assertSame(original, FetchErrorClassifier.clarify(dirWith("proxies: []\nrules:\n  - MATCH,DIRECT\n"), original))
     }
 
+    @Test fun oversized_body_is_not_classified_or_fully_reread() {
+        val oversized = "<!DOCTYPE html>" + " ".repeat(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES)
+        assertSame(original, FetchErrorClassifier.clarify(dirWith(oversized), original))
+    }
+
+    @Test fun body_at_inspection_limit_is_still_classified() {
+        val body = "<!DOCTYPE html>".padEnd(FetchErrorClassifier.MAX_CLASSIFICATION_BYTES, ' ')
+        val out = FetchErrorClassifier.clarify(dirWith(body), original)
+        assertTrue(out.message!!.contains("[E-11]"), out.message)
+    }
+
     @Test fun absent_file_non_network_keeps_original() {
         // No body + a non-network error (e.g. a parse/programmer error) → keep original.
         assertSame(original, FetchErrorClassifier.clarify(dirWith(null), original))

--- a/service/src/test/java/com/github/kr328/clash/service/util/MihomoConfigDocumentLinearTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/MihomoConfigDocumentLinearTest.kt
@@ -1,0 +1,29 @@
+package com.github.kr328.clash.service.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MihomoConfigDocumentLinearTest {
+    @Test
+    fun replaceHandlesLongTopLevelCommentPreambleInOnePass() {
+        val comments = (0 until 20_000).joinToString("\n") { "# next block comment $it" }
+        val yaml = "proxies:\n" +
+            "  - name: local\n" +
+            "    type: direct\n" +
+            "geox-url:\n" +
+            "  geoip: https://untrusted.example/geoip.dat\n" +
+            comments + "\n" +
+            "rules:\n" +
+            "  - MATCH,DIRECT\n"
+        val document = MihomoConfigDocument.parseOrThrow(yaml)
+        document.root["geox-url"] = mapOf("geoip" to "https://github.com/safe/geoip.dat")
+
+        val rendered = document.renderReplacing("geox-url")
+
+        assertTrue(rendered.contains("geoip: https://github.com/safe/geoip.dat"))
+        assertTrue(rendered.contains("# next block comment 0"))
+        assertTrue(rendered.indexOf("# next block comment 0") < rendered.indexOf("rules:"))
+        assertEquals(20_000, rendered.lineSequence().count { it.startsWith("# next block comment ") })
+    }
+}

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreviewTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyGroupsYamlPreviewTest.kt
@@ -171,6 +171,41 @@ class ProxyGroupsYamlPreviewTest {
     }
 
     @Test
+    fun untrustedFilterRejectsBacktrackingAndExtendedRegexShapes() {
+        assertFalse(ProxyGroupsYamlPreview.isSafeFilterPattern("(a+)+$"))
+        assertFalse(ProxyGroupsYamlPreview.isSafeFilterPattern("(?:a|aa)+$"))
+        assertFalse(ProxyGroupsYamlPreview.isSafeFilterPattern("(?=attacker)"))
+        assertFalse(ProxyGroupsYamlPreview.isSafeFilterPattern("(.)\\1"))
+        assertFalse(ProxyGroupsYamlPreview.isSafeFilterPattern("a".repeat(257)))
+        assertTrue(ProxyGroupsYamlPreview.isSafeFilterPattern("^(US|DE)-[0-9]$"))
+
+        val snapshot = ProfileSnapshot(
+            proxies = listOf(proxy("a".repeat(400) + "!")),
+            proxyGroups = listOf(group("Unsafe", includeAllProxies = true, filter = "(a+)+$")),
+        )
+        val unsafe = ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)["Unsafe"]
+        assertNotNull("unsafe filter must preserve the group as preview-unavailable", unsafe)
+        assertTrue(unsafe!!.members.isEmpty())
+    }
+
+    @Test
+    fun unsupportedCommonFilterPreservesDynamicGroupWithoutRunningJvmRegex() {
+        val snapshot = ProfileSnapshot(
+            proxies = listOf(proxy("US-1"), proxy("DE-1")),
+            proxyGroups = listOf(
+                group("InlineFlag", includeAllProxies = true, filter = "(?i)^us-"),
+                group("QuantifiedGroup", includeAllProxies = true, filter = "(US|DE)+"),
+                group("UnsafeExclude", includeAllProxies = true, excludeFilter = "(a+)+$"),
+            ),
+        )
+
+        val rows = ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)
+
+        assertEquals(setOf("InlineFlag", "QuantifiedGroup", "UnsafeExclude"), rows.keys)
+        assertTrue(rows.values.all { it.members.isEmpty() })
+    }
+
+    @Test
     fun parseProxyGroupsPreview_includeAllProxiesWithExcludeFilterDropsMatches() {
         // Repro of the user report: exclude-filter must drop members in the offline preview too,
         // mirroring the engine. Include path was already honored; exclusion was ignored.
@@ -211,5 +246,28 @@ class ProxyGroupsYamlPreviewTest {
         val rows = ProxyGroupsYamlPreview.parseProxyGroupsPreview(snapshot)
         assertFalse(rows.containsKey("Empty"))
         assertTrue(rows.containsKey("HasMembers"))
+    }
+
+    @Test
+    fun parseProxyGroupsPreview_boundsNamesGroupsAndMembersForIpc() {
+        val longName = "x".repeat(PreviewResourceLimits.MAX_NAME_CHARS + 1)
+        val members = (0 until PreviewResourceLimits.MAX_MEMBERS_PER_GROUP + 50).map { "node-$it" }
+        val groups = buildList {
+            add(group(longName, proxies = listOf("ignored")))
+            add(group("bounded", proxies = members))
+            repeat(PreviewResourceLimits.MAX_GROUPS + 10) { add(group("group-$it", proxies = listOf("node"))) }
+        }
+
+        val rows = ProxyGroupsYamlPreview.parseProxyGroupsPreview(ProfileSnapshot(proxyGroups = groups))
+
+        assertFalse(rows.containsKey(longName))
+        assertTrue(rows.size <= PreviewResourceLimits.MAX_GROUPS)
+        assertEquals(PreviewResourceLimits.MAX_MEMBERS_PER_GROUP, rows["bounded"]?.members?.size)
+        assertTrue(rows.values.sumOf { it.members.size } <= PreviewResourceLimits.MAX_TOTAL_MEMBERS)
+        assertTrue(
+            rows.entries.sumOf { (name, row) ->
+                name.length + row.members.sumOf(String::length) + row.staticProxies.sumOf(String::length)
+            } <= PreviewResourceLimits.MAX_OUTPUT_CHARS,
+        )
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreviewTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreviewTest.kt
@@ -83,4 +83,52 @@ class ProxyTransportYamlPreviewTest {
         val out = ProxyTransportYamlPreview.parse(snapshot)
         assertEquals(setOf("named"), out.keys)
     }
+
+    @Test
+    fun parse_boundsRowsNamesAndMetadataForIpc() {
+        val proxies = buildList {
+            add(jsonObj("name" to JsonPrimitive("x".repeat(PreviewResourceLimits.MAX_NAME_CHARS + 1))))
+            repeat(PreviewResourceLimits.MAX_TRANSPORTS + 50) {
+                add(
+                    jsonObj(
+                        "name" to JsonPrimitive("node-$it"),
+                        "type" to JsonPrimitive("t".repeat(500)),
+                        "network" to JsonPrimitive("n".repeat(500)),
+                    ),
+                )
+            }
+        }
+
+        val out = ProxyTransportYamlPreview.parse(ProfileSnapshot(proxies = proxies))
+
+        assertTrue(out.size <= PreviewResourceLimits.MAX_TRANSPORTS)
+        assertFalse(out.containsKey("x".repeat(PreviewResourceLimits.MAX_NAME_CHARS + 1)))
+        assertTrue(out.values.all { it.type.length <= 64 && it.network.length <= 64 })
+        assertTrue(
+            out.entries.sumOf { (name, info) -> name.length + info.type.length + info.network.length } <=
+                PreviewResourceLimits.MAX_OUTPUT_CHARS,
+        )
+    }
+
+    @Test
+    fun parse_skipsOversizedProviderFile() {
+        val dir = java.nio.file.Files.createTempDirectory("transport-provider-budget").toFile()
+        try {
+            val provider = dir.resolve("providers/proxies/huge.yaml")
+            requireNotNull(provider.parentFile).mkdirs()
+            provider.writeText(
+                "proxies:\n  - name: hidden\n    type: ss\n#" +
+                    "x".repeat(PreviewResourceLimits.MAX_PROVIDER_FILE_BYTES),
+            )
+            val snapshot = ProfileSnapshot(
+                proxyProviders = mapOf(
+                    "huge" to jsonObj("path" to JsonPrimitive("./proxies/huge.yaml")),
+                ),
+            )
+
+            assertTrue(ProxyTransportYamlPreview.parse(snapshot, dir).isEmpty())
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlMutationHelpersTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlMutationHelpersTest.kt
@@ -1,6 +1,8 @@
 package com.github.kr328.clash.service.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.nio.file.Files
@@ -131,6 +133,86 @@ class YamlMutationHelpersTest {
             assertTrue(proposed.contains("- MATCH,DIRECT"))
         } finally {
             dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun providerPathResolverConfinesPathsToProviderSandbox() {
+        val dir = Files.createTempDirectory("clashfest-provider-path").toFile()
+        try {
+            val valid = dir.resolve("providers/proxies/sub1.yaml")
+            requireNotNull(valid.parentFile).mkdirs()
+            valid.writeText("proxies: []")
+
+            assertEquals(
+                valid.canonicalFile,
+                ProxyDialerYamlEdit.resolveProviderPath(dir, "./proxies/sub1.yaml"),
+            )
+            assertEquals(
+                valid.canonicalFile,
+                ProxyDialerYamlEdit.resolveProviderPath(dir, valid.absolutePath),
+            )
+            assertNull(ProxyDialerYamlEdit.resolveProviderPath(dir, "../config.yaml"))
+            assertNull(ProxyDialerYamlEdit.resolveProviderPath(dir, dir.resolve("config.yaml").absolutePath))
+            assertNull(
+                ProxyDialerYamlEdit.resolveProviderPath(
+                    dir,
+                    requireNotNull(dir.parentFile).resolve("sibling.yaml").absolutePath,
+                ),
+            )
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun dialerProxyCannotPatchTraversalTargetButCanPatchProviderFile() {
+        val root = Files.createTempDirectory("clashfest-provider-edit").toFile()
+        val profile = root.resolve("profile").apply { mkdirs() }
+        val sibling = root.resolve("sibling.yaml").apply {
+            writeText("proxies:\n  - name: escaped\n    type: ss\n")
+        }
+        try {
+            profile.resolve("config.yaml").writeText(
+                """
+                    proxy-providers:
+                      hostile:
+                        type: file
+                        path: ../../sibling.yaml
+                """.trimIndent(),
+            )
+            assertFalse(ProxyDialerYamlEdit.applyDialerProxy(profile, "escaped", "DIRECT"))
+            assertFalse("dialer-proxy" in sibling.readText())
+
+            val provider = profile.resolve("providers/proxies/sub1.yaml")
+            requireNotNull(provider.parentFile).mkdirs()
+            provider.writeText("proxies:\n  - name: safe\n    type: ss\n")
+            profile.resolve("config.yaml").writeText(
+                """
+                    proxy-providers:
+                      safe:
+                        type: file
+                        path: ./proxies/sub1.yaml
+                """.trimIndent(),
+            )
+            assertTrue(ProxyDialerYamlEdit.applyDialerProxy(profile, "safe", "DIRECT"))
+            assertTrue("dialer-proxy: DIRECT" in provider.readText())
+
+            val providerNamedConfig = profile.resolve("providers/config.yaml")
+            providerNamedConfig.writeText("proxies:\n  - name: provider-config\n    type: ss\n")
+            profile.resolve("config.yaml").writeText(
+                """
+                    proxy-providers:
+                      ambiguous:
+                        type: file
+                        path: config.yaml
+                """.trimIndent(),
+            )
+            assertTrue(ProxyDialerYamlEdit.applyDialerProxy(profile, "provider-config", "DIRECT"))
+            assertTrue("dialer-proxy: DIRECT" in providerNamedConfig.readText())
+            assertFalse("dialer-proxy" in profile.resolve("config.yaml").readText())
+        } finally {
+            root.deleteRecursively()
         }
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlMutationHelpersTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlMutationHelpersTest.kt
@@ -150,16 +150,25 @@ class YamlMutationHelpersTest {
             )
             assertEquals(
                 valid.canonicalFile,
-                ProxyDialerYamlEdit.resolveProviderPath(dir, valid.absolutePath),
+                ProxyDialerYamlEdit.resolveProviderPath(dir, "/proxies/sub1.yaml"),
             )
-            assertNull(ProxyDialerYamlEdit.resolveProviderPath(dir, "../config.yaml"))
-            assertNull(ProxyDialerYamlEdit.resolveProviderPath(dir, dir.resolve("config.yaml").absolutePath))
-            assertNull(
-                ProxyDialerYamlEdit.resolveProviderPath(
-                    dir,
-                    requireNotNull(dir.parentFile).resolve("sibling.yaml").absolutePath,
-                ),
+            assertEquals(
+                valid.canonicalFile,
+                ProxyDialerYamlEdit.resolveProviderPath(dir, "../../proxies/sub1.yaml"),
             )
+            assertEquals(
+                valid.canonicalFile,
+                ProxyDialerYamlEdit.resolveProviderPath(dir, "ignored/../proxies/sub1.yaml"),
+            )
+            assertEquals("proxies/sub1.yaml", ProxyDialerYamlEdit.resolveAsRoot("/proxies/./sub1.yaml"))
+            assertEquals("proxies/sub1.yaml", ProxyDialerYamlEdit.resolveAsRoot("../../proxies/sub1.yaml"))
+
+            val outside = requireNotNull(dir.parentFile).resolve("sibling.yaml")
+            assertEquals(
+                dir.resolve("providers/sibling.yaml").canonicalFile,
+                ProxyDialerYamlEdit.resolveProviderPath(dir, "../../sibling.yaml"),
+            )
+            assertFalse(ProxyDialerYamlEdit.resolveProviderPath(dir, "../../sibling.yaml") == outside.canonicalFile)
         } finally {
             dir.deleteRecursively()
         }

--- a/service/src/test/java/com/github/kr328/clash/service/util/YamlPreviewSupportTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/YamlPreviewSupportTest.kt
@@ -25,6 +25,29 @@ class YamlPreviewSupportTest {
         assertTrue(diff.contains("   - MATCH,DIRECT"))
     }
 
+    @Test
+    fun unifiedDiffIsLinearAndSummarizedForLargeInputs() {
+        val current = (0 until 10_000).joinToString("\n") { "rule-$it: DIRECT" }
+        val proposed = (0 until 10_000).joinToString("\n") { "rule-$it: PROXY" }
+
+        val diff = YamlPreviewSupport.unifiedDiff(current, proposed)
+
+        assertTrue(diff.length <= 32 * 1024)
+        assertTrue(diff.contains("lines omitted") || diff.contains("diff truncated"))
+        assertTrue(diff.startsWith("--- current\n+++ proposed"))
+    }
+
+    @Test
+    fun previewPayloadTextIsBoundedButKeepsBothEnds() {
+        val text = "HEAD" + "x".repeat(200_000) + "TAIL"
+        val bounded = YamlPreviewSupport.boundedPreviewText(text)
+
+        assertTrue(bounded.length <= 64 * 1024)
+        assertTrue(bounded.startsWith("HEAD"))
+        assertTrue(bounded.endsWith("TAIL"))
+        assertTrue(bounded.contains("characters omitted"))
+    }
+
     @Test(expected = IllegalArgumentException::class)
     fun validateConfigYamlRejectsWrongRuleProviderShape() {
         YamlPreviewSupport.validateConfigYaml(


### PR DESCRIPTION
## Summary

Adds deterministic resource limits for untrusted subscription/profile processing so oversized or adversarial inputs cannot cause unbounded memory, CPU, traversal, or response-body use.

Key changes:

- bounds subscription name detection, profile fetch/error bodies, YAML previews, diffs, and proxy-group parsing;
- scopes core fetch headers and redirects to trusted destinations;
- constrains provider traversal and preview workloads;
- replaces expensive fallback matching paths with bounded behavior;
- adds focused regression tests for limits and trust transitions.

## Validation

- `:common:testAlphaDebugUnitTest`
- `:service:testAlphaDebugUnitTest`
- `:app:testAlphaDebugUnitTest`
- `assembleAlphaDebug`
- `git diff --check`

Validated independently on top of `Nemu-x/ClashFest:feat/init-clashfest` at `2ab9a913`.

## Review request

Prepared through **Codex Security and GPT-5.6 Sol** from a security-findings audit. Human maintainer/security review is explicitly requested before merge, with attention to limit values and compatibility with large real-world subscriptions.
