### PR TITLE
fix(core): cancel in-flight health checks on reset to unblock VPN tea…

### DIFF
--- a/core/src/main/golang/native/main.go
+++ b/core/src/main/golang/native/main.go
@@ -38,6 +38,10 @@ func coreInit(home, versionName, gitVersion C.c_string, sdkVersion C.int) {
 //export reset
 func reset() {
 	defer guard("reset")()
+	// Abort in-flight health checks on the outgoing config first: their url-test dials to dead nodes
+	// otherwise keep the tunnel (and, on teardown, the Android VpnService / system VPN key) alive for
+	// their full timeout — 10-30s after the tunnel is already logically down. See CancelHealthChecks.
+	tunnel.CancelHealthChecks()
 	config.LoadDefault()
 	tunnel.ResetStatistic()
 	tunnel.CloseAllConnections()

--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -2,6 +2,7 @@ package tunnel
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"sync"
 	"time"
@@ -119,6 +120,24 @@ func HealthCheckAll() {
 		go func(group string) {
 			HealthCheck(group)
 		}(g)
+	}
+}
+
+// CancelHealthChecks cancels the health-check context of every live proxy provider (subscription
+// providers and the synthetic per-group compatible providers alike). A plain config swap only
+// replaces the provider maps (tunnel.UpdateProxies) and never closes the outgoing ones, so their
+// url-test goroutines keep dialing until each hits its full per-proxy timeout. On VPN teardown that
+// stalls shutdown: the tunnel is logically down in ~90ms, but an in-flight batch against dead nodes
+// keeps the Android VpnService — and the system VPN key — alive for the 10-30s it takes the last
+// dial to give up. Cancelling the providers' health-check context aborts those dials at once.
+//
+// Called from reset() before LoadDefault swaps the config out; the providers are being discarded
+// anyway, and closing only fires ctxCancel (+ stops a subscription fetcher) — nothing blocking.
+func CancelHealthChecks() {
+	for _, p := range tunnel.Providers() {
+		if closer, ok := p.(io.Closer); ok {
+			_ = closer.Close()
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

On disconnect, the system VPN key (and `tun0`) lingered for up to ~30s after the
tunnel was already logically down. Reproduced and measured on device (Pixel, adb).

## Root cause

A config swap in mihomo (`tunnel.UpdateProxies`) only replaces the proxy/provider
maps — it never closes the *outgoing* providers. Their url-test health-check
goroutines keep running, and against dead nodes each dial waits out its full
per-proxy timeout. Android keeps the `VpnService` (and the status-bar VPN key)
alive until that in-flight native work finishes, so the key hangs for the length
of the slowest health-check batch.

`reset()` already called `CloseAllConnections()`, but that does not touch the
providers' health-check contexts.

## Fix

`reset()` now calls `CancelHealthChecks()` first. It closes every live proxy
provider — subscription providers and the synthetic per-group compatible
providers alike — so each provider's `Close()` fires its health-check
`ctxCancel()` and aborts the in-flight url-tests at once.

- Only runs on teardown / session start; never mid-session, so steady-state
  dedup/health behaviour is unchanged.
- No core (submodule) patch: the change lives in the app's native wrapper
  (`core/src/main/golang/native`).

## Measured

- Core-side teardown: **~30s → ~100ms** (gVisor stack close ~0.8ms; core silent
  right after).

### Known limitation (out of scope, not core-fixable)

When disconnecting under active app traffic, a residual ~5s can remain before the
key clears. This was traced to an Android `ConnectivityService` VPN-network
teardown floor that scales with the number of active *app* connections — the core
is fully torn down in ~100ms and sits idle during that window. It affects any
`VpnService`-based client and is not something the proxy core controls.

## Testing

Device (Pixel): repeated connect → traffic → disconnect cycles; verified the
long health-check tail is gone and normal browsing/DNS still work.
