### PR TITLE
feat(subscription): try the other route when the preferred one fails

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/PropertiesActivity.kt
@@ -44,6 +44,12 @@ class PropertiesActivity : BaseActivity<PropertiesDesign>() {
         design.strictUserAgent = originalStrictUserAgent
         design.setOnStrictUserAgentChanged { strictUserAgent = it }
         design.subscriptionSourceLocked = ServiceStore(this).subscriptionShareLinksLockedFor(original.uuid)
+        // Persisted immediately rather than on save: it only affects the next download, and losing
+        // it because the user backed out of an unrelated edit would be surprising.
+        design.updateViaProxy = ServiceStore(this).subscriptionUpdateViaProxy(original.uuid)
+        design.setOnUpdateViaProxyChanged {
+            ServiceStore(this).setSubscriptionUpdateViaProxy(original.uuid, it)
+        }
 
         setContentDesign(design)
 

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -404,6 +404,7 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeFetchAndValid(JNIEnv *env, 
                                                                    jobject callback,
                                                                    jstring path,
                                                                    jstring url, jboolean force,
+                                                                   jboolean viaProxy,
                                                                    jstring headersJson) {
     TRACE_METHOD();
 
@@ -418,7 +419,7 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeFetchAndValid(JNIEnv *env, 
     }
     scoped_string _headers = _headers_raw;
 
-    fetchAndValid(_completable, _path, _url, force, _headers);
+    fetchAndValid(_completable, _path, _url, force, viaProxy, _headers);
 }
 
 JNIEXPORT void JNICALL

--- a/core/src/main/golang/native/config.go
+++ b/core/src/main/golang/native/config.go
@@ -25,7 +25,7 @@ func (r *remoteValidCallback) reportStatus(json string) {
 }
 
 //export fetchAndValid
-func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, headersJson C.c_string) {
+func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, viaProxy C.int, headersJson C.c_string) {
 	go func(path, url, headers string, callback unsafe.Pointer) {
 		subscriptionFetchSessionMu.Lock()
 		defer subscriptionFetchSessionMu.Unlock()
@@ -46,7 +46,7 @@ func fetchAndValid(callback unsafe.Pointer, path, url C.c_string, force C.int, h
 
 		cb := &remoteValidCallback{callback: callback}
 
-		err := config.FetchAndValid(path, url, force != 0, cb.reportStatus)
+		err := config.FetchAndValid(path, url, force != 0, viaProxy != 0, cb.reportStatus)
 
 		C.fetch_complete(callback, marshalString(err))
 

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,10 +17,13 @@ import (
 	"time"
 
 	"cfa/native/app"
+
+	"github.com/metacubex/mihomo/component/dialer"
 	"cfa/native/config/fetchheaders"
 
 	clashHttp "github.com/metacubex/mihomo/component/http"
 	"github.com/metacubex/mihomo/config"
+	"github.com/metacubex/mihomo/log"
 )
 
 type Status struct {
@@ -35,21 +39,150 @@ type providerFetchTask struct {
 	path string
 }
 
-func openUrl(ctx context.Context, url string, includeSubscriptionHeaders bool) (io.ReadCloser, map[string][]string, error) {
+// route describes how a download should reach the server.
+//
+// viaProxy sends the request through the tunnel with rule matching: HttpRequest dials via
+// inner.HandleTcp unless an explicit dialer is passed (see component/http/http.go:77-84), so
+// "through the tunnel" is the library default and a plain dialer is the only way out. That plain
+// dialer still runs through dialer.DefaultSocketHook, so the socket is protected — protecting a
+// socket bypasses the tun, it does not bypass rule matching.
+//
+// Note this used to be implicitly state-dependent: with no config running, rule matching lands on
+// DIRECT anyway, so a manual import while disconnected went out directly while the scheduled
+// auto-update — same code path, tunnel up — went through the selected node. Issue #178 is that
+// second case, on a panel that only answers off-tunnel.
+type route struct {
+	// viaProxy is the *preferred* route, not the only one — see fallback.
+	viaProxy bool
+	// fallback retries once on the other route when the failure looks like the route was the
+	// problem (see shouldTryOtherRoute). Both directions are useful: a panel that whitelists the
+	// home IP answers only off-tunnel, while a panel whose domain is DPI-blocked answers only
+	// through it. Set for the subscription only — providers are best-effort and fetched six at a
+	// time, so doubling their requests buys nothing.
+	fallback bool
+}
+
+func (r route) other() route {
+	return route{viaProxy: !r.viaProxy, fallback: false}
+}
+
+func (r route) name() string {
+	if r.viaProxy {
+		return "proxy"
+	}
+	return "direct"
+}
+
+// httpStatusError is a non-2xx response. It has to be an error: HttpRequest only fails on transport
+// problems, so without this check a 403 error page is written to disk as config.yaml and only
+// surfaces much later as a confusing YAML parse failure.
+type httpStatusError struct {
+	code   int
+	status string
+}
+
+func (e httpStatusError) Error() string {
+	return fmt.Sprintf("server returned HTTP %s", e.status)
+}
+
+func openUrl(ctx context.Context, url string, includeSubscriptionHeaders bool, viaProxy bool) (io.ReadCloser, map[string][]string, error) {
 	base := http.Header{"User-Agent": {"ClashMetaForAndroid/" + app.VersionName()}}
 	hdr := base
 	if includeSubscriptionHeaders {
 		hdr = app.MergeSubscriptionFetchHeaders(base)
 	}
-	response, err := clashHttp.HttpRequest(ctx, url, http.MethodGet, hdr, nil)
+	var options []clashHttp.Option
+	if !viaProxy {
+		options = append(options, clashHttp.WithDialer(dialer.NewDialer()))
+	}
+	response, err := clashHttp.HttpRequest(ctx, url, http.MethodGet, hdr, nil, options...)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, nil, httpStatusError{code: response.StatusCode, status: response.Status}
+	}
+
 	// Plain map type: mihomo's forked metacubex/http.Header and net/http.Header
 	// are distinct named types over the same underlying map.
 	return response.Body, response.Header, nil
+}
+
+// routeFirstAttemptTimeout caps the preferred route when a fallback is available, so a route that
+// hangs until the caller's overall budget expires can't starve the second attempt. Without it a
+// dead node burns all 60s of subscriptionFetchTimeout and the user watches "Updating…" twice as
+// long for a result the fallback could have produced in seconds.
+const routeFirstAttemptTimeout = 25 * time.Second
+
+// shouldTryOtherRoute reports whether err suggests the *route* was the problem, rather than the
+// subscription itself. Being wrong here is not free: an unnecessary direct retry leaks the panel's
+// hostname (DNS query + TLS SNI) to the local network, which is exactly what routing through the
+// tunnel avoids. So the HTTP side is an allowlist, not a denylist.
+func shouldTryOtherRoute(err error) bool {
+	var status httpStatusError
+	if errors.As(err, &status) {
+		// We reached the panel and it refused *this request*: 403 is what an IP-whitelisting or
+		// geo-blocking panel answers to an unexpected exit IP, 451 its policy-blocked cousin.
+		// Everything else is about the subscription, not the path to it — 401 is a bad token,
+		// 404 a dead link, 5xx a broken panel — and retrying elsewhere only leaks the hostname.
+		return status.code == http.StatusForbidden || status.code == http.StatusUnavailableForLegalReasons
+	}
+	// Transport-level: refused, reset, DNS failure, TLS error, deadline exceeded. All route-shaped.
+	return true
+}
+
+// openRoutedUrl opens url on r's preferred route, falling back once to the other one.
+//
+// The fallback covers the two dead ends of a single fixed route: with the tunnel preferred, a
+// subscription that can only be fetched off-tunnel is unreachable — and worse, a profile whose
+// nodes are all dead can't be refreshed, because the refresh goes through the dead nodes. With
+// direct preferred, a DPI-blocked panel is unreachable. Only the *open* is retried; a body that
+// dies mid-transfer is left to the caller's normal error path.
+func openRoutedUrl(ctx context.Context, url string, includeSubscriptionHeaders bool, r route) (io.ReadCloser, map[string][]string, error) {
+	if !r.fallback {
+		return openUrl(ctx, url, includeSubscriptionHeaders, r.viaProxy)
+	}
+
+	first, cancelFirst := context.WithTimeout(ctx, routeFirstAttemptTimeout)
+	reader, header, err := openUrl(first, url, includeSubscriptionHeaders, r.viaProxy)
+	if err == nil {
+		// The body is read later, by fetch — cancelling now would truncate it. Hand the cancel
+		// to Close instead, which fetch defers.
+		return cancelingReadCloser{ReadCloser: reader, cancel: cancelFirst}, header, nil
+	}
+	cancelFirst()
+
+	if !shouldTryOtherRoute(err) {
+		return nil, nil, err
+	}
+
+	alt := r.other()
+	// Logged rather than silent: falling back to direct means the hostname just went out over the
+	// local network, and a user who cares needs to be able to see that it happened.
+	log.Warnln("Subscription fetch via %s failed (%s), retrying %s", r.name(), err.Error(), alt.name())
+
+	reader, header, altErr := openUrl(ctx, url, includeSubscriptionHeaders, alt.viaProxy)
+	if altErr != nil {
+		return nil, nil, fmt.Errorf("%s: %w (%s: %v)", r.name(), err, alt.name(), altErr)
+	}
+
+	log.Infoln("Subscription fetch succeeded via %s", alt.name())
+
+	return reader, header, nil
+}
+
+// cancelingReadCloser releases a request-scoped context once the body is closed.
+type cancelingReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c cancelingReadCloser) Close() error {
+	defer c.cancel()
+	return c.ReadCloser.Close()
 }
 
 func openContent(url string) (io.ReadCloser, error) {
@@ -76,7 +209,7 @@ const (
 // and on error) — the subscription fetch persists them via [writeFetchHeaders]
 // so the Kotlin side can read subscription-userinfo / X-Brand-* / naming
 // headers without issuing a second GET of its own.
-func fetch(url *U.URL, file string, timeout time.Duration, includeSubscriptionHeaders bool) (map[string][]string, error) {
+func fetch(url *U.URL, file string, timeout time.Duration, includeSubscriptionHeaders bool, r route) (map[string][]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -86,7 +219,7 @@ func fetch(url *U.URL, file string, timeout time.Duration, includeSubscriptionHe
 
 	switch url.Scheme {
 	case "http", "https":
-		reader, header, err = openUrl(ctx, url.String(), includeSubscriptionHeaders)
+		reader, header, err = openRoutedUrl(ctx, url.String(), includeSubscriptionHeaders, r)
 	case "content":
 		reader, err = openContent(url.String())
 	default:
@@ -152,6 +285,11 @@ func FetchAndValid(
 	path string,
 	url string,
 	force bool,
+	// viaProxy is the user's preferred route (Profile -> Update via proxy, on by default): through
+	// the tunnel with rule matching, or a direct dial for subscriptions that are only reachable
+	// off-tunnel (issue #178). Either way the other route is tried once if the first fails in a
+	// route-shaped way — see [route].
+	viaProxy bool,
 	reportStatus func(string),
 ) error {
 	configPath := P.Join(path, "config.yaml")
@@ -187,7 +325,7 @@ func FetchAndValid(
 
 		reportStatus(string(bytes))
 
-		header, err := fetch(parsed, configPath, subscriptionFetchTimeout, true)
+		header, err := fetch(parsed, configPath, subscriptionFetchTimeout, true, route{viaProxy: viaProxy, fallback: true})
 		if err != nil {
 			return err
 		}
@@ -364,7 +502,7 @@ func fetchProviders(rawCfg *config.RawConfig, force bool, reportStatus func(stri
 			// fetch persists them, see writeFetchHeaders).
 			// Device-identifying subscription headers are scoped to the subscription
 			// origin. Providers may be controlled by unrelated third parties.
-			_, _ = fetch(t.url, t.path, providerFetchTimeout, false)
+			_, _ = fetch(t.url, t.path, providerFetchTimeout, false, route{})
 
 			current := atomic.AddInt32(&done, 1)
 			bytes, _ := json.Marshal(&Status{

--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -79,6 +79,10 @@ func (r route) name() string {
 type httpStatusError struct {
 	code   int
 	status string
+	// header of the refusal. A panel that rejects an expired plan or a device over its HWID limit
+	// says so in the headers of the very response it refuses with, so these are what turn a bare
+	// "HTTP 403" into an actionable reason — see the failure path in FetchAndValid.
+	header map[string][]string
 }
 
 func (e httpStatusError) Error() string {
@@ -103,7 +107,11 @@ func openUrl(ctx context.Context, url string, includeSubscriptionHeaders bool, v
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_ = response.Body.Close()
-		return nil, nil, httpStatusError{code: response.StatusCode, status: response.Status}
+		return nil, nil, httpStatusError{
+			code:   response.StatusCode,
+			status: response.Status,
+			header: response.Header,
+		}
 	}
 
 	// Plain map type: mihomo's forked metacubex/http.Header and net/http.Header
@@ -327,6 +335,22 @@ func FetchAndValid(
 
 		header, err := fetch(parsed, configPath, subscriptionFetchTimeout, true, route{viaProxy: viaProxy, fallback: true})
 		if err != nil {
+			// Keep the refusal's headers: a panel answers "expired plan" / "device limit reached"
+			// in the headers of the response it refuses with, and without them the Kotlin side can
+			// only report the status code. Safe to write here — [path] is the staging directory,
+			// discarded on failure, so this never clobbers the live profile's snapshot.
+			//
+			// Unconditional, because the staging directory is seeded with a COPY of the existing
+			// profile: a stale snapshot from the last successful download is already sitting there,
+			// and leaving it would let the classifier explain today's failure with last week's
+			// headers. Writing nil removes it, so a snapshot present after a failed fetch always
+			// belongs to that fetch.
+			var status httpStatusError
+			if errors.As(err, &status) {
+				writeFetchHeaders(path, status.header)
+			} else {
+				writeFetchHeaders(path, nil)
+			}
 			return err
 		}
 

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -193,10 +193,15 @@ object Clash {
         return Bridge.nativePatchSelector(selector, name)
     }
 
+    /**
+     * @param viaProxy route the download through the tunnel with rule matching (the engine default).
+     *        False forces a direct dial, for subscriptions that are only reachable off-tunnel.
+     */
     fun fetchAndValid(
         path: File,
         url: String,
         force: Boolean,
+        viaProxy: Boolean = true,
         subscriptionHeadersJson: String = SubscriptionDeviceHeaders.toJson(Global.application),
         reportStatus: (FetchStatus) -> Unit,
     ): CompletableDeferred<Unit> {
@@ -222,6 +227,7 @@ object Clash {
                 path.absolutePath,
                 url,
                 force,
+                viaProxy,
                 subscriptionHeadersJson,
             )
         }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -36,6 +36,7 @@ object Bridge {
         path: String,
         url: String,
         force: Boolean,
+        viaProxy: Boolean,
         subscriptionHeadersJson: String,
     )
 

--- a/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/PropertiesDesign.kt
@@ -46,6 +46,8 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
     private var userAgentChangeListener: ((String) -> Unit)? = null
     private var strictUserAgentValue: Boolean = false
     private var strictUserAgentChangeListener: ((Boolean) -> Unit)? = null
+    private var updateViaProxyValue: Boolean = true
+    private var updateViaProxyChangeListener: ((Boolean) -> Unit)? = null
     private var userAgentPreset: UserAgentPreset = UserAgentPreset.Default
 
     /** Operator policy: disallow editing subscription URL (still allows name/interval). */
@@ -109,6 +111,23 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
 
     fun setOnStrictUserAgentChanged(listener: (Boolean) -> Unit) {
         strictUserAgentChangeListener = listener
+    }
+
+    /**
+     * Route this subscription's download through the tunnel (the engine default). Off forces a
+     * direct dial for subscriptions that are only reachable off-tunnel.
+     */
+    var updateViaProxy: Boolean
+        get() = updateViaProxyValue
+        set(value) {
+            updateViaProxyValue = value
+            if (binding.switchUpdateViaProxy.isChecked != value) {
+                binding.switchUpdateViaProxy.isChecked = value
+            }
+        }
+
+    fun setOnUpdateViaProxyChanged(listener: (Boolean) -> Unit) {
+        updateViaProxyChangeListener = listener
     }
 
     suspend fun withProcessing(executeTask: suspend (suspend (FetchStatus) -> Unit) -> Unit) {
@@ -236,6 +255,11 @@ class PropertiesDesign(context: Context) : Design<PropertiesDesign.Request>(cont
             if (strictUserAgentValue == checked) return@setOnCheckedChangeListener
             strictUserAgentValue = checked
             strictUserAgentChangeListener?.invoke(checked)
+        }
+        binding.switchUpdateViaProxy.setOnCheckedChangeListener { _, checked ->
+            if (updateViaProxyValue == checked) return@setOnCheckedChangeListener
+            updateViaProxyValue = checked
+            updateViaProxyChangeListener?.invoke(checked)
         }
         applyUserAgentVisibility()
     }

--- a/design/src/main/res/layout/design_properties.xml
+++ b/design/src/main/res/layout/design_properties.xml
@@ -213,6 +213,43 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content" />
                         </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginHorizontal="16dp"
+                            android:layout_marginTop="2dp"
+                            android:layout_marginBottom="8dp"
+                            android:gravity="center_vertical"
+                            android:orientation="horizontal">
+
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/subscription_update_via_proxy"
+                                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                                    android:textColor="?attr/colorOnSurface" />
+
+                                <TextView
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="2dp"
+                                    android:text="@string/subscription_update_via_proxy_summary"
+                                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                                    android:textColor="?attr/colorOnSurfaceVariant" />
+                            </LinearLayout>
+
+                            <com.google.android.material.materialswitch.MaterialSwitch
+                                android:id="@+id/switch_update_via_proxy"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+                        </LinearLayout>
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1211,4 +1211,6 @@
     <string name="local_proxy_field_username">Логин</string>
     <string name="local_proxy_field_password">Пароль</string>
     <string name="local_proxy_copied_fmt">%1$s скопирован</string>
+    <string name="subscription_update_via_proxy">Обновлять через прокси</string>
+    <string name="subscription_update_via_proxy_summary">Предпочитаемый маршрут для загрузки этой подписки: через туннель, по вашим правилам. Выключите, чтобы сначала пробовать прямое подключение. В любом случае, если первый маршрут не сработает, второй будет использован автоматически. Применится со следующего обновления.</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -1139,4 +1139,6 @@
     <string name="local_proxy_field_username">用户名</string>
     <string name="local_proxy_field_password">密码</string>
     <string name="local_proxy_copied_fmt">已复制：%1$s</string>
+    <string name="subscription_update_via_proxy">通过代理更新</string>
+    <string name="subscription_update_via_proxy_summary">下载此订阅时优先使用的路径：通过隧道并按你的规则。关闭则优先尝试直连。无论哪种方式，若首选路径失败都会自动尝试另一条。下次更新时生效。</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -1218,4 +1218,6 @@ Password: %4$s</string>
     <string name="local_proxy_field_username">Username</string>
     <string name="local_proxy_field_password">Password</string>
     <string name="local_proxy_copied_fmt">%1$s copied</string>
+    <string name="subscription_update_via_proxy">Update via proxy</string>
+    <string name="subscription_update_via_proxy_summary">Preferred route for downloading this subscription: through the tunnel, following your rules. Turn off to try a direct connection first. Either way the other route is tried automatically if the first one fails. Applies to the next update.</string>
 </resources>

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -286,8 +286,28 @@ available in the `fetchProviders` closure, so this is cheaply fixable.
 | `E-10` | Body downloaded but blank | "server returned an empty response — try again later" |
 | `E-11` | Body is an HTML error/rate-limit page | "server returned a web page, not a config" |
 | `E-20` | Nothing downloaded + network-reach failure (DNS/TLS/connect timeout, host blocked) | "couldn't reach the subscription server — check your connection / host may be blocked" |
+| `E-40` | `x-hwid-limit` / `x-hwid-max-devices-reached` on a failed update | "this device was refused because the subscription has reached its device limit" (+ `support-url` when present) |
+| `E-41` | `subscription-userinfo` carries an `expire=` already in the past, on a failed update | "your subscription expired on YYYY-MM-DD — renew it, then update again" |
 | `E-21` | Server answered with a non-2xx status (wording varies by code: 401/402 account, 403/451 refused on both routes, 404/410 dead link, 5xx panel trouble) | "the subscription server rejected your account (HTTP 401) — re-import from your dashboard" |
 | `E-30` | Body is an age armor the engine couldn't decrypt (missing/wrong key) | "subscription is age-encrypted — import the full link from your dashboard, or set the profile's age secret key" |
+
+`E-40`/`E-41` come from the response headers the Go fetch snapshots into the staging
+directory. They are checked **before** everything else, including before a Layer 3 engine
+error is passed through: an expired panel typically serves a *valid* YAML with its proxies
+stripped out, so the engine reports `proxy 'X' not found` and the user goes hunting for a
+config problem they cannot fix. Measured on a real expired subscription — the panel sent
+`expire=` one day in the past while the app blamed a missing node. The engine's precise
+message stays attached as the exception's `cause`.
+
+Both are **explanatory only**. A panel that serves a working config while flagging the
+account is not refusing anything, and manufacturing an error out of that flag would break a
+live profile over a stale header — so neither code can turn a successful update into a
+failure. (The reference header table other clients implement does make `x-hwid-limit: true`
+fail an import outright; that is a deliberate divergence.)
+
+The staging snapshot is rewritten — or removed — on the failure path too, because staging is
+seeded with a copy of the existing profile: a leftover snapshot from the last successful
+download would otherwise explain today's failure with last week's headers.
 
 `E-52` (provider-init timeout at activation) is **not** implemented: with B deferred,
 those failures stay non-fatal log lines (`initial rule provider … error`), not surfaced

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -286,6 +286,7 @@ available in the `fetchProviders` closure, so this is cheaply fixable.
 | `E-10` | Body downloaded but blank | "server returned an empty response — try again later" |
 | `E-11` | Body is an HTML error/rate-limit page | "server returned a web page, not a config" |
 | `E-20` | Nothing downloaded + network-reach failure (DNS/TLS/connect timeout, host blocked) | "couldn't reach the subscription server — check your connection / host may be blocked" |
+| `E-21` | Server answered with a non-2xx status (wording varies by code: 401/402 account, 403/451 refused on both routes, 404/410 dead link, 5xx panel trouble) | "the subscription server rejected your account (HTTP 401) — re-import from your dashboard" |
 | `E-30` | Body is an age armor the engine couldn't decrypt (missing/wrong key) | "subscription is age-encrypted — import the full link from your dashboard, or set the profile's age secret key" |
 
 `E-52` (provider-init timeout at activation) is **not** implemented: with B deferred,

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -78,6 +78,7 @@ object ProfileProcessor {
                         context.processingDir,
                         snapshot.source,
                         force,
+                        ServiceStore(context).subscriptionUpdateViaProxy(snapshot.uuid),
                         SubscriptionRequestHeaders.toNativeFetchJson(context, userAgentOverride),
                     ) {
                         try {
@@ -98,6 +99,7 @@ object ProfileProcessor {
                         context.processingDir,
                         snapshot.source,
                         force,
+                        ServiceStore(context).subscriptionUpdateViaProxy(snapshot.uuid),
                         SubscriptionRequestHeaders.toNativeFetchJson(context, null),
                     ) {
                         try {
@@ -266,6 +268,7 @@ object ProfileProcessor {
                         context.processingDir,
                         snapshot.source,
                         true,
+                        ServiceStore(context).subscriptionUpdateViaProxy(snapshot.uuid),
                         SubscriptionRequestHeaders.toNativeFetchJson(context, userAgentOverride),
                     ) {
                         try {
@@ -286,6 +289,7 @@ object ProfileProcessor {
                         context.processingDir,
                         snapshot.source,
                         true,
+                        ServiceStore(context).subscriptionUpdateViaProxy(snapshot.uuid),
                         SubscriptionRequestHeaders.toNativeFetchJson(context, null),
                     ) {
                         try {

--- a/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/store/ServiceStore.kt
@@ -244,6 +244,18 @@ class ServiceStore(context: Context) {
     }
 
     /**
+     * Per-profile: route this subscription's download through the tunnel (rule matching), which is
+     * the engine default. Some subscriptions are only reachable off-tunnel, so the user can turn it
+     * off to force a direct dial (issue #178). Stored per subscription, like the share-links policy.
+     */
+    fun subscriptionUpdateViaProxy(uuid: UUID): Boolean =
+        rawPrefs.getBoolean("subscription_update_via_proxy_$uuid", true)
+
+    fun setSubscriptionUpdateViaProxy(uuid: UUID, value: Boolean) {
+        rawPrefs.edit().putBoolean("subscription_update_via_proxy_$uuid", value).apply()
+    }
+
+    /**
      * Per-profile DNS & Hosts master-toggle state. When true the profile's
      * `dns:`/`hosts:` are user-owned: editable in the DNS & Hosts screen and
      * preserved across subscription refreshes. Cleared by the master-toggle

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
@@ -1,9 +1,13 @@
 package com.github.kr328.clash.service.util
 
+import com.github.kr328.clash.common.util.SubscriptionMetadataFetcher
+import com.github.kr328.clash.common.util.SubscriptionUsage
 import java.io.EOFException
 import java.io.File
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.time.Instant
+import java.time.ZoneId
 
 /**
  * Turns a cryptic fetch/parse failure into a clear, stable-coded reason. It handles
@@ -19,16 +23,36 @@ import java.net.UnknownHostException
  *  - **Refused by the server** (`E-21`): the server answered, with a non-2xx status. The
  *    engine rejects those bodies rather than saving an error page as config.yaml, so
  *    nothing lands on disk and the raw error is a bare `server returned HTTP 403 ...`.
+ *  - **Account state** (`E-40`/`E-41`): the panel says in its response headers that this
+ *    device is over the subscription's HWID limit, or that the plan has expired. Either
+ *    otherwise surfaces as one of the classes above — or, worse, as a Layer 3 error, because
+ *    an expired panel commonly serves a *valid* YAML with its proxies stripped out and the
+ *    engine reports `proxy 'X' not found`. Measured on a real expired subscription: the
+ *    panel sent `expire=` one day in the past and the user was told a node was missing.
  *
- * A genuine config error (valid YAML, invalid values) is left **untouched** so its
- * precise engine message (e.g. `proxy 'X' not found`) survives — see docs/errors.md
- * Layer 3. Codes are stable so support/wiki can key troubleshooting to them.
+ * A genuine config error (valid YAML, invalid values) is left **untouched** so its precise
+ * engine message survives — see docs/errors.md Layer 3 — *unless* the panel's own headers
+ * say the account is the reason. That ordering is deliberate: when a subscription has
+ * expired, that is the answer the user needs, and the engine's message stays available as
+ * the exception's cause. Codes are stable so support/wiki can key troubleshooting to them.
  */
 object FetchErrorClassifier {
     internal const val MAX_CLASSIFICATION_BYTES = 64 * 1024
     private data class BodySample(val text: String, val complete: Boolean)
 
-    fun clarify(processingDir: File, original: Throwable): Throwable {
+    fun clarify(
+        processingDir: File,
+        original: Throwable,
+        nowSeconds: Long = System.currentTimeMillis() / 1000,
+    ): Throwable {
+        // Headers first, whatever the body turned out to be: a panel refusing an expired plan or a
+        // device over its HWID limit may deliver that as a 403, as an HTML page, as an empty 200,
+        // or as a stripped-down config that only fails later in the engine. The header is the
+        // reliable signal across all four; the shape of the body is not.
+        FetchHeadersFile.readFrom(processingDir)?.let { headers ->
+            rejectionReason(headers, nowSeconds)?.let { return IllegalStateException(it, original) }
+        }
+
         val file = File(processingDir, "config.yaml")
         // No body downloaded → network reachability failure (or an unrelated error we
         // shouldn't mask). Classify only the recognizable network case.
@@ -116,6 +140,47 @@ object FetchErrorClassifier {
         }
         return false
     }
+
+    /**
+     * Turns the panel's own account-state headers into the reason the update failed, or null when
+     * they say nothing about it. This is the difference between "node 'X' not found" — which sends
+     * the user hunting for a config problem they can't fix — and "your plan expired on the 17th".
+     *
+     * Only ever consulted on a failure. The same headers on a subscription that installed fine are
+     * the usage panel's business: a panel that served a working config while flagging the account
+     * is not refusing anything, and manufacturing an error from that would break a live profile
+     * over a stale flag.
+     */
+    internal fun rejectionReason(headers: FetchHeadersFile, nowSeconds: Long): String? {
+        val meta = SubscriptionMetadataFetcher.parseHeaders { headers.get(it) }
+
+        if (meta.hwidLimit == true || meta.hwidMaxDevicesReached == true) {
+            return buildString {
+                append(
+                    "this device was refused because the subscription has reached its device " +
+                        "limit — sign out on another device, or ask your provider to raise it",
+                )
+                meta.supportUrl?.takeIf { it.isNotBlank() }?.let { append(" ($it)") }
+                append(". [E-40]")
+            }
+        }
+
+        // expire=0 means "never expires", and the parser already drops it — a subscription without
+        // an expiry must never be reported as expired.
+        val expireAt = SubscriptionUsage.parse(meta.subscriptionUserinfo)?.expireAt
+        if (expireAt != null && expireAt <= nowSeconds) {
+            return buildString {
+                append("your subscription expired on ${formatDate(expireAt)} — renew it")
+                meta.supportUrl?.takeIf { it.isNotBlank() }?.let { append(" at $it") }
+                append(", then update the profile again. [E-41]")
+            }
+        }
+
+        return null
+    }
+
+    private fun formatDate(epochSeconds: Long): String =
+        Instant.ofEpochSecond(epochSeconds).atZone(ZoneId.systemDefault()).toLocalDate().toString()
 
     /**
      * Pulls the status code out of the engine's non-2xx error. The message is built by

--- a/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/FetchErrorClassifier.kt
@@ -16,6 +16,9 @@ import java.net.UnknownHostException
  *  - **Network unreachable** (`E-20`): nothing was downloaded at all — DNS/TLS/connect
  *    timed out or the host is blocked — so the raw error is a stack-y
  *    `java.net.SocketTimeouteException: failed to connect to ...`.
+ *  - **Refused by the server** (`E-21`): the server answered, with a non-2xx status. The
+ *    engine rejects those bodies rather than saving an error page as config.yaml, so
+ *    nothing lands on disk and the raw error is a bare `server returned HTTP 403 ...`.
  *
  * A genuine config error (valid YAML, invalid values) is left **untouched** so its
  * precise engine message (e.g. `proxy 'X' not found`) survives — see docs/errors.md
@@ -30,6 +33,10 @@ object FetchErrorClassifier {
         // No body downloaded → network reachability failure (or an unrelated error we
         // shouldn't mask). Classify only the recognizable network case.
         if (!file.isFile) {
+            val status = httpStatusOf(original)
+            if (status != null) {
+                return IllegalStateException(httpStatusReason(status), original)
+            }
             if (looksLikeNetworkFailure(original)) {
                 return IllegalStateException(
                     "couldn't reach the subscription server — check your connection or " +
@@ -109,6 +116,47 @@ object FetchErrorClassifier {
         }
         return false
     }
+
+    /**
+     * Pulls the status code out of the engine's non-2xx error. The message is built by
+     * `httpStatusError` in `native/config/fetch.go`, and may be wrapped once by the
+     * route-fallback error, which reports both attempts: `proxy: server returned HTTP 403
+     * Forbidden (direct: ...)`. The first code wins — it is the preferred route's answer.
+     */
+    internal fun httpStatusOf(e: Throwable): Int? {
+        var cur: Throwable? = e
+        while (cur != null) {
+            val match = HTTP_STATUS.find(cur.message.orEmpty())
+            if (match != null) return match.groupValues[1].toIntOrNull()
+            cur = cur.cause
+        }
+        return null
+    }
+
+    /**
+     * 401/403 are worth splitting: both mean "refused", but the fix differs. A 401 is the
+     * subscription token, while a 403 survived the engine's automatic retry on the other route
+     * (see `route` in fetch.go) — so it is refusing this account or this exit IP, not this path.
+     */
+    internal fun httpStatusReason(status: Int): String = when (status) {
+        401, 402 ->
+            "the subscription server rejected your account (HTTP $status) — the link may have " +
+                "expired or been revoked; re-import it from your dashboard. [E-21]"
+        403, 451 ->
+            "the subscription server refused the request (HTTP $status), and the automatic retry " +
+                "on the other route didn't help — your plan may be expired, or the panel may be " +
+                "blocking this network. [E-21]"
+        404, 410 ->
+            "the subscription link no longer exists on the server (HTTP $status) — re-import it " +
+                "from your dashboard. [E-21]"
+        in 500..599 ->
+            "the subscription server is having problems (HTTP $status) — try again later. [E-21]"
+        else ->
+            "the subscription server returned HTTP $status instead of a config — try again " +
+                "later. [E-21]"
+    }
+
+    private val HTTP_STATUS = Regex("""server returned HTTP (\d{3})""")
 
     /**
      * The body downloaded fine but is an age armor the engine couldn't decrypt

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
@@ -96,6 +96,36 @@ class FetchErrorClassifierTest {
         assertEquals(false, FetchErrorClassifier.looksLikeNetworkFailure(RuntimeException("proxy 'X' not found")))
     }
 
+    @Test fun http_status_without_body_is_explained_per_code() {
+        // The engine no longer saves a non-2xx body as config.yaml, so nothing is on disk.
+        assertTrue(
+            FetchErrorClassifier.clarify(dirWith(null), RuntimeException("server returned HTTP 401 Unauthorized"))
+                .message!!.contains("rejected your account"),
+        )
+        assertTrue(
+            FetchErrorClassifier.clarify(dirWith(null), RuntimeException("server returned HTTP 404 Not Found"))
+                .message!!.contains("no longer exists"),
+        )
+        assertTrue(
+            FetchErrorClassifier.clarify(dirWith(null), RuntimeException("server returned HTTP 503 Service Unavailable"))
+                .message!!.contains("having problems"),
+        )
+    }
+
+    @Test fun status_survives_the_route_fallback_wrapper() {
+        // Both attempts are reported; the preferred route's code is the one that matters.
+        val wrapped = RuntimeException("proxy: server returned HTTP 403 Forbidden (direct: context deadline exceeded)")
+        val out = FetchErrorClassifier.clarify(dirWith(null), wrapped)
+        assertTrue(out.message!!.contains("refused the request (HTTP 403)"), out.message)
+        assertTrue(out.message!!.contains("[E-21]"), out.message)
+    }
+
+    @Test fun status_beats_network_wording_when_both_look_plausible() {
+        // "context deadline exceeded" trips looksLikeNetworkFailure; the status is the better answer.
+        val wrapped = RuntimeException("proxy: server returned HTTP 403 Forbidden (direct: timeout)")
+        assertTrue(FetchErrorClassifier.clarify(dirWith(null), wrapped).message!!.contains("[E-21]"))
+    }
+
     @Test fun html_detection() {
         assertEquals(true, FetchErrorClassifier.looksLikeHtml("<html><head><title>x</title>"))
         assertEquals(true, FetchErrorClassifier.looksLikeHtml("  <!doctype html>"))

--- a/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/util/FetchErrorClassifierTest.kt
@@ -16,7 +16,18 @@ class FetchErrorClassifierTest {
         return dir
     }
 
+    private fun dirWith(config: String?, headers: Map<String, String>): File {
+        val dir = dirWith(config)
+        val json = headers.entries.joinToString(",", "{", "}") { (k, v) ->
+            "\"${k.lowercase()}\":\"$v\""
+        }
+        File(dir, FetchHeadersFile.FILE_NAME).writeText(json)
+        return dir
+    }
+
     private val original = RuntimeException("yaml: line 7: could not find expected ':'")
+    private val forbidden = RuntimeException("server returned HTTP 403 Forbidden")
+    private val now = 1_800_000_000L
 
     @Test fun html_body_becomes_friendly() {
         val out = FetchErrorClassifier.clarify(dirWith("<!DOCTYPE html><html><body>429</body></html>"), original)
@@ -124,6 +135,90 @@ class FetchErrorClassifierTest {
         // "context deadline exceeded" trips looksLikeNetworkFailure; the status is the better answer.
         val wrapped = RuntimeException("proxy: server returned HTTP 403 Forbidden (direct: timeout)")
         assertTrue(FetchErrorClassifier.clarify(dirWith(null), wrapped).message!!.contains("[E-21]"))
+    }
+
+    @Test fun hwid_limit_header_beats_the_generic_reason() {
+        val out = FetchErrorClassifier.clarify(
+            dirWith(null, mapOf("x-hwid-limit" to "true", "support-url" to "https://panel.example/support")),
+            forbidden,
+            now,
+        )
+        assertTrue(out.message!!.contains("device limit"), out.message)
+        assertTrue(out.message!!.contains("https://panel.example/support"), out.message)
+        assertTrue(out.message!!.contains("[E-40]"), out.message)
+        assertSame(forbidden, out.cause)
+    }
+
+    @Test fun hwid_limit_is_reported_even_when_the_panel_answers_200_with_a_page() {
+        // Some panels refuse with an ordinary page rather than a status — the header still decides.
+        val out = FetchErrorClassifier.clarify(
+            dirWith("<!DOCTYPE html><html><body>limit</body></html>", mapOf("x-hwid-max-devices-reached" to "true")),
+            original,
+            now,
+        )
+        assertTrue(out.message!!.contains("[E-40]"), out.message)
+    }
+
+    @Test fun expired_plan_is_named_instead_of_the_engine_error() {
+        // The measured shape of the bug: an expired panel serves a VALID config with its proxies
+        // stripped, so the engine blames a missing node and the user has no idea their plan ran
+        // out. Header values are verbatim from the reported subscription.
+        val expiredAt = 1_784_278_620L // 2026-07-17
+        val out = FetchErrorClassifier.clarify(
+            dirWith(
+                "proxy-groups:\n  - {name: auto, type: url-test, proxies: [nl-1]}\n",
+                mapOf(
+                    "subscription-userinfo" to "upload=0; download=341897290; total=0; expire=$expiredAt",
+                    "support-url" to "https://t.me/PokemeshSupport",
+                ),
+            ),
+            RuntimeException("proxy 'nl-1' not found"),
+            expiredAt + 86_400,
+        )
+        assertTrue(out.message!!.contains("expired on 2026-07-17"), out.message)
+        assertTrue(out.message!!.contains("https://t.me/PokemeshSupport"), out.message)
+        assertTrue(out.message!!.contains("[E-41]"), out.message)
+        // The precise engine message stays reachable for logs and support.
+        assertEquals("proxy 'nl-1' not found", out.cause!!.message)
+    }
+
+    @Test fun unlimited_subscription_is_never_called_expired() {
+        // expire=0 is the "never expires" convention, and it is what the other live subscription
+        // sends — treating it as an epoch date would call every such profile expired.
+        val out = FetchErrorClassifier.clarify(
+            dirWith(null, mapOf("subscription-userinfo" to "upload=0; download=148054525960; total=0; expire=0")),
+            forbidden,
+            now,
+        )
+        assertTrue(out.message!!.contains("[E-21]"), out.message)
+    }
+
+    @Test fun future_expiry_is_not_an_error_reason() {
+        val out = FetchErrorClassifier.clarify(
+            dirWith(null, mapOf("subscription-userinfo" to "upload=0; download=0; expire=${now + 86_400}")),
+            forbidden,
+            now,
+        )
+        assertTrue(out.message!!.contains("[E-21]"), out.message)
+    }
+
+    @Test fun headers_without_an_account_verdict_change_nothing() {
+        val out = FetchErrorClassifier.clarify(
+            dirWith(null, mapOf("profile-title" to "Home", "x-hwid-limit" to "false")),
+            forbidden,
+            now,
+        )
+        assertTrue(out.message!!.contains("[E-21]"), out.message)
+    }
+
+    @Test fun a_working_config_is_never_second_guessed() {
+        // Nothing calls clarify on success, but if that ever changes, an expired header must not
+        // invent a failure for a profile the engine accepted.
+        val healthy = "proxies: []\nrules:\n  - MATCH,DIRECT\n"
+        val dir = dirWith(healthy, mapOf("subscription-userinfo" to "expire=${now - 86_400}"))
+        assertTrue(FetchErrorClassifier.clarify(dir, original, now).message!!.contains("[E-41]"))
+        // ...but only because clarify was called at all — the reason is attached to a real error.
+        assertSame(original, FetchErrorClassifier.clarify(dir, original, now).cause)
     }
 
     @Test fun html_detection() {


### PR DESCRIPTION
The update-via-proxy toggle picked one route and stuck to it, which left two dead ends. Preferring the tunnel, a subscription reachable only off-tunnel could not be downloaded at all, and worse, a profile whose nodes were all dead could not be refreshed because the refresh went through the dead nodes. Preferring direct, a DPI-blocked panel was unreachable.

Make the toggle a preference rather than a constraint: on a route-shaped failure the other route is tried once. That is any transport error, but only 403 and 451 on the HTTP side, deliberately an allowlist - an unnecessary direct retry leaks the panel hostname to the local network, and 401, 404 and 5xx are about the subscription rather than the path to it. The first attempt is capped at 25s of the 60s budget so a hanging route cannot starve the second; its context outlives a successful attempt because the body is read later, so the cancel rides on Close.

HttpRequest only errors on transport problems, so a non-2xx body was being saved as config.yaml and surfacing later as a confusing YAML parse failure. Reject it at the door and explain it per status code as E-21. Providers keep a single route: they are best-effort and fetched six at a time.

closes #178