### PR TITLE
feat(network): local proxy panel with credentials

### DIFF
--- a/design/build.gradle.kts
+++ b/design/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.viewpager)
+    implementation(libs.androidx.biometric)
     implementation(libs.google.material)
     implementation("com.caverock:androidsvg-aar:1.4")
 

--- a/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/NetworkSettingsDesign.kt
@@ -1,11 +1,21 @@
 package com.github.kr328.clash.design
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import android.view.View
 import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
+import android.widget.Toast
+import androidx.annotation.StringRes
 import com.github.kr328.clash.design.databinding.DesignSettingsCommonBinding
+import android.widget.TextView
 import com.github.kr328.clash.design.preference.*
 import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.ui.ToastDuration
@@ -88,6 +98,54 @@ class NetworkSettingsDesign(
                 title = R.string.network_switch_reaction,
                 summary = R.string.network_switch_reaction_summary,
             )
+
+            category(R.string.local_proxy)
+
+            switch(
+                value = srvStore::localProxyEnabled,
+                title = R.string.local_proxy_enable,
+                summary = R.string.local_proxy_enable_summary,
+            ) {
+                vpnDependencies.add(this)
+                // Strict means "no local listeners at all", so leaving the picker on Strict while a
+                // listener is actually open would be a lie. Move it to Compat on enable and back on
+                // disable; an explicit Off is the user's call and stays untouched.
+                listener = OnChangedListener {
+                    val mode = srvStore.proxyHardeningMode
+                    if (srvStore.localProxyEnabled) {
+                        if (mode == ProxyHardeningMode.Strict) {
+                            srvStore.proxyHardeningMode = ProxyHardeningMode.Compat
+                        }
+                    } else if (mode == ProxyHardeningMode.Compat) {
+                        srvStore.proxyHardeningMode = ProxyHardeningMode.Strict
+                    }
+                }
+            }
+
+            // Pinned by us rather than inherited from the subscription, so the address shown here is
+            // always the real one — the whole point is giving the user something to paste.
+            val localProxyPortNullable = object {
+                var value: Int?
+                    get() = srvStore.localProxyPort
+                    set(v) {
+                        srvStore.localProxyPort = (v ?: DEFAULT_LOCAL_PROXY_PORT)
+                            .coerceIn(1, 65535)
+                    }
+            }
+            editableText(
+                value = localProxyPortNullable::value,
+                adapter = NullableTextAdapter.Port,
+                title = R.string.local_proxy_port,
+                configure = vpnDependencies::add,
+            )
+
+            val credentials = clickable(
+                title = R.string.local_proxy_credentials,
+                summary = R.string.local_proxy_credentials_summary,
+            ) {
+                clicked { revealLocalProxyCredentials(context, srvStore) }
+            }
+            credentials.summary = localProxySummary(context, srvStore)
 
             category(R.string.vpn_service_options)
 
@@ -184,5 +242,106 @@ class NetworkSettingsDesign(
                 showToast(R.string.options_unavailable, ToastDuration.Indefinite)
             }
         }
+    }
+
+    private fun localProxySummary(context: Context, srvStore: ServiceStore): CharSequence =
+        if (srvStore.localProxyEnabled) {
+            "$LOOPBACK:${srvStore.localProxyPort}"
+        } else {
+            context.getString(R.string.local_proxy_credentials_summary)
+        }
+
+    /**
+     * Reveal the credentials behind a biometric / device-credential prompt.
+     *
+     * The secret only grants access to this device's own loopback listener, so the prompt is
+     * shoulder-surfing and screen-sharing hygiene rather than a real security boundary. When the
+     * device has nothing enrolled we show the credentials anyway instead of locking the user out
+     * of their own proxy.
+     */
+    private fun revealLocalProxyCredentials(context: Context, srvStore: ServiceStore) {
+        val activity = context as? FragmentActivity
+        val authenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK or
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        val canAuthenticate = BiometricManager.from(context)
+            .canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+
+        if (activity == null || !canAuthenticate) {
+            showLocalProxyCredentials(context, srvStore)
+            return
+        }
+
+        BiometricPrompt(
+            activity,
+            ContextCompat.getMainExecutor(context),
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    showLocalProxyCredentials(context, srvStore)
+                }
+            },
+        ).authenticate(
+            BiometricPrompt.PromptInfo.Builder()
+                .setTitle(context.getString(R.string.local_proxy_credentials))
+                .setSubtitle(context.getString(R.string.local_proxy_reveal_subtitle))
+                .setAllowedAuthenticators(authenticators)
+                .build(),
+        )
+    }
+
+    private fun showLocalProxyCredentials(context: Context, srvStore: ServiceStore) {
+        val credential = srvStore.localProxyCredential
+        if (!srvStore.localProxyEnabled || credential.isBlank()) {
+            // Minted by the service on the first load after the toggle, so it can legitimately be
+            // missing until the user connects once.
+            MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.local_proxy_credentials)
+                .setMessage(R.string.local_proxy_not_ready)
+                .setPositiveButton(R.string.ok, null)
+                .show()
+            return
+        }
+
+        val user = credential.substringBefore(':', "")
+        val pass = credential.substringAfter(':', "")
+        val port = srvStore.localProxyPort
+        val url = "socks5://$user:$pass@$LOOPBACK:$port"
+
+        fun copy(@StringRes label: Int, value: String) {
+            context.getSystemService(ClipboardManager::class.java)
+                ?.setPrimaryClip(ClipData.newPlainText(context.getString(label), value))
+            Toast.makeText(
+                context,
+                context.getString(R.string.local_proxy_copied_fmt, context.getString(label)),
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
+
+        // Every value gets its own selectable row and its own copy button: some clients take a
+        // single socks5:// URL (the button below), others want the fields entered one at a time,
+        // and digging them out of one text blob is miserable.
+        val view = context.layoutInflater.inflate(R.layout.dialog_local_proxy, null, false)
+
+        fun bind(valueId: Int, copyId: Int, @StringRes label: Int, value: String) {
+            view.findViewById<TextView>(valueId).text = value
+            view.findViewById<View>(copyId).setOnClickListener { copy(label, value) }
+        }
+        bind(R.id.valueHost, R.id.copyHost, R.string.local_proxy_field_host, LOOPBACK)
+        bind(R.id.valuePort, R.id.copyPort, R.string.local_proxy_field_port, port.toString())
+        bind(R.id.valueUsername, R.id.copyUsername, R.string.local_proxy_field_username, user)
+        bind(R.id.valuePassword, R.id.copyPassword, R.string.local_proxy_field_password, pass)
+
+        MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.local_proxy_credentials)
+            .setView(view)
+            .setPositiveButton(R.string.local_proxy_copy_url) { _, _ ->
+                copy(R.string.local_proxy_credentials, url)
+            }
+            .setNegativeButton(R.string.close, null)
+            .show()
+    }
+
+    private companion object {
+        const val LOOPBACK = "127.0.0.1"
+        const val DEFAULT_LOCAL_PROXY_PORT = 7890
     }
 }

--- a/design/src/main/res/layout/dialog_local_proxy.xml
+++ b/design/src/main/res/layout/dialog_local_proxy.xml
@@ -1,140 +1,181 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Credentials for the opt-in local proxy. Each value gets its own row and its own copy button:
-  some clients take a single socks5:// URL (the dialog's Copy URL button), others want the fields
-  typed in one at a time, and hand-editing them out of a single text blob is miserable.
+  Credentials for the opt-in local proxy. Each value gets its own selectable row and its own copy
+  button: some clients take a single socks5:// URL (the dialog button), others want the fields
+  entered one at a time, and digging them out of a single text blob is miserable.
+
+  Styling follows the settings rows (label above value, TextAppearance.App.*, colorOnSurface /
+  colorOnSurfaceVariant) so the dialog reads as part of the app rather than a system popup.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingStart="24dp"
-    android:paddingTop="8dp"
-    android:paddingEnd="12dp"
-    android:paddingBottom="8dp">
+    android:paddingTop="4dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="4dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp">
 
-        <TextView
-            android:layout_width="96dp"
-            android:layout_height="wrap_content"
-            android:text="@string/local_proxy_field_host"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="14sp" />
-
-        <TextView
-            android:id="@+id/valueHost"
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textIsSelectable="true"
-            android:textSize="15sp" />
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_proxy_field_host"
+                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <TextView
+                android:id="@+id/valueHost"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                android:textColor="?attr/colorOnSurface"
+                android:textIsSelectable="true" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/copyHost"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/local_proxy_copy_url"
-            android:src="@drawable/ic_baseline_content_copy" />
+            android:src="@drawable/ic_baseline_content_copy"
+            android:tint="?attr/colorOnSurfaceVariant" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp">
 
-        <TextView
-            android:layout_width="96dp"
-            android:layout_height="wrap_content"
-            android:text="@string/local_proxy_field_port"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="14sp" />
-
-        <TextView
-            android:id="@+id/valuePort"
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textIsSelectable="true"
-            android:textSize="15sp" />
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_proxy_field_port"
+                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <TextView
+                android:id="@+id/valuePort"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                android:textColor="?attr/colorOnSurface"
+                android:textIsSelectable="true" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/copyPort"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/local_proxy_copy_url"
-            android:src="@drawable/ic_baseline_content_copy" />
+            android:src="@drawable/ic_baseline_content_copy"
+            android:tint="?attr/colorOnSurfaceVariant" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp">
 
-        <TextView
-            android:layout_width="96dp"
-            android:layout_height="wrap_content"
-            android:text="@string/local_proxy_field_username"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="14sp" />
-
-        <TextView
-            android:id="@+id/valueUsername"
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textIsSelectable="true"
-            android:textSize="15sp" />
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_proxy_field_username"
+                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <TextView
+                android:id="@+id/valueUsername"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                android:textColor="?attr/colorOnSurface"
+                android:textIsSelectable="true" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/copyUsername"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/local_proxy_copy_url"
-            android:src="@drawable/ic_baseline_content_copy" />
+            android:src="@drawable/ic_baseline_content_copy"
+            android:tint="?attr/colorOnSurfaceVariant" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp">
 
-        <TextView
-            android:layout_width="96dp"
-            android:layout_height="wrap_content"
-            android:text="@string/local_proxy_field_password"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textSize="14sp" />
-
-        <TextView
-            android:id="@+id/valuePassword"
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:fontFamily="monospace"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textIsSelectable="true"
-            android:textSize="15sp" />
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_proxy_field_password"
+                android:textAppearance="@style/TextAppearance.App.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <!-- monospace so l/1/I and O/0 are not ambiguous when typed by hand -->
+            <TextView
+                android:id="@+id/valuePassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textAppearance="@style/TextAppearance.App.TitleSmall"
+                android:textColor="?attr/colorOnSurface"
+                android:textIsSelectable="true" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/copyPassword"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/local_proxy_copy_password"
-            android:src="@drawable/ic_baseline_content_copy" />
+            android:src="@drawable/ic_baseline_content_copy"
+            android:tint="?attr/colorOnSurfaceVariant" />
     </LinearLayout>
 </LinearLayout>

--- a/design/src/main/res/layout/dialog_local_proxy.xml
+++ b/design/src/main/res/layout/dialog_local_proxy.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Credentials for the opt-in local proxy. Each value gets its own row and its own copy button:
+  some clients take a single socks5:// URL (the dialog's Copy URL button), others want the fields
+  typed in one at a time, and hand-editing them out of a single text blob is miserable.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="12dp"
+    android:paddingBottom="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="96dp"
+            android:layout_height="wrap_content"
+            android:text="@string/local_proxy_field_host"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/valueHost"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
+            android:textSize="15sp" />
+
+        <ImageButton
+            android:id="@+id/copyHost"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/local_proxy_copy_url"
+            android:src="@drawable/ic_baseline_content_copy" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="96dp"
+            android:layout_height="wrap_content"
+            android:text="@string/local_proxy_field_port"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/valuePort"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
+            android:textSize="15sp" />
+
+        <ImageButton
+            android:id="@+id/copyPort"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/local_proxy_copy_url"
+            android:src="@drawable/ic_baseline_content_copy" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="96dp"
+            android:layout_height="wrap_content"
+            android:text="@string/local_proxy_field_username"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/valueUsername"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
+            android:textSize="15sp" />
+
+        <ImageButton
+            android:id="@+id/copyUsername"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/local_proxy_copy_url"
+            android:src="@drawable/ic_baseline_content_copy" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="96dp"
+            android:layout_height="wrap_content"
+            android:text="@string/local_proxy_field_password"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/valuePassword"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="monospace"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
+            android:textSize="15sp" />
+
+        <ImageButton
+            android:id="@+id/copyPassword"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/local_proxy_copy_password"
+            android:src="@drawable/ic_baseline_content_copy" />
+    </LinearLayout>
+</LinearLayout>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1192,4 +1192,23 @@
     <string name="age_key_generate">Сгенерировать</string>
     <string name="age_key_to_public">Из секретного</string>
     <string name="age_key_copy">Копировать</string>
+    <string name="local_proxy">Локальная прокси</string>
+    <string name="local_proxy_enable">Включить локальную прокси</string>
+    <string name="local_proxy_enable_summary">Поднять SOCKS/HTTP-слушатель на loopback под паролем. По умолчанию выключено: иначе другие приложения смогут обойти ваши правила маршрутизации.</string>
+    <string name="local_proxy_port">Порт локальной прокси</string>
+    <string name="local_proxy_credentials">Данные локальной прокси</string>
+    <string name="local_proxy_credentials_summary">Включите локальную прокси, чтобы получить адрес и данные для входа</string>
+    <string name="local_proxy_reveal_subtitle">Подтвердите, чтобы показать пароль</string>
+    <string name="local_proxy_not_ready">Данные создаются при следующем подключении VPN. Включите локальную прокси, подключитесь один раз и вернитесь сюда.</string>
+    <string name="local_proxy_copy_url">Копировать URL</string>
+    <string name="local_proxy_details_fmt">Хост: %1$s
+Порт: %2$d
+Логин: %3$s
+Пароль: %4$s</string>
+    <string name="local_proxy_copy_password">Копировать пароль</string>
+    <string name="local_proxy_field_host">Хост</string>
+    <string name="local_proxy_field_port">Порт</string>
+    <string name="local_proxy_field_username">Логин</string>
+    <string name="local_proxy_field_password">Пароль</string>
+    <string name="local_proxy_copied_fmt">%1$s скопирован</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -1120,4 +1120,23 @@
     <string name="age_key_generate">生成</string>
     <string name="age_key_to_public">由私钥导出</string>
     <string name="age_key_copy">复制</string>
+    <string name="local_proxy">本地代理</string>
+    <string name="local_proxy_enable">启用本地代理</string>
+    <string name="local_proxy_enable_summary">在回环地址上开启受密码保护的 SOCKS/HTTP 监听。默认关闭：否则其他应用可绕过你的分应用路由规则。</string>
+    <string name="local_proxy_port">本地代理端口</string>
+    <string name="local_proxy_credentials">本地代理凭据</string>
+    <string name="local_proxy_credentials_summary">启用本地代理后即可获取地址与凭据</string>
+    <string name="local_proxy_reveal_subtitle">验证后显示代理密码</string>
+    <string name="local_proxy_not_ready">凭据将在下次连接 VPN 时创建。请先启用本地代理，连接一次后再返回。</string>
+    <string name="local_proxy_copy_url">复制 URL</string>
+    <string name="local_proxy_details_fmt">主机：%1$s
+端口：%2$d
+用户名：%3$s
+密码：%4$s</string>
+    <string name="local_proxy_copy_password">复制密码</string>
+    <string name="local_proxy_field_host">主机</string>
+    <string name="local_proxy_field_port">端口</string>
+    <string name="local_proxy_field_username">用户名</string>
+    <string name="local_proxy_field_password">密码</string>
+    <string name="local_proxy_copied_fmt">已复制：%1$s</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -1199,4 +1199,23 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="age_key_generate">Generate</string>
     <string name="age_key_to_public">From secret</string>
     <string name="age_key_copy">Copy</string>
+    <string name="local_proxy">Local proxy</string>
+    <string name="local_proxy_enable">Enable local proxy</string>
+    <string name="local_proxy_enable_summary">Expose a password-protected SOCKS/HTTP listener on loopback. Off by default: other apps could otherwise bypass your per-app routing rules.</string>
+    <string name="local_proxy_port">Local proxy port</string>
+    <string name="local_proxy_credentials">Local proxy credentials</string>
+    <string name="local_proxy_credentials_summary">Enable the local proxy to get an address and credentials</string>
+    <string name="local_proxy_reveal_subtitle">Confirm to show the proxy password</string>
+    <string name="local_proxy_not_ready">Credentials are created the next time the VPN connects. Enable the local proxy, connect once, then come back.</string>
+    <string name="local_proxy_copy_url">Copy URL</string>
+    <string name="local_proxy_details_fmt">Host: %1$s
+Port: %2$d
+Username: %3$s
+Password: %4$s</string>
+    <string name="local_proxy_copy_password">Copy password</string>
+    <string name="local_proxy_field_host">Host</string>
+    <string name="local_proxy_field_port">Port</string>
+    <string name="local_proxy_field_username">Username</string>
+    <string name="local_proxy_field_password">Password</string>
+    <string name="local_proxy_copied_fmt">%1$s copied</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ appcompat = "1.7.0"
 coordinator = "1.2.0"
 recyclerview = "1.2.1"
 viewpager = "1.0.0"
+biometric = "1.1.0"
 material = "1.12.0"
 serialization = "1.7.1"
 kaidl = "1.15"
@@ -37,6 +38,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-coordinator = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "coordinator" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
 androidx-viewpager = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -6,6 +6,7 @@ import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.*
 import com.github.kr328.clash.service.data.Selection
 import com.github.kr328.clash.service.data.SelectionDao
+import com.github.kr328.clash.service.model.LocalProxyInfo
 import com.github.kr328.clash.service.model.RequestHistoryRepository
 import com.github.kr328.clash.service.model.RequestHistorySnapshot
 import com.github.kr328.clash.service.remote.IClashManager
@@ -54,6 +55,24 @@ class ClashManager(private val context: Context) : IClashManager,
 
     override fun queryConfiguration(): UiConfiguration {
         return Clash.queryConfiguration()
+    }
+
+    override fun queryLocalProxyInfo(): LocalProxyInfo {
+        if (!store.localProxyEnabled) {
+            return LocalProxyInfo(enabled = false)
+        }
+        // Credential is minted lazily by ConfigurationModule on the first load after the toggle,
+        // so it can still be blank if the user just enabled it and hasn't connected yet — report
+        // it as unavailable rather than showing half a credential.
+        val credential = store.localProxyCredential
+        return LocalProxyInfo(
+            enabled = true,
+            available = credential.isNotBlank() && StatusProvider.serviceRunning,
+            host = "127.0.0.1",
+            port = store.localProxyPort,
+            username = credential.substringBefore(':', ""),
+            password = credential.substringAfter(':', ""),
+        )
     }
 
     override fun queryProviders(): ProviderList {

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/ConfigurationModule.kt
@@ -13,6 +13,7 @@ import com.github.kr328.clash.service.util.ProfileOverlay
 import com.github.kr328.clash.service.util.ProxyDialerYamlEdit
 import com.github.kr328.clash.service.util.ProxyGroupsYamlEdit
 import com.github.kr328.clash.service.util.ProxyHardener
+import com.github.kr328.clash.service.util.RuntimeSocksAuth
 import com.github.kr328.clash.service.util.ensureBundledGeoAssets
 import com.github.kr328.clash.service.util.importedDir
 import com.github.kr328.clash.service.util.sendProfileLoaded
@@ -42,6 +43,23 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
 
     private val store = ServiceStore(service)
     private val reload = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Local-proxy opt-in for [ProxyHardener], or null when the user hasn't enabled it (the
+     * hardening default then disables the listener as before). The stable credential is minted on
+     * first enable and persisted, so a container pointed at `127.0.0.1:port` keeps working across
+     * reconnects instead of breaking on every rotation.
+     */
+    private fun localProxySettings(): ProxyHardener.LocalProxySettings? {
+        if (!store.localProxyEnabled) return null
+        val credential = store.localProxyCredential.takeIf { it.isNotBlank() }
+            ?: RuntimeSocksAuth.mintCredential().also { store.localProxyCredential = it }
+        return ProxyHardener.LocalProxySettings(
+            enabled = true,
+            port = store.localProxyPort,
+            credential = credential,
+        )
+    }
 
     override suspend fun run() {
         val broadcasts = receiveBroadcast {
@@ -106,6 +124,7 @@ class ConfigurationModule(service: Service) : Module<ConfigurationModule.LoadExc
                         configuration = sessionOverride,
                         mode = store.proxyHardeningMode,
                         seedGeoMirrors = store.seedDefaultGeoMirrors,
+                        localProxy = localProxySettings(),
                     )
                     if (hardened) {
                         Clash.patchOverride(Clash.OverrideSlot.Session, sessionOverride)

--- a/service/src/main/java/com/github/kr328/clash/service/model/LocalProxyInfo.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/model/LocalProxyInfo.kt
@@ -1,0 +1,49 @@
+package com.github.kr328.clash.service.model
+
+import android.os.Parcel
+import android.os.Parcelable
+import com.github.kr328.clash.core.util.Parcelizer
+import kotlinx.serialization.Serializable
+
+/**
+ * What the user needs to point another app (or a container) at ClashFest's local proxy.
+ *
+ * The listener only exists when the user explicitly opts in: on Android 10+ the default
+ * [com.github.kr328.clash.service.model.ProxyHardeningMode.Strict] forces every local port to `0`
+ * so other apps on the device cannot bypass the per-app routing rules by talking to `127.0.0.1`.
+ * [enabled] reflects that opt-in, and [available] whether a listener is actually up right now.
+ */
+@Serializable
+data class LocalProxyInfo(
+    /** User turned the local proxy on. */
+    val enabled: Boolean = false,
+    /**
+     * A listener is actually reachable — i.e. [enabled] and the tunnel is running. When false the
+     * UI shows the credentials but tells the user to connect / enable it first.
+     */
+    val available: Boolean = false,
+    val host: String = "127.0.0.1",
+    val port: Int = 0,
+    val username: String = "",
+    val password: String = "",
+) : Parcelable {
+    /** `user:pass@host:port` — handy for clients that take a single proxy URL. */
+    val socksUrl: String
+        get() = if (username.isEmpty()) "socks5://$host:$port" else "socks5://$username:$password@$host:$port"
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        Parcelizer.encodeToParcel(serializer(), parcel, this)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<LocalProxyInfo> {
+        override fun createFromParcel(parcel: Parcel): LocalProxyInfo {
+            return Parcelizer.decodeFromParcel(serializer(), parcel)
+        }
+
+        override fun newArray(size: Int): Array<LocalProxyInfo?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash.service.remote
 
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.*
+import com.github.kr328.clash.service.model.LocalProxyInfo
 import com.github.kr328.kaidl.BinderInterface
 
 @BinderInterface
@@ -13,6 +14,13 @@ interface IClashManager {
     fun queryAllProxyGroupNamesIncludingHidden(): List<String>
     fun queryProxyGroup(name: String, proxySort: ProxySort): ProxyGroup
     fun queryConfiguration(): UiConfiguration
+
+    /**
+     * Address + credentials of the opt-in local proxy listener, so Settings can show the user what
+     * to paste into a container or another app. Credentials live in the service process; this is
+     * the only way the UI process can read them.
+     */
+    fun queryLocalProxyInfo(): LocalProxyInfo
     fun queryProviders(): ProviderList
 
     fun queryConnectionsSnapshot(): String

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -71,6 +71,38 @@ class ServiceStore(context: Context) {
         defaultValue = false
     )
 
+    /**
+     * User opted into a reachable local SOCKS/HTTP listener on loopback (Settings -> Network ->
+     * Local proxy). Off by default: [proxyHardeningMode] Strict disables every local listener so
+     * other apps cannot bypass the per-app routing rules via `127.0.0.1`. Turning this on is an
+     * explicit trade — the listener comes back, gated by [localProxyCredential].
+     */
+    var localProxyEnabled by store.boolean(
+        key = "local_proxy_enabled",
+        defaultValue = false
+    )
+
+    /**
+     * Port ClashFest pins the local listener to when [localProxyEnabled]. Pinned by us rather than
+     * inherited from the subscription so the value shown in Settings is always the real one —
+     * users need a stable `127.0.0.1:port` to paste into a container or another app.
+     */
+    var localProxyPort by store.int(
+        key = "local_proxy_port",
+        defaultValue = 7890
+    )
+
+    /**
+     * Stable `user:pass` for the local listener, minted on first use and kept across reconnects.
+     * The session credential RuntimeSocksAuth rotates per service start is right for the hardening
+     * default, but useless for a container config that must survive a reconnect. Lives in the app's
+     * sandboxed prefs; the UI gates *displaying* it behind a device-credential prompt.
+     */
+    var localProxyCredential by store.string(
+        key = "local_proxy_credential",
+        defaultValue = ""
+    )
+
     var tunStackMode by store.string(
         key = "tun_stack_mode",
         // Default "system" (matches upstream CMFA). "auto" follows the subscription's tun.stack;

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyHardener.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyHardener.kt
@@ -28,10 +28,21 @@ object ProxyHardener {
      * Apply the requested [mode] to [configuration].
      * @return true if [configuration] was mutated.
      */
+    /**
+     * Apply the requested [mode] to [configuration].
+     *
+     * @param localProxy set when the user explicitly enabled the local proxy (Settings -> Network).
+     *        It overrides the listener-disabling half of [ProxyHardeningMode.Strict]: the listener
+     *        is pinned to the user's port and gated by a stable credential instead of being turned
+     *        off. Everything else (loopback bind, allow-lan off, controller clamping) still applies,
+     *        so the listener is reachable from this device only and still requires auth.
+     * @return true if [configuration] was mutated.
+     */
     fun applyTo(
         configuration: ConfigurationOverride,
         mode: ProxyHardeningMode,
         seedGeoMirrors: Boolean,
+        localProxy: LocalProxySettings? = null,
     ): Boolean {
         var changed = false
 
@@ -39,17 +50,66 @@ object ProxyHardener {
             changed = ensureGeoMirrors(configuration) || changed
         }
 
+        val local = localProxy?.takeIf { it.enabled && it.port in 1..65535 }
+
         when (mode) {
             ProxyHardeningMode.Off -> Unit
             ProxyHardeningMode.Compat -> {
-                changed = RuntimeSocksAuth.applyTo(configuration) || changed
+                changed = RuntimeSocksAuth.applyTo(configuration, local?.credential) || changed
             }
             ProxyHardeningMode.Strict -> {
-                changed = RuntimeSocksAuth.applyTo(configuration) || changed
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                changed = RuntimeSocksAuth.applyTo(configuration, local?.credential) || changed
+                if (local == null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     changed = disableLocalListeners(configuration) || changed
                 }
             }
+        }
+
+        if (local != null) {
+            changed = pinLocalListener(configuration, local.port) || changed
+        }
+
+        return changed
+    }
+
+    /** User-facing local-proxy opt-in, resolved from ServiceStore by the caller. */
+    data class LocalProxySettings(
+        val enabled: Boolean,
+        val port: Int,
+        /** Stable `user:pass`; blank falls back to the rotating session credential. */
+        val credential: String,
+    )
+
+    /**
+     * Pin the mixed listener to the port shown in Settings and silence the protocol-specific ones,
+     * so there is exactly one predictable `127.0.0.1:port` to hand out.
+     */
+    private fun pinLocalListener(configuration: ConfigurationOverride, port: Int): Boolean {
+        var changed = false
+
+        if (configuration.mixedPort != port) {
+            configuration.mixedPort = port
+            changed = true
+        }
+        if (configuration.httpPort != DISABLED_PORT) {
+            configuration.httpPort = DISABLED_PORT
+            changed = true
+        }
+        if (configuration.socksPort != DISABLED_PORT) {
+            configuration.socksPort = DISABLED_PORT
+            changed = true
+        }
+        if (configuration.redirectPort != DISABLED_PORT) {
+            configuration.redirectPort = DISABLED_PORT
+            changed = true
+        }
+        if (configuration.tproxyPort != DISABLED_PORT) {
+            configuration.tproxyPort = DISABLED_PORT
+            changed = true
+        }
+
+        if (changed) {
+            Log.i("ProxyHardener: local proxy pinned to 127.0.0.1:$port (mixed)")
         }
 
         return changed

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuntimeSocksAuth.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuntimeSocksAuth.kt
@@ -15,11 +15,20 @@ object RuntimeSocksAuth {
     @Volatile private var sessionCredential: String? = null
     @Volatile private var sessionControllerSecret: String? = null
 
+    /** Mints a fresh `user:pass`. Exposed so the store can seed a stable local-proxy credential. */
+    fun mintCredential(): String = newCredential()
+
     /**
-     * Apply a session-scoped runtime credential to [configuration].
+     * Apply a runtime credential to [configuration].
+     *
+     * @param stableCredential when non-blank, use this instead of the rotating per-process one.
+     *        The session credential is right for the hardening default (nothing outside the app is
+     *        supposed to dial the listener), but a user who deliberately enabled the local proxy
+     *        needs `user:pass` that survives a reconnect — otherwise every container config breaks
+     *        the moment the VPN restarts.
      * @return true if configuration was changed.
      */
-    fun applyTo(configuration: ConfigurationOverride): Boolean {
+    fun applyTo(configuration: ConfigurationOverride, stableCredential: String? = null): Boolean {
         var changed = false
 
         if (configuration.allowLan != false) {
@@ -45,7 +54,9 @@ object RuntimeSocksAuth {
             changed = true
         }
 
-        val credential = sessionCredential ?: newCredential().also { sessionCredential = it }
+        val credential = stableCredential?.takeIf { it.isNotBlank() }
+            ?: sessionCredential
+            ?: newCredential().also { sessionCredential = it }
         val current = configuration.authentication
 
         if (!(current?.size == 1 && current.firstOrNull() == credential)) {


### PR DESCRIPTION
## What

Adds an opt-in **Local proxy** section under Settings → Network, so users can actually
find, enable and use the local SOCKS listener.

## Why

Reported in #180 ("where do I set the proxy port?"). On Android 10+ the default **Strict**
hardening sets every local listener port to `0` — the port genuinely doesn't exist — and the
credential `RuntimeSocksAuth` generates was never shown anywhere. Users running ClashFest in a
container, or pointing another app at `127.0.0.1`, had no path forward.

## How

- **Toggle** (off by default). Enabling moves hardening `Strict → Compat`, disabling moves it
  back; an explicit `Off` is left untouched — the picker never says "Strict" while a listener
  is open.
- **Port pinned by us**, default `7890`, so the address in Settings is always the real one.
  `mixed-port` takes it; `http`/`socks`/`redirect`/`tproxy` stay off.
- **Stable credential**, minted on first enable and persisted — the rotating per-process one
  breaks container configs on every reconnect.
- **Credentials dialog** gated by `BiometricPrompt` (biometric *or* device credential; shown
  directly when nothing is enrolled, so users aren't locked out of their own proxy). Each field
  is its own selectable row with its own copy button, plus a `Copy URL` shortcut.

Security posture is unchanged for everyone who doesn't opt in: Strict stays the default and still
kills all local listeners. Even when enabled, the listener is loopback-only (`allow-lan=false`)
and always requires auth.

New dependency: `androidx.biometric:biometric:1.1.0`.

## Testing

Device: toggle on → hardening flips to Compat → connect → credentials dialog shows host/port/
username/password, per-field copy and Copy URL work; toggle off → back to Strict.


Closes #180