### PR TITLE
chore(release): bump version to 0.10.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,8 @@ subprojects {
             minSdk = 21
             targetSdk = 35
 
-            versionName = "0.10.0"
-            versionCode = 1000000
+            versionName = "0.10.1"
+            versionCode = 1001000
 
             resValue("string", "release_name", "v$versionName")
             resValue("integer", "release_code", "$versionCode")


### PR DESCRIPTION
versionCode follows the established scheme, minor times 100000, so a patch adds 1000: 0.10.0 was 1000000 and 0.10.1 is 1001000. Verified the build produces clashfest-v0.10.1 artifacts.