### PR TITLE
feat(preview): resolve offline proxy-group membership in the engine

### DIFF
--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -291,6 +291,18 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeParseProfileSnapshotFromByt
 }
 
 JNIEXPORT jstring JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeResolveProxyGroupsFromBytes(JNIEnv *env, jobject thiz,
+                                                                                  jstring yaml) {
+    TRACE_METHOD();
+
+    scoped_string _yaml = get_string(yaml);
+
+    scoped_string response = resolveProxyGroupsFromBytes(_yaml);
+
+    return new_string(response);
+}
+
+JNIEXPORT jstring JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeValidateProfileBytes(JNIEnv *env, jobject thiz,
                                                                           jstring yaml) {
     TRACE_METHOD();

--- a/core/src/main/golang/native/config.go
+++ b/core/src/main/golang/native/config.go
@@ -148,6 +148,17 @@ func parseProfileSnapshotFromBytes(yaml C.c_string) *C.char {
 	return C.CString(snapshot.MarshalJSONFromBytes([]byte(C.GoString(yaml))))
 }
 
+// resolveProxyGroupsFromBytes returns the proxy-group membership the engine itself computes for
+// in-memory YAML (include-all* expanded, use: resolved, filter/exclude-filter/exclude-type
+// applied) so the offline UI preview does not have to re-implement mihomo's group semantics.
+// Empty string on unparseable YAML — callers fall back to their own preview.
+//
+//export resolveProxyGroupsFromBytes
+func resolveProxyGroupsFromBytes(yaml C.c_string) *C.char {
+	defer guard("resolveProxyGroupsFromBytes")()
+	return C.CString(snapshot.ResolvedGroupsJSON([]byte(C.GoString(yaml))))
+}
+
 //export validateProfileBytes
 func validateProfileBytes(yaml C.c_string) *C.char {
 	defer guard("validateProfileBytes")()

--- a/core/src/main/golang/native/snapshot/groups.go
+++ b/core/src/main/golang/native/snapshot/groups.go
@@ -1,0 +1,96 @@
+package snapshot
+
+import (
+	"encoding/json"
+
+	"github.com/metacubex/mihomo/config"
+
+	// Same linkname reason as validate.go: config.ParseRawConfig needs
+	// hub/executor in the link graph.
+	_ "github.com/metacubex/mihomo/hub/executor"
+)
+
+// ResolvedGroup is the engine's own answer for a single proxy-group, in the shape the UI consumes.
+// Field names mirror mihomo's proxy JSON so the payload is recognisable at a glance.
+type ResolvedGroup struct {
+	Name   string   `json:"name"`
+	Type   string   `json:"type"`
+	Now    string   `json:"now,omitempty"`
+	Hidden bool     `json:"hidden,omitempty"`
+	All    []string `json:"all"`
+}
+
+// ResolvedGroupsJSON runs the engine's own parse pipeline over in-memory YAML and returns the
+// proxy-group membership mihomo actually computes — `include-all*` expanded, `use:` resolved,
+// `filter` / `exclude-filter` / `exclude-type` applied, provider name prefixes in place.
+//
+// This is the offline counterpart of tunnel.QueryProxyGroup. The UI needs the same answer while
+// the tunnel is down, and re-implementing mihomo's group semantics in Kotlin has repeatedly
+// diverged from the engine (a `filter` containing a quantifier or lookahead silently collapsed
+// the group to its declared `proxies:`; `use:`-backed groups resolved to nothing at all). Asking
+// the engine removes that whole class of divergence instead of chasing it directive by directive.
+//
+// No listeners and no TUN are started: this is the same parse ValidateBytes performs, so the cost
+// is one config parse. Providers opened during ParseRawConfig are always released.
+//
+// Returns a JSON array of [ResolvedGroup] in the config's own group order (mihomo's cfg.Proxies is
+// a map and would randomise it). An empty string means the YAML could not be parsed — callers
+// should fall back to their own preview; a valid config with no groups yields "[]".
+func ResolvedGroupsJSON(data []byte) string {
+	rawCfg, err := config.UnmarshalRawConfig(data)
+	if err != nil {
+		return ""
+	}
+
+	// Snapshot the declared order BEFORE parsing: ParseRawConfig topologically sorts
+	// rawCfg.ProxyGroup *in place* (a group referenced by another has to be built first), so
+	// reading it afterwards would hand the UI mihomo's build order instead of the user's.
+	order := make([]string, 0, len(rawCfg.ProxyGroup))
+	for _, raw := range rawCfg.ProxyGroup {
+		if name, _ := raw["name"].(string); name != "" {
+			order = append(order, name)
+		}
+	}
+
+	cfg, err := config.ParseRawConfig(rawCfg)
+	if err != nil {
+		return ""
+	}
+	defer closeProviders(cfg)
+
+	out := make([]ResolvedGroup, 0, len(order))
+	for _, name := range order {
+		p, ok := cfg.Proxies[name]
+		if !ok {
+			continue
+		}
+		blob, err := p.MarshalJSON()
+		if err != nil {
+			continue
+		}
+		var meta struct {
+			Type   string   `json:"type"`
+			Now    string   `json:"now"`
+			Hidden bool     `json:"hidden"`
+			All    []string `json:"all"`
+		}
+		// Only outbound *groups* carry `all`; a plain proxy marshals without it. That is the
+		// cheapest reliable discriminator and it comes straight from the engine.
+		if err := json.Unmarshal(blob, &meta); err != nil || meta.All == nil {
+			continue
+		}
+		out = append(out, ResolvedGroup{
+			Name:   name,
+			Type:   meta.Type,
+			Now:    meta.Now,
+			Hidden: meta.Hidden,
+			All:    meta.All,
+		})
+	}
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}

--- a/core/src/main/golang/native/snapshot/groups_test.go
+++ b/core/src/main/golang/native/snapshot/groups_test.go
@@ -1,0 +1,127 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Repro of a user report (2026-07): a select group with `include-all: true` and
+// `filter: '^(?!.*Netherlands 2)(…)'` rendered with a single member offline while other mihomo
+// clients showed four. Root cause was our Kotlin preview: isSafeFilterPattern rejects every
+// quantifier and every lookaround, so the filter could not be evaluated and the group collapsed
+// to its declared `proxies:`. This oracle proves the engine handles the exact same YAML, which is
+// why the offline preview now asks the engine instead of re-implementing the semantics.
+const lookaheadFilterYAML = `
+mixed-port: 7890
+mode: rule
+proxies:
+  - {name: "🇩🇪 Germany", type: ss, server: 1.1.1.1, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇫🇮 Finland", type: ss, server: 1.1.1.2, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 1", type: ss, server: 1.1.1.3, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 2", type: ss, server: 1.1.1.4, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇳🇱 Netherlands 3", type: ss, server: 1.1.1.5, port: 443, cipher: aes-128-gcm, password: a}
+  - {name: "🇸🇪 Sweden", type: ss, server: 1.1.1.6, port: 443, cipher: aes-128-gcm, password: a}
+proxy-groups:
+  - name: "▶️ YouTube"
+    type: select
+    include-all: true
+    filter: '^(?!.*Netherlands 2)(🇳🇱|NL|Netherlands|🇸🇪|SE|Sweden)'
+    proxies:
+      - "🎲 Fastest YouTube"
+  - name: "🎲 Fastest YouTube"
+    type: url-test
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    lazy: true
+    hidden: true
+    filter: '^(?!.*Netherlands 2)(🇳🇱|NL|Netherlands|🇸🇪|SE|Sweden)'
+    include-all: true
+rules:
+  - MATCH,▶️ YouTube
+`
+
+func decodeGroups(t *testing.T, blob string) []ResolvedGroup {
+	t.Helper()
+	if blob == "" {
+		t.Fatal("ResolvedGroupsJSON returned empty (parse failed)")
+	}
+	var groups []ResolvedGroup
+	if err := json.Unmarshal([]byte(blob), &groups); err != nil {
+		t.Fatalf("decode groups: %v (raw: %s)", err, blob)
+	}
+	return groups
+}
+
+func groupByName(t *testing.T, groups []ResolvedGroup, name string) ResolvedGroup {
+	t.Helper()
+	for _, g := range groups {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("group %q not found in %+v", name, groups)
+	return ResolvedGroup{}
+}
+
+func TestResolvedGroups_LookaheadFilterIsHonoured(t *testing.T) {
+	groups := decodeGroups(t, ResolvedGroupsJSON([]byte(lookaheadFilterYAML)))
+
+	yt := groupByName(t, groups, "▶️ YouTube")
+
+	// include-all + filter must expand to the three matching nodes, plus the declared sub-group.
+	want := map[string]bool{
+		"🎲 Fastest YouTube": true,
+		"🇳🇱 Netherlands 1":  true,
+		"🇳🇱 Netherlands 3":  true,
+		"🇸🇪 Sweden":         true,
+	}
+	if len(yt.All) != len(want) {
+		t.Fatalf("expected %d members, got %d: %v", len(want), len(yt.All), yt.All)
+	}
+	for _, name := range yt.All {
+		if !want[name] {
+			t.Fatalf("unexpected member %q (negative lookahead must drop Netherlands 2, filter must drop Germany/Finland); got %v", name, yt.All)
+		}
+	}
+}
+
+func TestResolvedGroups_PreservesConfigOrderAndHidden(t *testing.T) {
+	groups := decodeGroups(t, ResolvedGroupsJSON([]byte(lookaheadFilterYAML)))
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d: %+v", len(groups), groups)
+	}
+	// cfg.Proxies is a map; we iterate rawCfg.ProxyGroup so the config's own order survives.
+	if groups[0].Name != "▶️ YouTube" || groups[1].Name != "🎲 Fastest YouTube" {
+		t.Fatalf("group order not preserved: %s, %s", groups[0].Name, groups[1].Name)
+	}
+	if groups[0].Hidden {
+		t.Error("▶️ YouTube must not be hidden")
+	}
+	if !groups[1].Hidden {
+		t.Error("🎲 Fastest YouTube declares hidden: true, engine must report it")
+	}
+	if groups[0].Type == "" {
+		t.Error("group type must be reported")
+	}
+}
+
+func TestResolvedGroups_InvalidYamlReturnsEmpty(t *testing.T) {
+	if got := ResolvedGroupsJSON([]byte(": : not yaml : :")); got != "" {
+		t.Fatalf("invalid YAML must yield empty string so callers can fall back, got %q", got)
+	}
+}
+
+func TestResolvedGroups_NoGroupsYieldsEmptyArray(t *testing.T) {
+	const noGroups = `
+mixed-port: 7890
+mode: rule
+proxies:
+  - {name: "🇩🇪 Germany", type: ss, server: 1.1.1.1, port: 443, cipher: aes-128-gcm, password: a}
+rules:
+  - MATCH,DIRECT
+`
+	if got := ResolvedGroupsJSON([]byte(noGroups)); got != "[]" {
+		t.Fatalf("a valid config without groups must yield \"[]\", got %q", got)
+	}
+}

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -342,6 +342,29 @@ object Clash {
         return Bridge.nativeValidateProfileBytes(yaml)
     }
 
+    /**
+     * Asks the engine for the proxy-group membership it computes for [yaml] — `include-all*`
+     * expanded, `use:` resolved, `filter` / `exclude-filter` / `exclude-type` applied — so the
+     * offline preview matches what the running tunnel would report.
+     *
+     * Same parse as [validateProfileBytes]: no listeners, no TUN, no network, no engine state
+     * mutation; providers opened during the parse are released before returning.
+     *
+     * @return the resolved groups in config order, or **null** when the YAML could not be parsed
+     *         (callers should fall back to their own preview). A valid config with no groups
+     *         yields an empty list.
+     */
+    fun resolveProxyGroups(yaml: String): List<ResolvedProxyGroup>? {
+        val raw = Bridge.nativeResolveProxyGroupsFromBytes(yaml)
+        if (raw.isBlank()) return null
+        return runCatching {
+            ProfileSnapshotJson.decodeFromString(
+                ListSerializer(ResolvedProxyGroup.serializer()),
+                raw,
+            )
+        }.getOrNull()
+    }
+
     private fun decodeSnapshotEnvelope(rawJson: String): ProfileSnapshot {
         val envelope = ProfileSnapshotJson.decodeFromString(
             ProfileSnapshotEnvelope.serializer(),

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -56,6 +56,7 @@ object Bridge {
     external fun nativeValidateProfile(completable: CompletableDeferred<Unit>, path: String)
     external fun nativeParseProfileSnapshot(path: String): String
     external fun nativeParseProfileSnapshotFromBytes(yaml: String): String
+    external fun nativeResolveProxyGroupsFromBytes(yaml: String): String
     external fun nativeValidateProfileBytes(yaml: String): String?
     external fun nativeQueryProviders(): String
     external fun nativeQueryConnectionsSnapshot(): String

--- a/core/src/main/java/com/github/kr328/clash/core/model/ResolvedProxyGroup.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/ResolvedProxyGroup.kt
@@ -1,0 +1,27 @@
+package com.github.kr328.clash.core.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A proxy-group with the membership **the engine itself computed**, produced by
+ * `Bridge.nativeResolveProxyGroupsFromBytes`.
+ *
+ * Unlike [ProfileSnapshot], which exposes `proxy-groups` exactly as written in YAML (raw and
+ * unresolved), this carries mihomo's answer: `include-all*` expanded, `use:` resolved,
+ * `filter` / `exclude-filter` / `exclude-type` applied, provider name prefixes in place.
+ *
+ * Use this for the offline preview so the disconnected UI matches what the running tunnel
+ * reports. Re-implementing mihomo's group semantics in Kotlin has repeatedly diverged from the
+ * engine — a `filter` with a quantifier or lookahead silently collapsed a group to its declared
+ * `proxies:`, and `use:`-backed groups resolved to nothing at all.
+ */
+@Serializable
+data class ResolvedProxyGroup(
+    val name: String,
+    val type: String = "",
+    /** Currently selected member, when the engine reports one. */
+    val now: String = "",
+    val hidden: Boolean = false,
+    /** Resolved member names, in the engine's order. */
+    val all: List<String> = emptyList(),
+)

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -7,6 +7,10 @@ import com.github.kr328.clash.common.util.SubscriptionNameGuesser
 import com.github.kr328.clash.common.util.SubscriptionUsage
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ProfileSnapshot
+import com.github.kr328.clash.core.model.Proxy
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import com.github.kr328.clash.service.data.Database
 import com.github.kr328.clash.service.data.Imported
 import com.github.kr328.clash.service.data.ImportedDao
@@ -601,22 +605,72 @@ class ProfileManager(private val context: Context) : IProfileManager,
             }
             try {
                 val snapshot = getOrParseSnapshot(uuid, file)
-                // includeHidden = true: when the live engine path serves the
-                // UI, the picker pills walk every group (visible + hidden) via
-                // Clash.queryAllProxyGroupNamesIncludingHidden, so the offline
-                // preview must match that universe — otherwise hidden auto
-                // subgroups have no rows during the warmup race (live data not
-                // ready yet, offline fallback missing the group), and the
-                // expanded carriage flashes empty until proxyDetails arrives.
-                ProxyGroupsYamlPreview.parseProxyGroupsPreview(
-                    snapshot,
-                    file.parentFile,
-                    includeHidden = true,
-                )
+                // Ask the engine first. It resolves include-all* / use: / filter / exclude-filter /
+                // exclude-type exactly as the running tunnel does, so the disconnected UI reports the
+                // same membership as the connected one. The Kotlin preview below re-implements those
+                // semantics and has repeatedly diverged (a filter with a quantifier or lookahead
+                // silently collapsed a group to its declared proxies:; use:-backed groups resolved to
+                // nothing), so it stays only as a fallback for YAML the engine refuses to parse.
+                //
+                // includeHidden = true in both paths: when the live engine path serves the UI, the
+                // picker pills walk every group (visible + hidden) via
+                // Clash.queryAllProxyGroupNamesIncludingHidden, so the offline preview must match that
+                // universe — otherwise hidden auto subgroups have no rows during the warmup race and
+                // the expanded carriage flashes empty until proxyDetails arrives.
+                engineProxyGroupsPreview(file, snapshot)
+                    ?: ProxyGroupsYamlPreview.parseProxyGroupsPreview(
+                        snapshot,
+                        file.parentFile,
+                        includeHidden = true,
+                    )
             } catch (_: Exception) {
                 emptyMap()
             }
         }
+    }
+
+    /**
+     * Engine-resolved membership for the offline preview, or null when mihomo cannot parse the
+     * config (caller falls back to the Kotlin preview).
+     *
+     * `staticProxies` still comes from the snapshot: it must stay the *declared* `proxies:` list,
+     * never the expanded one, because the picker's 1-hop heuristic uses it to tell a pure dispatch
+     * shell from a group whose members are flat only because of `include-all`.
+     */
+    private fun engineProxyGroupsPreview(
+        file: File,
+        snapshot: ProfileSnapshot,
+    ): Map<String, ProxyGroupPreviewRow>? {
+        val resolved = runCatching { Clash.resolveProxyGroups(file.readText()) }.getOrNull()
+            ?: return null
+
+        val declaredByName = HashMap<String, List<String>>(snapshot.proxyGroups.size)
+        for (group in snapshot.proxyGroups) {
+            val name = (group["name"] as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+            if (name.isEmpty()) continue
+            declaredByName[name] = (group["proxies"] as? JsonArray)
+                .orEmpty()
+                .mapNotNull { (it as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf(String::isNotEmpty) }
+        }
+
+        return resolved.associate { group ->
+            group.name to ProxyGroupPreviewRow(
+                type = engineGroupType(group.type),
+                members = group.all,
+                hidden = group.hidden,
+                staticProxies = declaredByName[group.name].orEmpty(),
+            )
+        }
+    }
+
+    /** mihomo marshals adapter types as `Selector` / `URLTest` / …; YAML spells them `url-test`. */
+    private fun engineGroupType(raw: String): Proxy.Type = when (raw.trim().lowercase()) {
+        "selector", "select" -> Proxy.Type.Selector
+        "fallback" -> Proxy.Type.Fallback
+        "urltest", "url-test" -> Proxy.Type.URLTest
+        "loadbalance", "load-balance" -> Proxy.Type.LoadBalance
+        "relay" -> Proxy.Type.Relay
+        else -> Proxy.Type.Selector
     }
 
     override suspend fun readProxyTransports(uuid: UUID): Map<String, ProxyTransportInfo> {


### PR DESCRIPTION
The offline preview re-implemented mihomo's group semantics in Kotlin and kept diverging from the running tunnel: a filter containing a quantifier or lookahead was rejected by isSafeFilterPattern and silently collapsed the group to its declared proxies:, use:-backed groups resolved to nothing, exclude-type was unimplemented and provider name prefixes were never applied.

Add snapshot.ResolvedGroupsJSON: the engine's own UnmarshalRawConfig + ParseRawConfig (same parse ValidateBytes uses - no listeners, no TUN, providers released) returning the membership mihomo computes, in the config's declared group order. ProfileManager asks the engine first and falls back to the Kotlin preview only for YAML the engine cannot parse.

Verified on device: offline group counts now match the connected view exactly.