### PR TITLE
perf(battery): cut background CPU and radio wakeups

### DIFF
--- a/core/src/main/cpp/main.c
+++ b/core/src/main/cpp/main.c
@@ -15,14 +15,15 @@
 JNIEXPORT void JNICALL
 Java_com_github_kr328_clash_core_bridge_Bridge_nativeInit(JNIEnv *env, jobject thiz,
                                                           jstring home,
-                                                          jstring version_name, jint sdk_version) {
+                                                          jstring version_name, jint sdk_version,
+                                                          jboolean debug) {
     TRACE_METHOD();
 
     scoped_string _home = get_string(home);
     scoped_string _version_name = get_string(version_name);
     char* _git_version = make_String(GIT_VERSION);
 
-    coreInit(_home, _version_name, _git_version, sdk_version);
+    coreInit(_home, _version_name, _git_version, sdk_version, (int) debug);
 }
 
 JNIEXPORT void JNICALL
@@ -233,6 +234,16 @@ Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheckAll(JNIEnv *env,
     TRACE_METHOD();
 
     healthCheckAll();
+}
+
+JNIEXPORT void JNICALL
+Java_com_github_kr328_clash_core_bridge_Bridge_nativeHealthCheckAutoGroups(JNIEnv *env, jobject thiz,
+                                                                          jobject completable) {
+    TRACE_METHOD();
+
+    jobject _completable = new_global(completable);
+
+    healthCheckAutoGroups(_completable);
 }
 
 JNIEXPORT jboolean JNICALL

--- a/core/src/main/golang/native/app/app.go
+++ b/core/src/main/golang/native/app/app.go
@@ -3,12 +3,25 @@ package app
 import (
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 var appVersionName string
 var platformVersion int
 var installedAppsUid = map[int]string{}
+
+// debugBuild gates verbosity that is only worth its cost while developing. Atomic because the
+// core's log-forwarding goroutine starts when the library loads, before coreInit sets this.
+var debugBuild atomic.Bool
+
+func ApplyDebugBuild(debug bool) {
+	debugBuild.Store(debug)
+}
+
+func DebugBuild() bool {
+	return debugBuild.Load()
+}
 
 func ApplyVersionName(versionName string) {
 	appVersionName = versionName

--- a/core/src/main/golang/native/log.go
+++ b/core/src/main/golang/native/log.go
@@ -8,6 +8,8 @@ import (
 	"time"
 	"unsafe"
 
+	"cfa/native/app"
+
 	"github.com/metacubex/mihomo/log"
 )
 
@@ -17,12 +19,43 @@ type message struct {
 	Time    int64  `json:"time"`
 }
 
+// shouldForwardToLogcat decides whether an engine log line earns an Android logcat write.
+//
+// Every forwarded line costs a CString malloc, a JNI hop, a write syscall into logd and a free.
+// mihomo emits one INFO line per connection and logs DNS activity at DEBUG, so on a busy device
+// this used to be thousands of lines a minute in release builds, for output nobody reads. It is
+// not only CPU: the upstream log channel is unbuffered ahead of a 200-slot subscriber queue, so
+// a slow consumer here backpressures into whichever tunnel goroutine emitted the line.
+//
+// Note the level check was missing entirely before — sibling subscribeLogcat has always applied
+// one, so `Debugln` output was reaching logcat even at `log-level: info`.
+//
+// Debug builds keep the firehose (minus what the configured level already suppresses), which is
+// what makes `adb logcat` worth reading while developing. Release builds forward warnings, errors
+// and our own "[APP]" breadcrumbs. The in-app log screen is unaffected: it runs off
+// subscribeLogcat, which does its own filtering.
+func shouldForwardToLogcat(msg log.Event) bool {
+	if strings.HasPrefix(msg.Payload, "[APP]") {
+		return true
+	}
+
+	if msg.LogLevel < log.Level() {
+		return false
+	}
+
+	return app.DebugBuild() || msg.LogLevel >= log.WARNING
+}
+
 func init() {
 	go func() {
 		sub := log.Subscribe()
 		defer log.UnSubscribe(sub)
 
 		for msg := range sub {
+			if !shouldForwardToLogcat(msg) {
+				continue
+			}
+
 			cPayload := C.CString(msg.Payload)
 
 			switch msg.LogLevel {

--- a/core/src/main/golang/native/main.go
+++ b/core/src/main/golang/native/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"runtime/debug"
 
+	"cfa/native/app"
 	"cfa/native/config"
 	"cfa/native/delegate"
 	"cfa/native/tunnel"
@@ -23,12 +24,15 @@ func main() {
 }
 
 //export coreInit
-func coreInit(home, versionName, gitVersion C.c_string, sdkVersion C.int) {
+func coreInit(home, versionName, gitVersion C.c_string, sdkVersion C.int, debug C.int) {
 	defer guard("coreInit")()
 	h := C.GoString(home)
 	v := C.GoString(versionName)
 	g := C.GoString(gitVersion)
 	s := int(sdkVersion)
+
+	// Set before delegate.Init so the very first core log lines are already gated correctly.
+	app.ApplyDebugBuild(debug != 0)
 
 	delegate.Init(h, v, g, s)
 

--- a/core/src/main/golang/native/tunnel.go
+++ b/core/src/main/golang/native/tunnel.go
@@ -136,6 +136,26 @@ func healthCheckAll() {
 	tunnel.HealthCheckAll()
 }
 
+//export healthCheckAutoGroups
+func healthCheckAutoGroups(completable unsafe.Pointer) {
+	go func() {
+		completed := false
+		defer func() {
+			if r := recover(); r != nil {
+				logRecover("healthCheckAutoGroups", r)
+				if !completed {
+					C.complete(completable, marshalString(fmt.Sprintf("native panic: %v", r)))
+				}
+			}
+		}()
+
+		tunnel.HealthCheckAutoGroups()
+
+		C.complete(completable, nil)
+		completed = true
+	}()
+}
+
 //export patchSelector
 func patchSelector(selector, name C.c_string) C.int {
 	defer guard("patchSelector")()

--- a/core/src/main/golang/native/tunnel/connectivity.go
+++ b/core/src/main/golang/native/tunnel/connectivity.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
 	"github.com/metacubex/mihomo/common/utils"
+	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/constant/provider"
 	"github.com/metacubex/mihomo/log"
 	"github.com/metacubex/mihomo/tunnel"
@@ -122,6 +123,92 @@ func HealthCheckAll() {
 			HealthCheck(group)
 		}(g)
 	}
+}
+
+// selfRoutingGroup reports whether a group picks its own outbound and therefore
+// gains something from a forced probe. `select` groups don't: the user pinned a
+// node by hand and the group will keep using it no matter what the probe says,
+// so testing them only burns radio for delay numbers nobody is looking at (the
+// screen is usually off when this runs). Relay is a fixed chain, same story.
+func selfRoutingGroup(t C.AdapterType) bool {
+	switch t {
+	case C.URLTest, C.Fallback, C.LoadBalance:
+		return true
+	default:
+		return false
+	}
+}
+
+// HealthCheckAutoGroups probes exactly what a default-network switch can actually
+// re-route: the url-test / fallback / load-balance groups, each backing provider
+// hit exactly once.
+//
+// This replaces "walk every group name and call HealthCheck on it", which was
+// doubly wasteful. First, it included `select` and relay groups, which cannot
+// re-route (see selfRoutingGroup). Second, and worse, HealthCheck(group) probes
+// every provider *of that group*, so a provider shared by N groups — the normal
+// shape of a subscription where several groups `use:` the same provider — was
+// url-tested N times, meaning every node in it was dialed N times per switch.
+// mihomo's own singledo only dedups concurrent checks *within* one provider, so
+// it could not save us here.
+//
+// Deduplication is by provider name, which is safe: mihomo keeps providers in a
+// map keyed by name (tunnel.Providers()), so names are unique by construction.
+//
+// Note what this does NOT dedup: two groups that each inline their own `proxies:`
+// list get two distinct compatible providers, and a node listed in both is still
+// probed twice. Deduplicating down to individual nodes would mean running URLTest
+// ourselves instead of provider.HealthCheck(), which would silently drop the extra
+// health-check URLs that groups register on a shared provider (HealthCheck.extra)
+// — a correctness loss for a smaller win. Left as is deliberately.
+//
+// Returns (groups probed, providers probed) for logging.
+func HealthCheckAutoGroups() (int, int) {
+	seen := make(map[string]struct{})
+	targets := make([]provider.ProxyProvider, 0, 4)
+	groups := 0
+
+	proxies := tunnel.Proxies()
+
+	for _, name := range QueryAllProxyGroupNamesIncludingHidden() {
+		p := proxies[name]
+		if p == nil || !selfRoutingGroup(p.Type()) {
+			continue
+		}
+
+		g, ok := p.Adapter().(outboundgroup.ProxyGroup)
+		if !ok {
+			continue
+		}
+
+		groups++
+
+		for _, prov := range g.Providers() {
+			if _, dup := seen[prov.Name()]; dup {
+				continue
+			}
+			seen[prov.Name()] = struct{}{}
+			targets = append(targets, prov)
+		}
+	}
+
+	wg := &sync.WaitGroup{}
+
+	for _, prov := range targets {
+		wg.Add(1)
+
+		go func(pr provider.ProxyProvider) {
+			defer wg.Done()
+
+			pr.HealthCheck()
+		}(prov)
+	}
+
+	wg.Wait()
+
+	log.Infoln("[APP] Network switch health check: %d self-routing groups -> %d providers", groups, len(targets))
+
+	return groups, len(targets)
 }
 
 // CancelHealthChecks cancels the health-check context of every live proxy provider (subscription

--- a/core/src/main/java/com/github/kr328/clash/core/Clash.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/Clash.kt
@@ -197,6 +197,19 @@ object Clash {
         Bridge.nativeHealthCheckAll()
     }
 
+    /**
+     * Probe only the groups that can re-route on their own (url-test / fallback /
+     * load-balance), hitting each backing provider exactly once. Used on a
+     * default-network switch, where the old "health-check every group name" walk
+     * re-tested a shared provider once per group referencing it.
+     * See tunnel.HealthCheckAutoGroups.
+     */
+    fun healthCheckAutoGroups(): CompletableDeferred<Unit> {
+        return CompletableDeferred<Unit>().apply {
+            Bridge.nativeHealthCheckAutoGroups(this)
+        }
+    }
+
     fun patchSelector(selector: String, name: String): Boolean {
         return Bridge.nativePatchSelector(selector, name)
     }

--- a/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/bridge/Bridge.kt
@@ -1,5 +1,6 @@
 package com.github.kr328.clash.core.bridge
 
+import android.content.pm.ApplicationInfo
 import android.os.Build
 import android.os.ParcelFileDescriptor
 import androidx.annotation.Keep
@@ -30,6 +31,7 @@ object Bridge {
     external fun nativeHealthCheck(completable: CompletableDeferred<Unit>, name: String)
     external fun nativeHealthCheckWithCallback(callback: ProxyDelayCallback, name: String, testUrl: String)
     external fun nativeHealthCheckAll()
+    external fun nativeHealthCheckAutoGroups(completable: CompletableDeferred<Unit>)
     external fun nativePatchSelector(selector: String, name: String): Boolean
     external fun nativeFetchAndValid(
         completable: FetchCallback,
@@ -76,7 +78,7 @@ object Bridge {
     external fun nativeSubscribeLogcat(callback: LogcatInterface)
     external fun nativeCoreVersion(): String
 
-    private external fun nativeInit(home: String, versionName: String, sdkVersion: Int)
+    private external fun nativeInit(home: String, versionName: String, sdkVersion: Int, debug: Boolean)
 
     init {
         System.loadLibrary("bridge")
@@ -89,9 +91,13 @@ object Bridge {
         val home = ctx.filesDir.resolve("clash").apply { mkdirs() }.absolutePath
         val versionName = ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName ?: "unknown"
         val sdkVersion = Build.VERSION.SDK_INT
+        // Gates how much of the engine's log bus is mirrored into logcat: everything while
+        // developing, warnings and errors only in release. Read off the installed app rather than
+        // BuildConfig so the core module doesn't need one. See shouldForwardToLogcat.
+        val debuggable = (ctx.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 
         Log.d("Home = $home")
 
-        nativeInit(home, versionName, sdkVersion)
+        nativeInit(home, versionName, sdkVersion, debuggable)
     }
 }

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkObserveModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkObserveModule.kt
@@ -54,8 +54,25 @@ class NetworkObserveModule(service: Service) : Module<Network?>(service) {
         @Volatile var losingMs: Long = 0,
         @Volatile var dnsList: List<InetAddress> = emptyList(),
         @Volatile var capabilities: NetworkCapabilities? = null,
+        /** Last [routingSignature] we acted on, so pure signal/bandwidth chirps can be dropped. */
+        @Volatile var routingSignature: String? = null,
     ) {
         fun isAvailable(): Boolean = losingMs < System.currentTimeMillis()
+    }
+
+    /**
+     * The part of a network's capabilities that can change where traffic should go. Cellular
+     * connections report onCapabilitiesChanged constantly as link bandwidth and signal strength
+     * are re-estimated; every one of those used to wake the module, burn a 180ms coalescing
+     * window and cost a getLinkProperties IPC, only for the DNS list to come back identical.
+     */
+    private fun NetworkCapabilities.routingSignature(): String {
+        val transports = TRACKED_TRANSPORTS.filter(::hasTransport).joinToString(",")
+        val validated = hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        val notVpn = hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+        val notRestricted = hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
+
+        return "$transports|$validated|$notVpn|$notRestricted"
     }
 
     private val networkInfos = ConcurrentHashMap<Network, NetworkInfo>()
@@ -95,8 +112,19 @@ class NetworkObserveModule(service: Service) : Module<Network?>(service) {
         }
 
         override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+            val info = networkInfos[network]
+            // Always keep the freshest capabilities — networkToInt() prioritises networks off them.
+            info?.capabilities = networkCapabilities
+
+            val signature = runCatching { networkCapabilities.routingSignature() }.getOrNull()
+            if (info != null && signature != null && signature == info.routingSignature) {
+                // Bandwidth/signal chirp on an otherwise unchanged network: nothing downstream
+                // can act on it, so don't wake the select loop for it.
+                return
+            }
+            info?.routingSignature = signature
+
             Log.i("NetworkObserve onCapabilitiesChanged")
-            networkInfos[network]?.capabilities = networkCapabilities
             networks.trySend(network)
         }
 
@@ -272,27 +300,19 @@ class NetworkObserveModule(service: Service) : Module<Network?>(service) {
         service.sendConnectionsChanged()
         Log.i("NetworkObserve preferred network switched -> $network: closed $closed stale connections")
 
+        // Probe only what a switch can actually re-route, with each provider hit once. The
+        // previous version health-checked EVERY group name including hidden ones, which
+        // re-tested a shared provider once per referencing group — on a normal subscription
+        // that is the same nodes dialed 5-15x per switch, screen off included. Closing the
+        // stale connections above is what actually fixes "VPN on, nothing loads"; the probe
+        // only shortens the window before auto groups converge. See Clash.healthCheckAutoGroups.
         launch {
             try {
-                val groups = Clash.queryAllGroupNamesIncludingHidden()
-                val checks = groups.map { it to Clash.healthCheck(it) }
-                var failures = 0
-                checks.forEach { (name, check) ->
-                    try {
-                        check.await()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        failures++
-                        Log.w("NetworkObserve health check failed for group $name", e)
-                    }
-                }
-
-                Log.i("NetworkObserve health checks completed: ${groups.size - failures}/${groups.size}")
+                Clash.healthCheckAutoGroups().await()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Log.w("NetworkObserve could not start group health checks", e)
+                Log.w("NetworkObserve auto-group health check failed", e)
             }
             service.sendConnectionsChanged()
         }
@@ -358,6 +378,26 @@ class NetworkObserveModule(service: Service) : Module<Network?>(service) {
 
                 Log.i("NetworkObserve dns = []")
                 Clash.notifyDnsChanged(emptyList())
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * Transports that change how traffic is routed. Kept in sync with the ones
+         * [networkToInt] scores; anything else lands in its `else` bucket anyway.
+         */
+        private val TRACKED_TRANSPORTS = buildList {
+            add(NetworkCapabilities.TRANSPORT_WIFI)
+            add(NetworkCapabilities.TRANSPORT_ETHERNET)
+            add(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+            add(NetworkCapabilities.TRANSPORT_CELLULAR)
+            add(NetworkCapabilities.TRANSPORT_VPN)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                add(NetworkCapabilities.TRANSPORT_USB)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                add(NetworkCapabilities.TRANSPORT_SATELLITE)
             }
         }
     }

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkSwitchReactionGate.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/NetworkSwitchReactionGate.kt
@@ -9,7 +9,18 @@ internal data class NetworkSwitchReactionDecision<T : Any>(
 internal class NetworkSwitchReactionGate<T : Any>(
     private val startedAt: Long,
     private val startupGraceMs: Long = 5_000L,
-    private val flapGuardMs: Long = 3_000L,
+    /**
+     * Minimum spacing between two full reactions, nudged 3s -> 5s so a single network change
+     * that arrives as a burst of callbacks (available -> losing -> capabilities, which can
+     * straggle over a couple of seconds) reacts once instead of twice.
+     *
+     * Deliberately NOT larger. A wider guard was tried while chasing a battery report, on the
+     * theory that repeated reactions were burning radio; measurement showed the drain came from
+     * the subscription's own url-test timers, not from here, and stretching the guard only made
+     * the phone slower to recover after a real Wi-Fi <-> cellular switch — the exact wait this
+     * feature exists to remove.
+     */
+    private val flapGuardMs: Long = 5_000L,
 ) {
     private var initialized = false
     private var observed: T? = null

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/SpeedWidgetModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/SpeedWidgetModule.kt
@@ -29,25 +29,22 @@ class SpeedWidgetModule(service: Service) : Module<Unit>(service) {
     private val widgetManager = AppWidgetManager.getInstance(service)
 
     private var widgetsPresent = false
-    private var tickCounter = 0
 
     /**
-     * Widgets are rarely added/removed, so re-check presence only every ~30 fast ticks (~30s)
-     * instead of an AppWidgetManager IPC every second — needless battery otherwise. A newly-added
-     * widget still renders immediately via the provider's onUpdate; live frames catch up here. (O-05)
+     * Widgets are rarely added or removed, so this AppWidgetManager IPC is only worth running on
+     * the slow path — screen-on, profile-loaded, and every idle tick (~30s). A newly-added widget
+     * still renders immediately via the provider's onUpdate; live frames catch up here. (O-05)
      */
-    private fun widgetsPresent(): Boolean {
-        if (tickCounter % 30 == 0) {
-            widgetsPresent = runCatching {
-                widgetManager.getAppWidgetIds(SpeedWidgetRenderer.provider(service)).isNotEmpty()
-            }.getOrDefault(false)
-        }
-        tickCounter++
+    private fun refreshWidgetsPresent(): Boolean {
+        widgetsPresent = runCatching {
+            widgetManager.getAppWidgetIds(SpeedWidgetRenderer.provider(service)).isNotEmpty()
+        }.getOrDefault(false)
+
         return widgetsPresent
     }
 
     private fun push(running: Boolean) {
-        if (!widgetsPresent()) return
+        if (!widgetsPresent) return
         val now = if (running) Clash.queryTrafficNow() else 0L
         SpeedWidgetRenderer.renderAll(
             service,
@@ -71,6 +68,7 @@ class SpeedWidgetModule(service: Service) : Module<Unit>(service) {
         val tickerFast = ticker(TimeUnit.SECONDS.toMillis(1))
         val tickerIdle = ticker(TimeUnit.SECONDS.toMillis(30))
 
+        refreshWidgetsPresent()
         push(running = true)
 
         try {
@@ -78,17 +76,34 @@ class SpeedWidgetModule(service: Service) : Module<Unit>(service) {
                 select<Unit> {
                     screenToggle.onReceive {
                         interactive = it.action == Intent.ACTION_SCREEN_ON
-                        if (interactive) push(running = true)
+                        if (interactive) {
+                            refreshWidgetsPresent()
+                            push(running = true)
+                        }
                     }
-                    profileLoaded.onReceive { push(running = true) }
-                    if (interactive) {
+                    profileLoaded.onReceive {
+                        refreshWidgetsPresent()
+                        push(running = true)
+                    }
+                    // The 1s ticker only earns its wakeups when a widget is actually on a home
+                    // screen to receive the frames. Most installs have none, and waking a service
+                    // coroutine every second for the whole time the screen is on to discover that
+                    // again is pure battery. Falling back to the idle ticker keeps re-checking
+                    // presence every ~30s, so a widget added later is picked up on its own.
+                    if (interactive && widgetsPresent) {
                         tickerFast.onReceive { push(running = true) }
                     } else {
-                        tickerIdle.onReceive { push(running = true) }
+                        tickerIdle.onReceive {
+                            refreshWidgetsPresent()
+                            push(running = true)
+                        }
                     }
                 }
             }
         } finally {
+            // Re-check rather than trusting the cached flag: the final "not running" frame is the
+            // one the user is left looking at, so it must reach a widget added since the last poll.
+            refreshWidgetsPresent()
             push(running = false)
         }
     }

--- a/service/src/test/java/com/github/kr328/clash/service/clash/module/NetworkSwitchReactionGateTest.kt
+++ b/service/src/test/java/com/github/kr328/clash/service/clash/module/NetworkSwitchReactionGateTest.kt
@@ -7,6 +7,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NetworkSwitchReactionGateTest {
+    /**
+     * The flap-window tests below pin the guard explicitly so they exercise the mechanism
+     * rather than whatever the shipped default happens to be; [defaultFlapGuardSpacesReactions]
+     * is the one that pins the default itself.
+     */
+    private val testFlapGuardMs = 3_000L
+
     @Test
     fun initialObservationAndStartupChangesDoNotReact() {
         val gate = NetworkSwitchReactionGate<String>(startedAt = 1_000L)
@@ -31,7 +38,7 @@ class NetworkSwitchReactionGateTest {
 
     @Test
     fun switchInsideFlapWindowGetsGuaranteedRetry() {
-        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L)
+        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L, flapGuardMs = testFlapGuardMs)
         gate.observe("wifi", now = 0L, enabled = true)
         gate.observe("cellular", now = 5_000L, enabled = true)
 
@@ -46,7 +53,7 @@ class NetworkSwitchReactionGateTest {
 
     @Test
     fun newerCandidateReplacesDeferredCandidate() {
-        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L)
+        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L, flapGuardMs = testFlapGuardMs)
         gate.observe("wifi-a", now = 0L, enabled = true)
         gate.observe("cellular", now = 5_000L, enabled = true)
         gate.observe("wifi-a", now = 7_000L, enabled = true)
@@ -60,7 +67,7 @@ class NetworkSwitchReactionGateTest {
 
     @Test
     fun returningToSettledNetworkCancelsDeferredReaction() {
-        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L)
+        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L, flapGuardMs = testFlapGuardMs)
         gate.observe("wifi", now = 0L, enabled = true)
         gate.observe("cellular", now = 5_000L, enabled = true)
 
@@ -76,7 +83,7 @@ class NetworkSwitchReactionGateTest {
 
     @Test
     fun airplaneModeCancelsRetryAndRecoveryReacts() {
-        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L)
+        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L, flapGuardMs = testFlapGuardMs)
         gate.observe("wifi", now = 0L, enabled = true)
         gate.observe("cellular", now = 5_000L, enabled = true)
         gate.observe("wifi", now = 7_000L, enabled = true)
@@ -87,6 +94,24 @@ class NetworkSwitchReactionGateTest {
 
         val recovered = gate.observe("cellular", now = 8_000L, enabled = true)
         assertEquals("cellular", recovered.reaction)
+    }
+
+    /**
+     * The shipped guard is 5s: long enough that one network change arriving as a burst of
+     * callbacks reacts once, short enough that a genuine Wi-Fi <-> cellular switch is not left
+     * waiting. Pinned here because the value is a deliberate trade-off, not an arbitrary number.
+     */
+    @Test
+    fun defaultFlapGuardSpacesReactions() {
+        val gate = NetworkSwitchReactionGate<String>(startedAt = 0L)
+        gate.observe("wifi", now = 0L, enabled = true)
+        gate.observe("cellular", now = 5_000L, enabled = true)
+
+        val tooSoon = gate.observe("wifi", now = 7_000L, enabled = true)
+        assertNull(tooSoon.reaction)
+        assertEquals(3_000L, tooSoon.retryAfterMs)
+
+        assertEquals("wifi", gate.retry("wifi", now = 10_000L, enabled = true).reaction)
     }
 
     @Test


### PR DESCRIPTION
Sweep of background-service work, plus device measurements on a Pixel 7 Pro / Nothing Phone 4a Pro / Moto Razr 40

- **Network-switch reaction**: probe only url-test/fallback/load-balance groups, each backing provider once (was: every group, provider re-tested per referencing group). Flap guard 3s -> 5s.
- **Core log bridge**: apply a level filter (there was none - engine `Debugln`, including resolved domain names, reached logcat on release) and forward only WARN/ERROR outside debug builds. 537 log lines per idle minute -> 0.
- **Speed widget**: stop the 1Hz ticker when no widget exists.
- **Capability chirps**: ignore ones that do not change routing.


Bench-verified only: build + unit tests green, switch reaction reports `2 self-routing groups -> 2 providers` on device. No field soak yet.