### PR TITLE
feat(proxy-picker): long-press ping to measure latency to your own host

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -333,11 +333,12 @@ class MainActivity : BaseActivity<MainDesign>() {
      * refreshRuntimeGroupDetails — per-proxy push only carries the delay
      * measurement itself.
      */
-    private suspend fun runPerProxyHealthCheck(group: String) {
+    private suspend fun runPerProxyHealthCheck(group: String, testUrl: String = "") {
         runCatching {
             withClash {
                 healthCheckPerProxy(
                     group,
+                    testUrl,
                     object : IProxyDelayObserver {
                         override fun onDelay(
                             grp: String,
@@ -870,7 +871,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                     }
                 }
 
-                design.profilePingAllRequests.onReceive { (profile, group, nodeNames) ->
+                design.profilePingAllRequests.onReceive { (profile, group, nodeNames, testUrl) ->
                     launch {
                         try {
                             design.setPingingProfile(profile.uuid)
@@ -897,7 +898,7 @@ class MainActivity : BaseActivity<MainDesign>() {
                                     design.patchProxyDetails(primed)
                                 }
                                 val jobs = groupsToRefresh.map { groupName ->
-                                    launch { runPerProxyHealthCheck(groupName) }
+                                    launch { runPerProxyHealthCheck(groupName, testUrl) }
                                 }
                                 jobs.forEach { it.join() }
                                 // Closing refresh captures `now` / `alive` fields the per-proxy

--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -217,13 +217,15 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheck(JNIEnv *env, jo
 JNIEXPORT void JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheckWithCallback(JNIEnv *env, jobject thiz,
                                                                               jobject callback,
-                                                                              jstring name) {
+                                                                              jstring name,
+                                                                              jstring test_url) {
     TRACE_METHOD();
 
     jobject _callback = new_global(callback);
     scoped_string _name = get_string(name);
+    scoped_string _test_url = get_string(test_url);
 
-    healthCheckWithCallback(_callback, _name);
+    healthCheckWithCallback(_callback, _name, _test_url);
 }
 
 JNIEXPORT void JNICALL

--- a/core/src/main/golang/native/tunnel.go
+++ b/core/src/main/golang/native/tunnel.go
@@ -98,8 +98,8 @@ func healthCheck(completable unsafe.Pointer, name C.c_string) {
 }
 
 //export healthCheckWithCallback
-func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
-	go func(name string, callback unsafe.Pointer) {
+func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string, testUrl C.c_string) {
+	go func(name string, testUrl string, callback unsafe.Pointer) {
 		completed := false
 		defer func() {
 			if r := recover(); r != nil {
@@ -111,7 +111,7 @@ func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
 			}
 		}()
 
-		earlyErr := tunnel.HealthCheckWithCallback(name, func(proxyName string, delayMs int, errMsg string) {
+		earlyErr := tunnel.HealthCheckWithCallback(name, testUrl, func(proxyName string, delayMs int, errMsg string) {
 			var errCStr *C.char
 			if errMsg != "" {
 				errCStr = marshalString(errMsg)
@@ -127,7 +127,7 @@ func healthCheckWithCallback(callback unsafe.Pointer, name C.c_string) {
 
 		C.release_object(callback)
 		completed = true
-	}(C.GoString(name), callback)
+	}(C.GoString(name), C.GoString(testUrl), callback)
 }
 
 //export healthCheckAll

--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -154,8 +155,17 @@ func CancelHealthChecks() {
 //
 // errMsg is empty on success, otherwise carries the proxy's URLTest error
 // reason; delayMs is meaningful only when errMsg == "".
+// testURL, when non-empty, replaces the provider's configured health-check URL for THIS run only.
+// It is a one-shot measurement target the user typed, not a setting: nothing is persisted engine-side
+// and the automatic url-test/fallback timers keep using the subscription's own URL, because those are
+// driven by mihomo itself from the group config.
+//
+// Note what changes with a custom target. The default is a `generate_204` endpoint, which answers with
+// an empty body, so the number is close to a round trip. An arbitrary site returns a real page and may
+// negotiate TLS, so its figure is legitimately higher — it is still latency, never throughput.
 func HealthCheckWithCallback(
 	name string,
+	testURL string,
 	onDelay func(proxyName string, delayMs int, errMsg string),
 ) string {
 	p := tunnel.Proxies()[name]
@@ -170,10 +180,15 @@ func HealthCheckWithCallback(
 	// Bound concurrent URLTests across the whole group, not per provider —
 	// a kaso-style config can stack several providers behind one group and
 	// each one's leaf count adds to the outgoing socket pressure.
+	override := strings.TrimSpace(testURL)
+
 	eg := new(errgroup.Group)
 	eg.SetLimit(perGroupConcurrencyLimit)
 	for _, prov := range g.Providers() {
-		url := prov.HealthCheckURL()
+		url := override
+		if url == "" {
+			url = prov.HealthCheckURL()
+		}
 		if url == "" {
 			url = defaultHealthCheckURL
 		}

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -161,8 +161,15 @@ object Clash {
      * single UI patch fires per proxy at its natural resolution time
      * instead of every poll tick.
      */
+    /**
+     * @param testUrl one-shot override for the health-check target. Blank keeps each provider's
+     *        configured URL (the normal case). A custom target measures latency to that host and
+     *        nothing else: it does not change the automatic url-test timers, which mihomo drives
+     *        from the group config, and it never reports throughput.
+     */
     fun healthCheckPerProxy(
         name: String,
+        testUrl: String = "",
         onProxyDelay: (proxyName: String, delayMs: Int, errMsg: String) -> Unit,
     ): CompletableDeferred<Unit> {
         val deferred = CompletableDeferred<Unit>()
@@ -181,6 +188,7 @@ object Clash {
                 }
             },
             name,
+            testUrl,
         )
         return deferred
     }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -28,7 +28,7 @@ object Bridge {
     external fun nativeQueryAllGroupNamesIncludingHidden(): String
     external fun nativeQueryGroup(name: String, sort: String): String?
     external fun nativeHealthCheck(completable: CompletableDeferred<Unit>, name: String)
-    external fun nativeHealthCheckWithCallback(callback: ProxyDelayCallback, name: String)
+    external fun nativeHealthCheckWithCallback(callback: ProxyDelayCallback, name: String, testUrl: String)
     external fun nativeHealthCheckAll()
     external fun nativePatchSelector(selector: String, name: String): Boolean
     external fun nativeFetchAndValid(

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -128,7 +128,18 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
     val profileMenuRequests = Channel<Pair<Profile, View>>(Channel.UNLIMITED)
     val profileEditRequests = Channel<Profile>(Channel.UNLIMITED)
     val patchHomeProxyRequests = Channel<Triple<Profile, String, String>>(Channel.CONFLATED)
-    val profilePingAllRequests = Channel<Triple<Profile, String, List<String>>>(Channel.UNLIMITED)
+    /**
+     * A ping-all request. Was a Triple until the custom latency target arrived; [testUrl] is blank
+     * for a normal tap and carries a one-shot host when the user long-pressed and typed one.
+     */
+    data class PingAllRequest(
+        val profile: Profile,
+        val group: String,
+        val proxyNames: List<String>,
+        val testUrl: String = "",
+    )
+
+    val profilePingAllRequests = Channel<PingAllRequest>(Channel.UNLIMITED)
     val profileForceUpdateRequests = Channel<Profile>(Channel.UNLIMITED)
     val profileProxyYamlRequests = Channel<Triple<Profile, String, String>>(Channel.UNLIMITED)
     /** Fires when user expands/collapses any profile panel so the host can reload proxy previews. */
@@ -251,7 +262,9 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         { profile, group, proxyName ->
             patchHomeProxyRequests.trySend(Triple(profile, group, proxyName))
         },
-        { profile, group, proxyNames -> profilePingAllRequests.trySend(Triple(profile, group, proxyNames)) },
+        { profile, group, proxyNames, testUrl ->
+            profilePingAllRequests.trySend(PingAllRequest(profile, group, proxyNames, testUrl))
+        },
         { profile -> profileForceUpdateRequests.trySend(profile) },
         { profile, group, proxy -> profileProxyYamlRequests.trySend(Triple(profile, group, proxy)) },
         { profile, group -> profileVisibleGroupChanged.trySend(profile to group) },
@@ -269,7 +282,9 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         { profile, group, proxyName ->
             patchHomeProxyRequests.trySend(Triple(profile, group, proxyName))
         },
-        { profile, group, proxyNames -> profilePingAllRequests.trySend(Triple(profile, group, proxyNames)) },
+        { profile, group, proxyNames, testUrl ->
+            profilePingAllRequests.trySend(PingAllRequest(profile, group, proxyNames, testUrl))
+        },
         { profile ->
             if (profile.imported && profile.type != Profile.Type.File) {
                 profileForceUpdateRequests.trySend(profile)

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -34,6 +34,11 @@ import com.github.kr328.clash.service.model.ProxyTransportInfo
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import androidx.appcompat.widget.TooltipCompat
 import com.google.android.material.button.MaterialButton
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.google.android.material.color.MaterialColors
 import java.util.UUID
 
@@ -42,7 +47,7 @@ class ProfileAdapter(
     private val onMenuClicked: (Profile, View) -> Unit,
     private val onExpandToggle: (Profile) -> Unit = {},
     private val onProxyNodeSelected: (Profile, String, String) -> Unit = { _, _, _ -> },
-    private val onPingAll: (Profile, String, List<String>) -> Unit = { _, _, _ -> },
+    private val onPingAll: (Profile, String, List<String>, String) -> Unit = { _, _, _, _ -> },
     private val onForceUpdate: (Profile) -> Unit = {},
     private val onProxyYamlDetail: (profile: Profile, groupName: String, proxyName: String) -> Unit =
         { _, _, _ -> },
@@ -59,6 +64,8 @@ class ProfileAdapter(
     private var proxyGroupNames: List<String> = emptyList()
     /** The `excludeNotSelectable` setting [proxyGroupNames] was queried with — see [setProxyContext]. */
     private var excludeNotSelectable: Boolean = false
+    /** Prefill for the latency-target dialog; the measurement target itself is never sticky. */
+    private var lastLatencyTarget: String = ""
     private var proxyDetails: Map<String, ProxyGroup> = emptyMap()
     private var activeProfileUuid: UUID? = null
     private var clashRunning: Boolean = false
@@ -759,6 +766,63 @@ class ProfileAdapter(
         ).withSelectionOverlay(profile.uuid, groupName)
     }
 
+    /**
+     * Asks for a one-shot latency target and hands back a URL ready for URLTest.
+     *
+     * The last entry is remembered only to prefill the field — the measurement itself is never
+     * sticky, so closing the dialog leaves the next tap measuring the default target as before.
+     */
+    private fun showLatencyTargetDialog(context: Context, onConfirm: (String) -> Unit) {
+        val view = context.layoutInflater.inflate(R.layout.dialog_latency_target, null, false)
+        val inputLayout = view.findViewById<TextInputLayout>(R.id.latency_target_input_layout)
+        val input = view.findViewById<TextInputEditText>(R.id.latency_target_input)
+        input.setText(lastLatencyTarget)
+        input.setSelection(input.text?.length ?: 0)
+
+        val dialog = MaterialAlertDialogBuilder(context)
+            .setView(view)
+            .setPositiveButton(R.string.latency_target_run, null)
+            .setNegativeButton(R.string.cancel, null)
+            .create()
+
+        // Validate without dismissing: setPositiveButton's own listener always closes, which would
+        // throw the typed text away on a typo.
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val url = normalizeLatencyTarget(input.text?.toString().orEmpty())
+                if (url == null) {
+                    inputLayout.error = context.getString(R.string.latency_target_invalid)
+                    return@setOnClickListener
+                }
+                lastLatencyTarget = input.text?.toString()?.trim().orEmpty()
+                dialog.dismiss()
+                onConfirm(url)
+            }
+        }
+        dialog.show()
+    }
+
+    /**
+     * Turns what a person types into something URLTest can dial, or null if it cannot.
+     *
+     * People type "youtube.com", so a missing scheme is assumed to be https rather than rejected.
+     * A bare host with no dot ("localhost", or a half-typed name) is refused: URLTest would hang
+     * until the timeout and report every proxy as dead, which reads as a bug in the app rather
+     * than a typo.
+     */
+    internal fun normalizeLatencyTarget(raw: String): String? {
+        val text = raw.trim()
+        if (text.isEmpty()) return null
+        val withScheme = if (text.startsWith("http://") || text.startsWith("https://")) {
+            text
+        } else {
+            "https://$text"
+        }
+        val host = runCatching { java.net.URI(withScheme).host }.getOrNull()
+        if (host.isNullOrBlank() || !host.contains('.')) return null
+        return withScheme
+    }
+
     private fun proxySelectionKey(uuid: UUID, groupName: String): String =
         "${uuid}|${groupName}"
 
@@ -1083,9 +1147,12 @@ class ProfileAdapter(
             val pinging = states.pingingUuid == profile.uuid
             sheet.proxySheetPingProgress.visibility = if (pinging) View.VISIBLE else View.GONE
             sheet.proxySheetPingButton.visibility = if (pinging) View.INVISIBLE else View.VISIBLE
-            sheet.proxySheetPingButton.setOnClickListener {
+            // Resolves what a ping would cover right now: the rows the user can actually see in
+            // the current group, falling back to the group's own members when the list has not
+            // been laid out yet. Shared by the tap and the long press so both measure the same set.
+            fun pingTargets(): Pair<String, List<String>>? {
                 val currentIndex = selectedGroupIndex[profile.uuid] ?: 0
-                val groupName = groupNames.getOrNull(currentIndex) ?: return@setOnClickListener
+                val groupName = groupNames.getOrNull(currentIndex) ?: return null
                 val names = visibleRows()
                     .filter { it.groupIndex == currentIndex }
                     .map { it.proxy.name }
@@ -1096,10 +1163,41 @@ class ProfileAdapter(
                             ?.map { it.name }
                             .orEmpty()
                     }
-                if (names.isEmpty()) return@setOnClickListener
+                if (names.isEmpty()) return null
+                return groupName to names
+            }
+
+            fun startPing(groupName: String, names: List<String>, testUrl: String) {
                 lastPingAllAt[profile.uuid] = System.currentTimeMillis()
-                onPingAll(profile, groupName, names)
+                onPingAll(profile, groupName, names, testUrl)
                 sheet.root.post(refreshRunnable)
+            }
+
+            sheet.proxySheetPingButton.setOnClickListener {
+                val (groupName, names) = pingTargets() ?: return@setOnClickListener
+                startPing(groupName, names, "")
+            }
+            // Long press picks a different target for one run. Deliberately not a setting: the
+            // default check URL is what the subscription tuned its own auto-switching around, so
+            // making a custom host permanent here would quietly change what "fastest" means.
+            //
+            // Targets are resolved on confirm, not here. Resolving up front meant that whenever the
+            // current group had no rows to measure the gesture returned silently, which from the
+            // outside is indistinguishable from a long press that does not work at all.
+            sheet.proxySheetPingButton.setOnLongClickListener {
+                showLatencyTargetDialog(sheet.root.context) { url ->
+                    val targets = pingTargets()
+                    if (targets == null) {
+                        Toast.makeText(
+                            sheet.root.context,
+                            R.string.latency_target_nothing_to_test,
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                        return@showLatencyTargetDialog
+                    }
+                    startPing(targets.first, targets.second, url)
+                }
+                true
             }
 
             sheet.proxySheetSearch.addTextChangedListener { editable ->
@@ -1617,7 +1715,7 @@ class ProfileAdapter(
         pingView.setOnClickListener {
             pingingGroupByUuid[profile.uuid] = groupName
             val names = proxyGroupForRow(profile, groupName)?.proxies?.map { it.name }.orEmpty()
-            onPingAll(profile, groupName, names)
+            onPingAll(profile, groupName, names, "")
         }
 
         header.setOnClickListener {

--- a/design/src/main/res/layout/dialog_latency_target.xml
+++ b/design/src/main/res/layout/dialog_latency_target.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  One-shot latency target, opened by long-pressing the ping button. Deliberately not a settings
+  field: a normal tap keeps measuring against the subscription's own health-check URL, and this
+  only changes the target for the run the user is starting right now.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/latency_target_title"
+        android:textAppearance="@style/TextAppearance.App.TitleMedium"
+        android:textColor="?attr/colorOnSurface" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:text="@string/latency_target_summary"
+        android:textAppearance="@style/TextAppearance.App.BodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/latency_target_input_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="@string/latency_target_hint"
+        app:errorEnabled="true">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/latency_target_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionGo"
+            android:inputType="textUri"
+            android:maxLines="1"
+            tools:text="youtube.com" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:text="@string/latency_target_note"
+        android:textAppearance="@style/TextAppearance.App.BodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
+</LinearLayout>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1215,4 +1215,11 @@
     <string name="local_proxy_copied_fmt">%1$s скопирован</string>
     <string name="subscription_update_via_proxy">Обновлять через прокси</string>
     <string name="subscription_update_via_proxy_summary">Предпочитаемый маршрут для загрузки этой подписки: через туннель, по вашим правилам. Выключите, чтобы сначала пробовать прямое подключение. В любом случае, если первый маршрут не сработает, второй будет использован автоматически. Применится со следующего обновления.</string>
+    <string name="latency_target_title">Цель теста задержки</string>
+    <string name="latency_target_summary">Измерить задержку до нужного вам сайта вместо стандартного адреса проверки. Только для этого теста.</string>
+    <string name="latency_target_hint">Сайт или URL</string>
+    <string name="latency_target_note">Это задержка, а не скорость скачивания. Настоящая страница отвечает медленнее пустого ответа по умолчанию, поэтому числа будут выше.</string>
+    <string name="latency_target_invalid">Введите сайт, например example.com</string>
+    <string name="latency_target_run">Проверить</string>
+    <string name="latency_target_nothing_to_test">В этой группе нечего проверять</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -1143,4 +1143,11 @@
     <string name="local_proxy_copied_fmt">已复制：%1$s</string>
     <string name="subscription_update_via_proxy">通过代理更新</string>
     <string name="subscription_update_via_proxy_summary">下载此订阅时优先使用的路径：通过隧道并按你的规则。关闭则优先尝试直连。无论哪种方式，若首选路径失败都会自动尝试另一条。下次更新时生效。</string>
+    <string name="latency_target_title">延迟测试目标</string>
+    <string name="latency_target_summary">使用你指定的网站替代默认检测地址来测量延迟。仅对本次测试生效。</string>
+    <string name="latency_target_hint">网站或 URL</string>
+    <string name="latency_target_note">测的是延迟，不是下载速度。真实页面比默认的空响应慢，因此数值会更高。</string>
+    <string name="latency_target_invalid">请输入网站，例如 example.com</string>
+    <string name="latency_target_run">测试</string>
+    <string name="latency_target_nothing_to_test">该分组没有可测试的节点</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -1222,4 +1222,11 @@ Password: %4$s</string>
     <string name="local_proxy_copied_fmt">%1$s copied</string>
     <string name="subscription_update_via_proxy">Update via proxy</string>
     <string name="subscription_update_via_proxy_summary">Preferred route for downloading this subscription: through the tunnel, following your rules. Turn off to try a direct connection first. Either way the other route is tried automatically if the first one fails. Applies to the next update.</string>
+    <string name="latency_target_title">Latency test target</string>
+    <string name="latency_target_summary">Measure latency to a site of your choice instead of the default check URL. Applies to this test only.</string>
+    <string name="latency_target_hint">Site or URL</string>
+    <string name="latency_target_note">Latency only, not download speed. A real page answers slower than the default empty response, so expect higher numbers.</string>
+    <string name="latency_target_invalid">Enter a site like example.com</string>
+    <string name="latency_target_run">Test</string>
+    <string name="latency_target_nothing_to_test">No nodes to test in this group</string>
 </resources>

--- a/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ClashManager.kt
@@ -176,14 +176,14 @@ class ClashManager(private val context: Context) : IClashManager,
         return Clash.healthCheck(group).await()
     }
 
-    override suspend fun healthCheckPerProxy(group: String, observer: IProxyDelayObserver) {
+    override suspend fun healthCheckPerProxy(group: String, testUrl: String, observer: IProxyDelayObserver) {
         // JNI fires onProxyDelay from arbitrary worker threads. AIDL stubs are
         // not thread-safe across simultaneous calls, so the observer must
         // tolerate concurrent onDelay() — IPC marshals them serially through
         // the binder transaction queue, but a DeadObjectException from a
         // crashed activity must not kill the whole health-check pipeline.
         val finalErr: String? = runCatching {
-            Clash.healthCheckPerProxy(group) { name, ms, err ->
+            Clash.healthCheckPerProxy(group, testUrl) { name, ms, err ->
                 runCatching { observer.onDelay(group, name, ms, err) }
             }.await()
             null

--- a/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/remote/IClashManager.kt
@@ -27,7 +27,12 @@ interface IClashManager {
 
     suspend fun healthCheck(group: String)
 
-    suspend fun healthCheckPerProxy(group: String, observer: IProxyDelayObserver)
+    /**
+     * @param testUrl one-shot latency target the user typed, or blank to use each provider's
+     *        configured health-check URL. Never persisted; the automatic url-test timers are
+     *        unaffected.
+     */
+    suspend fun healthCheckPerProxy(group: String, testUrl: String, observer: IProxyDelayObserver)
 
     fun healthCheckAll()
     suspend fun updateProvider(type: Provider.Type, name: String)


### PR DESCRIPTION
Closes #189. The health-check target came from the subscription and could not be changed, so there was no way to ask how a node behaves against a specific site. Long-pressing the ping button now opens a dialog for a one-shot target; a normal tap is unchanged.

The override reaches URLTest through the same path the update-via-proxy flag uses: Go, the cgo export, main.c, Bridge, Clash, IClashManager. It is deliberately not a setting. The automatic url-test and fallback timers keep using the group's own URL, because mihomo drives those from the config and the subscription tuned its auto-switching around that address - making a custom host sticky would quietly redefine what fastest means.

Input is normalized: a missing scheme becomes https, and a bare name with no dot is rejected, because URLTest would otherwise hang to the timeout and report every node dead, which reads as an app bug rather than a typo. Validation keeps the dialog open instead of discarding what was typed. The dialog states plainly that this measures latency and not download speed, and that a real page answers slower than the default empty response.