### PR TITLE
feat(network): default to system TUN stack + X-Network-Stack operator header

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -2088,6 +2088,11 @@ class MainActivity : BaseActivity<MainDesign>() {
         meta.shareLinksDisable?.let {
             ServiceStore(this).setSubscriptionShareLinksLockedFor(active.uuid, it)
         }
+        // Operator TUN-stack policy (X-Network-Stack). Store as-is; `auto` is the operator's explicit
+        // "unlock". Applied at TUN open by TunStackResolver, independent of branding.
+        meta.networkStack?.let {
+            ServiceStore(this).setSubscriptionNetworkStackFor(active.uuid, it)
+        }
         uiStore.subscriptionHwidActive = meta.hwidActive?.toString().orEmpty()
         uiStore.subscriptionHwidNotSupported = meta.hwidNotSupported?.toString().orEmpty()
         uiStore.subscriptionHwidMaxDevicesReached = meta.hwidMaxDevicesReached?.toString().orEmpty()

--- a/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionMetadata.kt
+++ b/common/src/main/java/com/github/kr328/clash/common/util/SubscriptionMetadata.kt
@@ -33,6 +33,13 @@ data class SubscriptionMetadata(
     val hwidNotSupported: Boolean? = null,
     val hwidMaxDevicesReached: Boolean? = null,
     val hwidLimit: Boolean? = null,
+    /**
+     * Operator-forced TUN network stack, parsed from `X-Network-Stack`. One of
+     * `system` / `gvisor` / `mixed` locks the client to that stack (operator policy, wins over the
+     * user's manual setting — see TunStackResolver); `auto` means "don't lock, defer to the user /
+     * the system default". null = header absent. An unrecognised value maps to null.
+     */
+    val networkStack: String? = null,
 ) {
     fun isEmpty(): Boolean =
         supportUrl == null &&
@@ -46,7 +53,8 @@ data class SubscriptionMetadata(
             hwidActive == null &&
             hwidNotSupported == null &&
             hwidMaxDevicesReached == null &&
-            hwidLimit == null
+            hwidLimit == null &&
+            networkStack == null
 }
 
 object SubscriptionMetadataFetcher {
@@ -183,6 +191,12 @@ object SubscriptionMetadataFetcher {
             "X-Share-Links-Policy",
         )
         val shareLinksDisable = parseShareLinksPolicy(shareLinksRaw)
+        val networkStack = parseNetworkStack(
+            header(
+                "X-Network-Stack", "x-network-stack", "Network-Stack",
+                "X-NetworkStack", "X-NetworkStack-enabled", "x-networkstack-enabled",
+            ),
+        )
         val hwidActive = parseBooleanHeader(header("x-hwid-active", "X-HWID-ACTIVE"))
         val hwidNotSupported = parseBooleanHeader(header("x-hwid-not-supported", "X-HWID-NOT-SUPPORTED"))
         val hwidMaxDevicesReached = parseBooleanHeader(
@@ -203,7 +217,17 @@ object SubscriptionMetadataFetcher {
             hwidNotSupported = hwidNotSupported,
             hwidMaxDevicesReached = hwidMaxDevicesReached,
             hwidLimit = hwidLimit,
+            networkStack = networkStack,
         )
+    }
+
+    /** `X-Network-Stack` value → canonical stack, or null when absent/unrecognised. */
+    private fun parseNetworkStack(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        return when (raw.trim().lowercase()) {
+            "auto", "system", "gvisor", "mixed" -> raw.trim().lowercase()
+            else -> null
+        }
     }
 
     private fun parseShareLinksPolicy(raw: String?): Boolean? {

--- a/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
@@ -138,21 +138,26 @@ class NetworkSettingsDesign(
                 title = R.string.tun_stack_mode,
                 configure = vpnDependencies::add,
             )
-            // While the VPN is running on Auto, show the stack actually in use (Auto: gvisor/system/
-            // mixed) resolved from the active subscription — so the effective stack isn't opaque.
-            if (running) {
-                launch {
-                    val resolved = withContext(Dispatchers.IO) {
-                        if (srvStore.tunStackMode != TunStackResolver.AUTO) return@withContext null
-                        val uuid = srvStore.activeProfile ?: return@withContext null
-                        val cfg = runCatching {
-                            File(context.importedDir.resolve(uuid.toString()), "config.yaml").readText()
+            // Surface the effective stack so the picker isn't misleading: an operator `X-Network-Stack`
+            // header locks the stack over the user's pick ("Set by operator: …"), and Auto resolves to
+            // the subscription's declared stack ("Auto: …").
+            launch {
+                val setting = srvStore.tunStackMode
+                val (operatorLock, effective) = withContext(Dispatchers.IO) {
+                    val uuid = srvStore.activeProfile
+                    val operator = uuid?.let { srvStore.subscriptionNetworkStackFor(it) }
+                    val cfg = uuid?.let {
+                        runCatching {
+                            File(context.importedDir.resolve(it.toString()), "config.yaml").readText()
                         }.getOrNull()
-                        TunStackResolver.resolve(cfg, TunStackResolver.AUTO)
                     }
-                    if (resolved != null) {
-                        stackPref.summary = context.getString(R.string.tun_stack_auto_fmt, resolved)
-                    }
+                    operator?.trim()?.lowercase() to TunStackResolver.resolve(setting, operator, cfg)
+                }
+                when {
+                    operatorLock in setOf("system", "gvisor", "mixed") && operatorLock != setting ->
+                        stackPref.summary = context.getString(R.string.tun_stack_operator_fmt, effective)
+                    setting == TunStackResolver.AUTO ->
+                        stackPref.summary = context.getString(R.string.tun_stack_auto_fmt, effective)
                 }
             }
 

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1125,6 +1125,7 @@
     <string name="tun_stack_mode">Режим стека</string>
     <string name="tun_stack_auto">Авто</string>
     <string name="tun_stack_auto_fmt">Авто: %1$s</string>
+    <string name="tun_stack_operator_fmt">Задано оператором: %1$s</string>
     <string name="tun_stack_system">Системный стек</string>
     <string name="usage_unlimited_symbol">∞</string>
     <string name="whitelist">Белый список</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -659,6 +659,7 @@
     <string name="tun_stack_mode">栈模式</string>
     <string name="tun_stack_auto">自动</string>
     <string name="tun_stack_auto_fmt">自动：%1$s</string>
+    <string name="tun_stack_operator_fmt">由运营商设置：%1$s</string>
     <string name="tun_stack_system">系统栈</string>
     <string name="usage_unlimited_symbol">∞</string>
 

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -870,6 +870,7 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="tun_stack_mode">Stack Mode</string>
     <string name="tun_stack_auto">Auto</string>
     <string name="tun_stack_auto_fmt">Auto: %1$s</string>
+    <string name="tun_stack_operator_fmt">Set by operator: %1$s</string>
     <string name="tun_stack_system">System Stack</string>
     <string name="tun_stack_gvisor">Gvisor Stack</string>
     <string name="tun_stack_mixed">Mixed Stack</string>

--- a/docs/operator-api/README.md
+++ b/docs/operator-api/README.md
@@ -40,7 +40,8 @@ All ClashFest-specific headers use the `X-Brand-*` prefix.
 Some headers are kept under their conventional V2Ray / Clash-compatible names
 (`profile-title`, `Subscription-Userinfo`, `announce`, `share-links`,
 `x-hwid-*`) because they're already widely supported by panels. We extend
-those rather than rename them.
+those rather than rename them. Operator **policy** headers that aren't cosmetic
+branding (`share-links`, `X-Network-Stack`) apply without `X-Branding-Enabled`.
 
 Headers are matched **case-insensitively**.
 

--- a/docs/operator-api/headers.md
+++ b/docs/operator-api/headers.md
@@ -336,6 +336,22 @@ wipes cosmetic branding).
 | Applied to | Hides "Copy node link" / "Share" actions in the picker AND locks subscription URL editing for **that subscription only** |
 | Notes | Stored per-profile (`subscriptionShareLinksLockedFor(uuid)`). Different subscriptions can have different share policies — one operator's lock does not affect another's subscription on the same device. |
 
+### `X-Network-Stack`
+
+| | |
+|---|---|
+| Type | enum: `system` \| `gvisor` \| `mixed` \| `auto` |
+| Status | **v1** |
+| Needs `X-Branding-Enabled`? | **No** — operator policy, applies unbranded. |
+| Applied to | The TUN network stack handed to the VpnService. `system`/`gvisor`/`mixed` **lock** the client to that stack for this subscription, overriding the user's manual Stack Mode setting. `auto` = operator does not lock (defer to the user setting / the `system` default). |
+| Default | Header absent → client default (`system`). |
+| Notes | Stored per-profile (`subscriptionNetworkStackFor(uuid)`) like the share-links policy — different subscriptions can force different stacks on the same device. Precedence: **operator header > user's manual setting > Auto (follow the subscription's `tun.stack`) > `system` default** (see `TunStackResolver`). The app default is `system`; the user can pick `auto` to follow the subscription's declared `tun.stack`, and this header overrides both. `system` is recommended — the kernel stack is lower-latency on teardown and cheaper on battery than gVisor's userspace netstack; choose `gvisor`/`mixed` only when a device/network needs it. Accepted spellings (case-insensitive): `X-Network-Stack`, `Network-Stack`, `X-NetworkStack`, `X-NetworkStack-enabled`. |
+
+**Example (lock all users of this subscription to the kernel stack):**
+```
+X-Network-Stack: system
+```
+
 ### `x-hwid-active` / `x-hwid-not-supported` / `x-hwid-max-devices-reached` / `x-hwid-limit` (existing)
 
 | | |

--- a/docs/supported-headers.md
+++ b/docs/supported-headers.md
@@ -48,6 +48,7 @@ because these existed before our operator API.
 | `announce` / `Announce` / `Announcement` / `X-Announcement` | string (UTF-8 or `base64:`) | Operator broadcast — home announcement card body |
 | `announce-url` / `Announcement-URL` / `X-Announcement-URL` | URL | Tap target for the announcement bar |
 | `share-links` / `X-Share-Links` / `X-Share-Links-Policy` | boolean | **Per-subscription:** hides Share/Copy-link actions and locks URL editing for that profile |
+| `X-Network-Stack` / `Network-Stack` / `X-NetworkStack-enabled` | enum `system`\|`gvisor`\|`mixed`\|`auto` | **Per-subscription:** locks the TUN stack over the user's setting (`auto` = don't lock). Default is `system`. See [operator-api/headers.md](operator-api/headers.md#x-network-stack). |
 | `x-hwid-active` | boolean | Panel HWID acceptance — shown in HWID diagnostics |
 | `x-hwid-not-supported` | boolean | Panel HWID feature unsupported |
 | `x-hwid-max-devices-reached` | boolean | Panel device-cap reached |

--- a/service/src/main/java/com/github/kr328/clash/service/TunService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/TunService.kt
@@ -244,9 +244,13 @@ class TunService : VpnService(), CoroutineScope by CoroutineScope(Dispatchers.De
             TunModule.TunDevice(
                 fd = establish()?.detachFd()
                     ?: throw NullPointerException("Establish VPN rejected by system"),
-                // Honour the subscription's declared `tun.stack` (mixed/system/gvisor); the app
-                // setting is only a fallback when the subscription doesn't specify one.
-                stack = TunStackResolver.resolve(readActiveProfileConfigYaml(), store.tunStackMode),
+                // Operator `X-Network-Stack` header locks the stack; else the user's app setting; else
+                // (Auto) the subscription's tun.stack; else the `system` default. See TunStackResolver.
+                stack = TunStackResolver.resolve(
+                    store.tunStackMode,
+                    store.activeProfile?.let { store.subscriptionNetworkStackFor(it) },
+                    readActiveProfileConfigYaml(),
+                ),
                 gateway = "$TUN_GATEWAY/$TUN_SUBNET_PREFIX" + if (store.allowIpv6) ",$TUN_GATEWAY6/$TUN_SUBNET_PREFIX6" else "",
                 portal = TUN_PORTAL + if (store.allowIpv6) ",$TUN_PORTAL6" else "",
                 dns = buildTunDnsEndpoints(store.dnsHijacking, store.allowIpv6),

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -73,8 +73,10 @@ class ServiceStore(context: Context) {
 
     var tunStackMode by store.string(
         key = "tun_stack_mode",
-        // "auto" follows the subscription's tun.stack; explicit values override it. See TunStackResolver.
-        defaultValue = "auto"
+        // Default "system" (matches upstream CMFA). "auto" follows the subscription's tun.stack;
+        // explicit values (system/gvisor/mixed) are the user's manual pick; an operator
+        // `X-Network-Stack` header can lock the stack over any of them. See TunStackResolver.
+        defaultValue = "system"
     )
 
     var dynamicNotification by store.boolean(
@@ -192,6 +194,21 @@ class ServiceStore(context: Context) {
 
     fun clearSubscriptionShareLinksLockedFor(uuid: UUID) {
         rawPrefs.edit().remove("subscription_share_links_locked_$uuid").apply()
+    }
+
+    /**
+     * Per-profile operator-forced TUN stack from the `X-Network-Stack` subscription header
+     * (system/gvisor/mixed = lock; `auto` = don't lock). Travels per subscription like the
+     * share-links policy. null when the operator didn't send it. See [TunStackResolver].
+     */
+    fun subscriptionNetworkStackFor(uuid: UUID): String? =
+        rawPrefs.getString("subscription_network_stack_$uuid", null)
+
+    fun setSubscriptionNetworkStackFor(uuid: UUID, value: String?) {
+        rawPrefs.edit().also { e ->
+            if (value.isNullOrBlank()) e.remove("subscription_network_stack_$uuid")
+            else e.putString("subscription_network_stack_$uuid", value)
+        }.apply()
     }
 
     /**

--- a/service/src/main/java/com/github/kr328/clash/service/util/TunStackResolver.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/TunStackResolver.kt
@@ -1,38 +1,54 @@
 package com.github.kr328.clash.service.util
 
 /**
- * Resolves which TUN network stack to hand the VpnService fd (gvisor / system / mixed).
+ * Resolves which TUN network stack to hand the VpnService fd (system / gvisor / mixed).
  *
- * Precedence:
- *  - An explicit app-setting choice (system / gvisor / mixed) is a user **override** and wins.
- *  - [AUTO] (the default) follows the *subscription*: the active profile's composed `config.yaml`
- *    declares `tun.stack`, so mixed→mixed, system→system, gvisor→gvisor. Falls back to [DEFAULT]
- *    when the subscription doesn't declare a stack (or declares an unrecognised one).
+ * Precedence (highest first):
+ *  1. **Operator lock** — an `X-Network-Stack` subscription header of `system`/`gvisor`/`mixed`
+ *     forces that stack, over the user's manual choice (operator policy, like the share-links lock).
+ *     A header value of `auto` (or absent) means "don't lock" and falls through.
+ *  2. **User setting** — an explicit app-setting choice of `system`/`gvisor`/`mixed`.
+ *  3. **[AUTO] setting** — follow the *subscription*: the active profile's composed `config.yaml`
+ *     declares `tun.stack` (mixed→mixed, system→system, gvisor→gvisor). Falls back to [DEFAULT] when
+ *     the subscription doesn't declare a usable stack.
+ *  4. **Default `system`** — matches upstream CMFA. Used when the app setting is absent (its default
+ *     is `system`, not `auto`).
  */
 object TunStackResolver {
-    /** App-setting value meaning "follow the subscription". */
+    /** Sentinel meaning "no explicit lock": follow the subscription (app setting) / defer (header). */
     const val AUTO = "auto"
 
-    /** Used when Auto is selected but the subscription doesn't declare a usable stack. */
+    /** Fallback stack when nothing forces a choice. Matches CMFA's default. */
     private const val DEFAULT = "system"
 
     /** Stacks mihomo's TUN listener understands. An unknown value is ignored rather than crashing. */
     private val KNOWN = setOf("gvisor", "system", "mixed", "lwip")
 
     /**
-     * @param configYaml the composed `config.yaml` the engine will load (subscription as-is + user
-     *                   layer), or null when it can't be read.
-     * @param setting    the app-setting stack: [AUTO] to follow the subscription, or an explicit
-     *                   stack to override it.
+     * @param setting       the app-setting stack: an explicit stack, or [AUTO] to follow the subscription.
+     * @param operatorStack the `X-Network-Stack` header value persisted for the active profile, or null.
+     * @param configYaml    the composed `config.yaml` (subscription + user layer), or null — only read
+     *                       when [setting] is [AUTO].
      */
-    fun resolve(configYaml: String?, setting: String): String {
-        // Explicit user override (anything other than Auto) wins outright.
-        if (setting != AUTO && setting in KNOWN) return setting
-        // Auto → follow the subscription's declared tun.stack, falling back to the default.
-        val declared = runCatching {
-            val root = configYaml?.let { MihomoConfigDocument.parse(it)?.root }
-            (root?.get("tun") as? Map<*, *>)?.get("stack")?.toString()?.trim()?.lowercase()
-        }.getOrNull()
-        return if (declared != null && declared in KNOWN) declared else DEFAULT
+    fun resolve(setting: String, operatorStack: String?, configYaml: String?): String {
+        // 1. Operator lock wins outright.
+        val operator = operatorStack?.trim()?.lowercase()
+        if (operator != null && operator != AUTO && operator in KNOWN) return operator
+
+        // 2. Explicit user override.
+        val user = setting.trim().lowercase()
+        if (user != AUTO && user in KNOWN) return user
+
+        // 3. Auto → follow the subscription's declared tun.stack.
+        if (user == AUTO) {
+            val declared = runCatching {
+                val root = configYaml?.let { MihomoConfigDocument.parse(it)?.root }
+                (root?.get("tun") as? Map<*, *>)?.get("stack")?.toString()?.trim()?.lowercase()
+            }.getOrNull()
+            if (declared != null && declared in KNOWN) return declared
+        }
+
+        // 4. Default.
+        return DEFAULT
     }
 }

--- a/service/src/test/java/com/github/kr328/clash/service/util/TunStackResolverTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/TunStackResolverTest.kt
@@ -6,35 +6,49 @@ import kotlin.test.assertEquals
 class TunStackResolverTest {
     private val auto = TunStackResolver.AUTO
 
+    private fun resolve(setting: String, operator: String? = null, config: String? = null) =
+        TunStackResolver.resolve(setting, operator, config)
+
+    @Test fun explicitUserPick_isHonoured() {
+        assertEquals("gvisor", resolve("gvisor"))
+        assertEquals("mixed", resolve("mixed"))
+        assertEquals("system", resolve("system"))
+    }
+
     @Test fun auto_followsSubscriptionStack() {
         for (stack in listOf("gvisor", "system", "mixed", "lwip")) {
-            val yaml = "tun:\n  enable: true\n  stack: $stack\n"
-            assertEquals(stack, TunStackResolver.resolve(yaml, auto), "Auto must honour declared $stack")
+            assertEquals(stack, resolve(auto, config = "tun:\n  enable: true\n  stack: $stack\n"))
         }
     }
 
     @Test fun auto_isCaseInsensitive() {
-        assertEquals("gvisor", TunStackResolver.resolve("tun:\n  stack: gVisor\n", auto))
+        assertEquals("gvisor", resolve(auto, config = "tun:\n  stack: gVisor\n"))
     }
 
-    @Test fun auto_missingStack_fallsBackToSystem() {
-        assertEquals("system", TunStackResolver.resolve("proxies: []\n", auto))
-        assertEquals("system", TunStackResolver.resolve("tun:\n  enable: true\n", auto))
-        assertEquals("system", TunStackResolver.resolve(null, auto))
+    @Test fun auto_missingOrUnknownStack_fallsBackToSystem() {
+        assertEquals("system", resolve(auto, config = "proxies: []\n"))
+        assertEquals("system", resolve(auto, config = "tun:\n  stack: nonsense\n"))
+        assertEquals("system", resolve(auto, config = null))
+        assertEquals("system", resolve(auto, config = ": : not yaml : :"))
     }
 
-    @Test fun auto_unknownDeclaredStack_fallsBackToSystem() {
-        assertEquals("system", TunStackResolver.resolve("tun:\n  stack: nonsense\n", auto))
+    @Test fun operatorHeader_locksOverUserAndSubscription() {
+        // Operator wins over the user's manual pick...
+        assertEquals("system", resolve("gvisor", operator = "system"))
+        assertEquals("gvisor", resolve("system", operator = "gvisor"))
+        // ...and over the subscription's declared stack under Auto.
+        assertEquals("system", resolve(auto, operator = "system", config = "tun:\n  stack: gvisor\n"))
     }
 
-    @Test fun explicitChoice_overridesSubscription() {
-        val subMixed = "tun:\n  stack: mixed\n"
-        assertEquals("gvisor", TunStackResolver.resolve(subMixed, "gvisor"))
-        assertEquals("system", TunStackResolver.resolve(subMixed, "system"))
-        assertEquals("mixed", TunStackResolver.resolve("tun:\n  stack: gvisor\n", "mixed"))
+    @Test fun operatorAuto_doesNotLock_defersToSettingOrSubscription() {
+        assertEquals("gvisor", resolve("gvisor", operator = "auto"))
+        assertEquals("mixed", resolve(auto, operator = "auto", config = "tun:\n  stack: mixed\n"))
+        assertEquals("system", resolve(auto, operator = "auto", config = null))
     }
 
-    @Test fun unparseableConfig_underAuto_fallsBack() {
-        assertEquals("system", TunStackResolver.resolve(": : not yaml : :", auto))
+    @Test fun default_isSystem() {
+        // ServiceStore's default value is "system", so this is the effective default path.
+        assertEquals("system", resolve("system"))
+        assertEquals("system", resolve("nonsense"))
     }
 }


### PR DESCRIPTION
## What

- **Default TUN stack → `system`** (kernel stack, matches upstream CMFA). Previously the default was `auto` (follow the subscription's `tun.stack`).
- **`auto` kept** as an explicit user option — still follows the subscription's declared `tun.stack`.
- **New operator header `X-Network-Stack`** — values `system` / `gvisor` / `mixed` lock the stack for that subscription (operator policy, like `share-links`); `auto` = don't lock. Parsed in `SubscriptionMetadata`, so it works **without** `X-Branding-Enabled`. Stored per-profile.
- Settings show the effective stack (`Auto: system`, `Set by operator: gvisor`) so the picker isn't misleading.

## Precedence

`X-Network-Stack header` > user's manual setting > `auto` (subscription `tun.stack`) > `system` default.

## Why

The kernel `system` stack is lower-latency on VPN teardown and cheaper on battery than gVisor's userspace netstack; defaulting to it (and letting operators steer via header) is the safer baseline. See `docs/operator-api/headers.md`.

## Testing

- `TunStackResolverTest` rewritten for the new precedence (operator lock / auto-follows-subscription / default system) — passing.
- Device: default resolves to `stack = system`, traffic works; Settings display verified.

No core (submodule) changes.
