### PR TITLE
build(security): pin CI and Gradle inputs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,19 +10,23 @@ on:
       - 'feat/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
@@ -32,7 +36,7 @@ jobs:
           cache: gradle
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Grant gradlew execute permission
         run: chmod +x gradlew
@@ -49,7 +53,7 @@ jobs:
         run: ./gradlew assembleAlphaDebug
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clashfest-alpha-apk
           path: app/build/outputs/apk/**/*.apk

--- a/.github/workflows/prerelease-dev.yml
+++ b/.github/workflows/prerelease-dev.yml
@@ -14,10 +14,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Ensure tags for root and core submodule
         run: |
@@ -25,14 +26,14 @@ jobs:
           git -C core/src/foss/golang/clash fetch --tags --force
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
           cache: gradle
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Grant gradlew execute permission
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
           cache: gradle
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Grant gradlew execute permission
         run: chmod +x gradlew

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Hardens GitHub Actions and Gradle bootstrap inputs against supply-chain drift.

Key changes:

- pins third-party GitHub Actions to immutable commit SHAs;
- grants workflows only the permissions required by their jobs;
- disables credential persistence where checkout credentials are unnecessary;
- configures the Gradle distribution SHA-256 checksum.

## Validation

- `assembleAlphaDebug`
- `git diff --check`
- Gradle wrapper checksum verification during wrapper bootstrap

Validated independently on top of `Nemu-x/ClashFest:feat/init-clashfest` at `2ab9a913`.

## Review request

Prepared through **Codex Security and GPT-5.6 Sol** from a security-findings audit. Human maintainer/security review is explicitly requested before merge, especially for workflow permission requirements and future action-update maintenance.
