### PR TITLE
fix: dashboard battery/CPU regression + ambient animation cost

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,8 @@ subprojects {
             minSdk = 21
             targetSdk = 35
 
-            versionName = "0.10.1"
-            versionCode = 1001000
+            versionName = "0.10.2"
+            versionCode = 1002000
 
             resValue("string", "release_name", "v$versionName")
             resValue("integer", "release_code", "$versionCode")

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -175,15 +175,16 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
     private var powerSweepAnimator: ValueAnimator? = null
 
     /**
-     * Frame gate for the ambient power animations. The animators tick every vsync (120Hz on
-     * modern panels), but a 2.6s breath / 4.6s sweep carries no visible detail at 120fps — so we
-     * only push the scale/alpha/rotation (which triggers the redraw) at ~30fps. Cuts the connected
-     * dashboard's continuous full-screen redraw ~4x with no perceptible change. Per-animator
-     * timestamps so each throttles independently.
+     * The three ambient power effects (button breath, halo breath, conic sweep) are driven by a
+     * SINGLE animator that ticks the clock; each vsync we derive all three values from elapsed
+     * time. This replaced three separate INFINITE ValueAnimators — a method trace showed their
+     * per-vsync machinery (Keyframe/clampFraction ×3) dominating the main thread on the connected
+     * dashboard. One driver = one machinery pass, and all view writes land in a single frame gate
+     * (~30fps) so the redraw fires once, not three staggered times. Visual output is identical:
+     * the formulas reproduce each animator's period, interpolator and phase exactly.
      */
-    private var lastBreathFrameNs = 0L
-    private var lastHaloFrameNs = 0L
-    private var lastSweepFrameNs = 0L
+    private var ambientStartNs = 0L
+    private var lastAmbientFrameNs = 0L
 
     /**
      * Tracks the running flag the breath animators were last spun up for, so
@@ -943,49 +944,35 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
         innerRing.alpha = 0.0f
         halo.alpha = 0.20f
 
-        // Button: gentle scale breath (epicentre).
-        powerBreathAnimator = ValueAnimator.ofFloat(1.0f, 1.04f).apply {
+        // One driver ticks the clock; the gated listener derives button scale (breath, 2.6s
+        // REVERSE accel-decel), halo alpha (same, +120ms phase) and sweep rotation (4.6s linear)
+        // from elapsed time — reproducing the three former animators without their per-vsync cost.
+        val breath = AccelerateDecelerateInterpolator()
+        val sweep = binding.powerSweep
+        ambientStartNs = System.nanoTime()
+        lastAmbientFrameNs = 0L
+        powerBreathAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = period
-            repeatCount = ValueAnimator.INFINITE
-            repeatMode = ValueAnimator.REVERSE
-            interpolator = AccelerateDecelerateInterpolator()
-            addUpdateListener { animator ->
-                val now = System.nanoTime()
-                if (now - lastBreathFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
-                lastBreathFrameNs = now
-                val v = animator.animatedValue as Float
-                button.scaleX = v
-                button.scaleY = v
-            }
-            start()
-        }
-        // The single soft glow: halo alpha breathes under the button, slightly phase-shifted.
-        powerHaloBreathAnimator = ValueAnimator.ofFloat(0.20f, 0.40f).apply {
-            duration = period
-            startDelay = 120L
-            repeatCount = ValueAnimator.INFINITE
-            repeatMode = ValueAnimator.REVERSE
-            interpolator = AccelerateDecelerateInterpolator()
-            addUpdateListener { animator ->
-                val now = System.nanoTime()
-                if (now - lastHaloFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
-                lastHaloFrameNs = now
-                halo.alpha = animator.animatedValue as Float
-            }
-            start()
-        }
-        // Soft conic shimmer slowly rotating around the orb — a subtle premium glint (kept quiet
-        // on purpose; louder "alive" effects read cheap on the orb).
-        powerSweepAnimator = ValueAnimator.ofFloat(0f, 360f).apply {
-            duration = 4600L
             repeatCount = ValueAnimator.INFINITE
             repeatMode = ValueAnimator.RESTART
             interpolator = android.view.animation.LinearInterpolator()
-            addUpdateListener { animator ->
+            addUpdateListener {
                 val now = System.nanoTime()
-                if (now - lastSweepFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
-                lastSweepFrameNs = now
-                binding.powerSweep.rotation = animator.animatedValue as Float
+                if (now - lastAmbientFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
+                lastAmbientFrameNs = now
+                val elapsedMs = (now - ambientStartNs) / 1_000_000L
+                // REVERSE triangle over 2*period, accel-decel on each half — matches ofFloat REVERSE.
+                fun breathe(ms: Long): Float {
+                    if (ms < 0) return 0f
+                    val cyc = ms % (2 * period)
+                    val tri = if (cyc < period) cyc.toFloat() / period else (2 * period - cyc).toFloat() / period
+                    return breath.getInterpolation(tri)
+                }
+                val s = 1.0f + 0.04f * breathe(elapsedMs)
+                button.scaleX = s
+                button.scaleY = s
+                halo.alpha = 0.20f + 0.20f * breathe(elapsedMs - 120L)
+                sweep.rotation = (elapsedMs % 4600L).toFloat() / 4600f * 360f
             }
             start()
         }

--- a/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/MainDesign.kt
@@ -119,6 +119,9 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
 
     private companion object {
         private val DEFAULT_TABS = listOf(MainTab.Home, MainTab.Profiles, MainTab.Routing, MainTab.Settings)
+
+        /** ~30fps gate for the ambient power animations (33ms between rendered frames). */
+        private const val AMBIENT_MIN_FRAME_NS = 33_000_000L
     }
 
     /** Set by MainActivity to react to taps on the in-header update badge. */
@@ -169,7 +172,18 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
     private var powerHaloBreathAnimator: ValueAnimator? = null
     private var powerRingInnerBreathAnimator: ValueAnimator? = null
     private var powerRingOuterBreathAnimator: ValueAnimator? = null
-    private var powerSweepAnimator: android.animation.ObjectAnimator? = null
+    private var powerSweepAnimator: ValueAnimator? = null
+
+    /**
+     * Frame gate for the ambient power animations. The animators tick every vsync (120Hz on
+     * modern panels), but a 2.6s breath / 4.6s sweep carries no visible detail at 120fps — so we
+     * only push the scale/alpha/rotation (which triggers the redraw) at ~30fps. Cuts the connected
+     * dashboard's continuous full-screen redraw ~4x with no perceptible change. Per-animator
+     * timestamps so each throttles independently.
+     */
+    private var lastBreathFrameNs = 0L
+    private var lastHaloFrameNs = 0L
+    private var lastSweepFrameNs = 0L
 
     /**
      * Tracks the running flag the breath animators were last spun up for, so
@@ -936,6 +950,9 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
             repeatMode = ValueAnimator.REVERSE
             interpolator = AccelerateDecelerateInterpolator()
             addUpdateListener { animator ->
+                val now = System.nanoTime()
+                if (now - lastBreathFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
+                lastBreathFrameNs = now
                 val v = animator.animatedValue as Float
                 button.scaleX = v
                 button.scaleY = v
@@ -950,19 +967,26 @@ class MainDesign(context: Context) : Design<MainDesign.Request>(context) {
             repeatMode = ValueAnimator.REVERSE
             interpolator = AccelerateDecelerateInterpolator()
             addUpdateListener { animator ->
+                val now = System.nanoTime()
+                if (now - lastHaloFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
+                lastHaloFrameNs = now
                 halo.alpha = animator.animatedValue as Float
             }
             start()
         }
         // Soft conic shimmer slowly rotating around the orb — a subtle premium glint (kept quiet
         // on purpose; louder "alive" effects read cheap on the orb).
-        powerSweepAnimator = android.animation.ObjectAnimator.ofFloat(
-            binding.powerSweep, View.ROTATION, 0f, 360f,
-        ).apply {
+        powerSweepAnimator = ValueAnimator.ofFloat(0f, 360f).apply {
             duration = 4600L
             repeatCount = ValueAnimator.INFINITE
             repeatMode = ValueAnimator.RESTART
             interpolator = android.view.animation.LinearInterpolator()
+            addUpdateListener { animator ->
+                val now = System.nanoTime()
+                if (now - lastSweepFrameNs < AMBIENT_MIN_FRAME_NS) return@addUpdateListener
+                lastSweepFrameNs = now
+                binding.powerSweep.rotation = animator.animatedValue as Float
+            }
             start()
         }
     }

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileManager.kt
@@ -123,6 +123,24 @@ class ProfileManager(private val context: Context) : IProfileManager,
     private data class CachedSnapshot(val lastModified: Long, val snapshot: ProfileSnapshot)
     private val snapshotCache = LinkedHashMap<UUID, CachedSnapshot>()
     private val snapshotCacheLock = Any()
+
+    /**
+     * In-memory cache of the engine-resolved proxy-group preview keyed by
+     * profile UUID, mirroring [snapshotCache]. [engineProxyGroupsPreview] runs
+     * mihomo's full ParseRawConfig over config.yaml through JNI — far heavier
+     * than the snapshot parse — and the dashboard ticker calls it every ~2s per
+     * previewed profile, so without this the resolve dominated CPU/battery on
+     * heavy subscriptions while the app was open. Invalidated by config.yaml
+     * lastModified like the snapshot; the `null` result (engine could not
+     * parse → Kotlin fallback) is cached too, so an unparsable config is not
+     * re-resolved every tick.
+     */
+    private data class CachedEnginePreview(
+        val lastModified: Long,
+        val preview: Map<String, ProxyGroupPreviewRow>?,
+    )
+    private val enginePreviewCache = LinkedHashMap<UUID, CachedEnginePreview>()
+    private val enginePreviewCacheLock = Any()
     // Serializes nextProfileOrder() + Pending insert pairs. Without it, two concurrent
     // imports (e.g. auto-update + manual click) can both read the same MAX(profileOrder)
     // and produce duplicate ordering values that compare non-deterministically.
@@ -196,6 +214,9 @@ class ProfileManager(private val context: Context) : IProfileManager,
     private fun invalidateSnapshotCache(uuid: UUID) {
         synchronized(snapshotCacheLock) {
             snapshotCache.remove(uuid)
+        }
+        synchronized(enginePreviewCacheLock) {
+            enginePreviewCache.remove(uuid)
         }
     }
 
@@ -617,7 +638,7 @@ class ProfileManager(private val context: Context) : IProfileManager,
                 // Clash.queryAllProxyGroupNamesIncludingHidden, so the offline preview must match that
                 // universe — otherwise hidden auto subgroups have no rows during the warmup race and
                 // the expanded carriage flashes empty until proxyDetails arrives.
-                engineProxyGroupsPreview(file, snapshot)
+                engineProxyGroupsPreview(uuid, file, snapshot)
                     ?: ProxyGroupsYamlPreview.parseProxyGroupsPreview(
                         snapshot,
                         file.parentFile,
@@ -637,7 +658,39 @@ class ProfileManager(private val context: Context) : IProfileManager,
      * never the expanded one, because the picker's 1-hop heuristic uses it to tell a pure dispatch
      * shell from a group whose members are flat only because of `include-all`.
      */
+    /**
+     * Cache wrapper over [engineProxyGroupsPreviewUncached]: reuses the resolved preview while
+     * config.yaml's lastModified is unchanged, so the dashboard ticker's ~2s cadence no longer
+     * re-runs mihomo's full parse on every tick (the 0.10.1 battery regression). Both a resolved
+     * map AND a `null` (engine could not parse) are cached — an unparsable config falls back to
+     * the Kotlin preview once, not every tick.
+     */
     private fun engineProxyGroupsPreview(
+        uuid: UUID,
+        file: File,
+        snapshot: ProfileSnapshot,
+    ): Map<String, ProxyGroupPreviewRow>? {
+        val lastMod = file.lastModified()
+        synchronized(enginePreviewCacheLock) {
+            val cached = enginePreviewCache[uuid]
+            if (cached != null && cached.lastModified == lastMod) {
+                // LRU touch — promote to most-recently-used.
+                enginePreviewCache.remove(uuid)
+                enginePreviewCache[uuid] = cached
+                return cached.preview
+            }
+        }
+        val computed = engineProxyGroupsPreviewUncached(file, snapshot)
+        synchronized(enginePreviewCacheLock) {
+            enginePreviewCache[uuid] = CachedEnginePreview(lastMod, computed)
+            while (enginePreviewCache.size > SNAPSHOT_CACHE_MAX) {
+                enginePreviewCache.remove(enginePreviewCache.keys.first())
+            }
+        }
+        return computed
+    }
+
+    private fun engineProxyGroupsPreviewUncached(
         file: File,
         snapshot: ProfileSnapshot,
     ): Map<String, ProxyGroupPreviewRow>? {


### PR DESCRIPTION
## Summary

Two independent battery/CPU fixes on the dashboard, both measured on device (Pixel, `/proc/stat` tick deltas + `gfxinfo` frame counts).

### 1. Cache the engine-resolved proxy-group preview (0.10.1 regression)

`readProxyGroupsPreview` ran mihomo's full config parse (`Clash.resolveProxyGroups`, JNI + `ParseRawConfig` over the whole `config.yaml`) on **every** call. The dashboard ticker fires it every ~2s per previewed profile — uncached, unlike the neighbouring `snapshotCache`. On heavy subscriptions this burned CPU/battery in the `:background` process whenever the app was open, on Samsung and Xiaomi alike. Introduced in 0.10.1 (#182); 0.10.0's preview was a light Kotlin parse of the cached snapshot.

**Fix:** wrap the resolve in `enginePreviewCache` keyed by `(uuid, config.yaml mtime)`, mirroring `snapshotCache`. A `null` (engine-unparsable) result is cached too, so it falls back to the Kotlin preview once, not every tick. Invalidated on profile delete/update.

**Measured:** `:background` process ~1% with the dashboard open, down from a full parse every tick.

### 2. Ambient power-button animation (not a regression, found in the same audit)

The breathing power button (scale + halo + conic sweep) redrew the whole dashboard every vsync — ~120fps continuously while the VPN was connected and the app was open, with no visible detail at that rate for a 2.6s breath. A method trace showed three separate `INFINITE` `ValueAnimator`s dominating the main thread: per-vsync machinery ×3 plus three staggered display-list rebuilds.

**Fix:** frame-gate view updates to ~30fps, then collapse the three animators into a single driver that ticks the clock while a gated listener derives all three values from elapsed time (same period / interpolator / phase — visually identical).

**Measured (connected, settled):**
- Dashboard frames: **~613 → ~148 per 5s** (≈120fps → steady 30fps, ~4× fewer redraws)
- Main thread: **14-19% → 10-13%**

## Testing

- Device A/B for both fixes (baseline build vs fixed build, identical conditions).
- Preview still renders correctly; no crash on expand/switch.
- Breathing animation visually unchanged at 30fps.

## Notes

Version bumped to 0.10.2 (hotfix). Further main-thread headroom exists (the driver still ticks at vsync; a `postDelayed` clock would cut it further) but risks animation jitter, so it's left out of the hotfix.
