### PR TITLE
feat(settings): optional subscription refresh before connecting

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -1553,6 +1553,10 @@ class MainActivity : BaseActivity<MainDesign>() {
     }
 
     private fun shouldAutoRefreshBeforeStart(profile: Profile): Boolean {
+        // Opt-out (#197): people on flaky or slow panels would rather connect now with the config
+        // they already have than wait on a refresh they did not ask for. Scheduled updates
+        // (ProfileReceiver alarms) are unaffected — this only governs the Connect tap.
+        if (!uiStore.updateProfileBeforeConnect) return false
         if (profile.type != Profile.Type.Url || profile.source.isBlank()) return false
         val now = System.currentTimeMillis()
         val last = profile.updatedAt.takeIf { it > 0L } ?: return true

--- a/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/AppSettingsDesign.kt
@@ -46,6 +46,13 @@ class AppSettingsDesign(
                 summary = R.string.allow_clash_auto_restart,
             )
 
+            switch(
+                value = uiStore::updateProfileBeforeConnect,
+                icon = R.drawable.ic_baseline_update,
+                title = R.string.update_before_connect_title,
+                summary = R.string.update_before_connect_summary,
+            )
+
             category(R.string.interface_)
 
             selectableList(

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -92,6 +92,18 @@ class UiStore(context: Context) {
         defaultValue = false,
     )
 
+    /**
+     * Whether tapping Connect may refresh a stale subscription first (#197).
+     *
+     * ON by default — that is the behaviour every existing install already has, and a silently
+     * stale subscription is the worse failure mode for most people. Turning it off makes Connect
+     * start the saved config immediately; the profile still refreshes on its own schedule.
+     */
+    var updateProfileBeforeConnect: Boolean by store.boolean(
+        key = "update_profile_before_connect",
+        defaultValue = true,
+    )
+
     /** Experimental gate for the per-profile DNS & Hosts editor (OFF by default). */
     var dnsHostsEnabled: Boolean by store.boolean(
         key = "dns_hosts_enabled",

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -510,6 +510,8 @@
 
     <string name="auto_restart">Автоматический перезапуск</string>
     <string name="allow_clash_auto_restart">Разрешить Clash автоматически перезапускаться</string>
+    <string name="update_before_connect_title">Обновлять подписку перед подключением</string>
+    <string name="update_before_connect_summary">Обновлять устаревшую подписку при нажатии «Подключить». Выключите, чтобы подключаться сразу с сохранённой конфигурацией — обновления по расписанию продолжат работать.</string>
 
     <string name="route_system_traffic">Маршрутизировать системный трафик</string>
     <string name="routing_via_vpn_service">Автоматически маршрутизировать весь системный трафик через VPN</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -134,6 +134,8 @@
     <string name="show_traffic_summary">在通知中自动刷新流量</string>
     <string name="allow_clash_auto_restart">允许 Clash 自动重启</string>
     <string name="auto_restart">自动重启</string>
+    <string name="update_before_connect_title">连接前更新订阅</string>
+    <string name="update_before_connect_summary">点击“连接”时刷新过期的订阅。关闭后将直接使用已保存的配置连接 — 定时更新仍会照常运行。</string>
     <string name="stopped">已停止</string>
     <string name="help">帮助</string>
     <string name="tap_to_start">点此启动</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -656,6 +656,8 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
 
     <string name="auto_restart">Auto Restart</string>
     <string name="allow_clash_auto_restart">Allow clash auto restart</string>
+    <string name="update_before_connect_title">Update subscription before connecting</string>
+    <string name="update_before_connect_summary">Refresh a stale subscription when you tap Connect. Turn off to connect straight away with the saved config — scheduled updates still run.</string>
 
     <string name="route_system_traffic">Route System Traffic</string>
     <string name="routing_via_vpn_service">Auto routing all system traffic via VpnService</string>


### PR DESCRIPTION
Closes #197.

Tapping Connect refreshed a stale subscription first — `shouldAutoRefreshBeforeStart` fires when the profile is older than its own `interval`, or 12h when none is set. On a slow or flaky panel that is a wait nobody asked for, in front of the one action they did ask for.

- New global switch under Settings -> App -> Behavior: *Update subscription before connecting*.
- ON by default, so existing installs keep todays behaviour.
- Off means Connect starts the saved config immediately. Scheduled updates (ProfileReceiver alarms) are untouched.
- Strings for en / ru / zh.

No per-profile variant: profiles already carry their own `interval`, so a DB column and migration for a second way to say the same thing is not worth it.