### PR TITLE
feat(theme): let the user pick the UI font weight

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/BaseActivity.kt
@@ -309,6 +309,15 @@ abstract class BaseActivity<D : Design<*>> : AppCompatActivity(),
             // widgets unambiguously neutral — and re-applies TrueBlack surfaces when pure-black is on
             // (otherwise the neutral pin leaves grey cards on the black canvas).
             com.github.kr328.clash.design.branding.BrandThemeApplier.applyToActivity(this)
+
+            // Font weight last (#195), so the chosen face beats the base theme's. Sloth is skipped
+            // for the same reason it skips palette / dynamic-color / true-black above: it is a
+            // self-contained look. Mirrored in BrandThemeApplier.themedContextFor for MainActivity.
+            if (uiStore.homeBackgroundStyle != HomeBackgroundStyle.Sloth) {
+                com.github.kr328.clash.design.branding.BrandThemeApplier
+                    .fontWeightOverlay(uiStore.themeFontWeight)
+                    ?.let { theme.applyStyle(it, true) }
+            }
         }
 
         applyWindowAppearance(this)

--- a/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/ThemeSettingsDesign.kt
@@ -13,6 +13,7 @@ import com.github.kr328.clash.design.databinding.DesignThemeSettingsBinding
 import com.github.kr328.clash.design.model.DarkMode
 import com.github.kr328.clash.design.model.HomeBackgroundStyle
 import com.github.kr328.clash.design.model.ThemePalette
+import com.github.kr328.clash.design.model.ThemeFontWeight
 import com.github.kr328.clash.design.model.ThemeTextScale
 import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.design.util.layoutInflater
@@ -63,6 +64,7 @@ class ThemeSettingsDesign(
         setupPalettes()
         setupTrueBlack()
         setupTextScale()
+        setupFontWeight()
         setupHomeBackground()
         setupReset()
     }
@@ -407,6 +409,27 @@ class ThemeSettingsDesign(
                 R.id.text_scale_large -> ThemeTextScale.Large
                 R.id.text_scale_extra -> ThemeTextScale.ExtraLarge
                 else -> ThemeTextScale.Default
+            }
+            recreateAll()
+        }
+    }
+
+    private fun setupFontWeight() {
+        binding.fontWeightGroup.check(
+            when (uiStore.themeFontWeight) {
+                ThemeFontWeight.Default -> R.id.font_weight_default
+                ThemeFontWeight.Medium -> R.id.font_weight_medium
+                ThemeFontWeight.SemiBold -> R.id.font_weight_semibold
+                ThemeFontWeight.Bold -> R.id.font_weight_bold
+            }
+        )
+        binding.fontWeightGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (!isChecked) return@addOnButtonCheckedListener
+            uiStore.themeFontWeight = when (checkedId) {
+                R.id.font_weight_medium -> ThemeFontWeight.Medium
+                R.id.font_weight_semibold -> ThemeFontWeight.SemiBold
+                R.id.font_weight_bold -> ThemeFontWeight.Bold
+                else -> ThemeFontWeight.Default
             }
             recreateAll()
         }

--- a/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/branding/BrandThemeApplier.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.view.ContextThemeWrapper
 import com.github.kr328.clash.design.R
 import com.github.kr328.clash.design.model.HomeBackgroundStyle
+import com.github.kr328.clash.design.model.ThemeFontWeight
 import com.github.kr328.clash.design.model.ThemePalette
 import com.github.kr328.clash.design.store.UiStore
 import com.google.android.material.color.DynamicColors
@@ -189,6 +190,17 @@ object BrandThemeApplier {
             ctx
         }
 
+        // Font weight last, so it wins over the base theme's face (#195). Skipped on Sloth, which
+        // owns its own typography. When nothing above produced a wrapper we must make one rather
+        // than applyStyle onto the Activity: MainActivity keeps its Activity theme deliberately
+        // virgin so a soft recreate can re-derive the whole chain.
+        val fontOverlay = if (sloth) null else fontWeightOverlay(uiStore.themeFontWeight)
+        val themedWithFont: Context = when {
+            fontOverlay == null -> themed
+            themed === activity -> ContextThemeWrapper(activity, fontOverlay)
+            else -> themed.apply { theme.applyStyle(fontOverlay, true) }
+        }
+
         // What the wrapper actually carries — owned contract shared with applyToActivity.
         store.lastAppliedAccent = if (brandSeed != null) brandHex else ""
         if (brandSeed != null) {
@@ -196,7 +208,7 @@ object BrandThemeApplier {
                 "BrandThemeApplier: themed wrapper carries brand accent=$brandHex",
             )
         }
-        return themed
+        return themedWithFont
     }
 
     /**
@@ -286,6 +298,20 @@ object BrandThemeApplier {
         ThemePalette.Amber -> if (night) R.style.ThemeOverlay_ClashFest_PaletteAmber_Dark else R.style.ThemeOverlay_ClashFest_PaletteAmber_Light
         ThemePalette.Mint -> if (night) R.style.ThemeOverlay_ClashFest_PaletteMint_Dark else R.style.ThemeOverlay_ClashFest_PaletteMint_Light
         ThemePalette.Graphite -> if (night) R.style.ThemeOverlay_ClashFest_PaletteGraphite_Dark else R.style.ThemeOverlay_ClashFest_PaletteGraphite_Light
+    }
+
+    /**
+     * Theme overlay for the user's font-weight choice (#195), or null when nothing should change.
+     *
+     * Null for [ThemeFontWeight.Default] so the shipped theme is untouched for anyone who never
+     * opens the setting. Callers must skip this entirely on the Sloth skin — it carries its own
+     * face, like it carries its own colors.
+     */
+    fun fontWeightOverlay(weight: ThemeFontWeight): Int? = when (weight) {
+        ThemeFontWeight.Default -> null
+        ThemeFontWeight.Medium -> R.style.ThemeOverlay_ClashFest_Font_Medium
+        ThemeFontWeight.SemiBold -> R.style.ThemeOverlay_ClashFest_Font_SemiBold
+        ThemeFontWeight.Bold -> R.style.ThemeOverlay_ClashFest_Font_Bold
     }
 
     private val HEX_COLOR = Regex("^#[0-9A-Fa-f]{6}$")

--- a/design/src/main/java/com/github/kr328/clash/design/model/ThemeFontWeight.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/model/ThemeFontWeight.kt
@@ -1,0 +1,23 @@
+package com.github.kr328.clash.design.model
+
+/**
+ * User-selected weight for the app's UI font (#195 — "the current font is too thin for me").
+ *
+ * All three bundled faces are variable fonts, so a heavier weight costs no extra assets: the
+ * font-family resources behind [Medium]/[SemiBold]/[Bold] point at the same `.ttf` and only differ
+ * in `fontVariationSettings`. [Default] applies no overlay at all, which keeps the theme exactly as
+ * it ships for everyone who never touches this.
+ *
+ * `fontVariationSettings` needs API 26. Below that the resource still resolves — the attribute is
+ * ignored — so old devices render the regular weight instead of crashing. The setting simply has no
+ * visible effect there.
+ *
+ * The SlothClash skin is deliberately excluded (it owns its own look, same way it bypasses palette,
+ * dynamic color and true-black), so this only ever overrides the Manrope-based default themes.
+ */
+enum class ThemeFontWeight(val weight: Int) {
+    Default(400),
+    Medium(500),
+    SemiBold(600),
+    Bold(700),
+}

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -9,6 +9,7 @@ import com.github.kr328.clash.design.model.AppLanguage
 import com.github.kr328.clash.design.model.DarkMode
 import com.github.kr328.clash.design.model.HomeBackgroundStyle
 import com.github.kr328.clash.design.model.ProfileSortMode
+import com.github.kr328.clash.design.model.ThemeFontWeight
 import com.github.kr328.clash.design.model.ThemePalette
 import com.github.kr328.clash.design.model.ThemeTextScale
 
@@ -67,6 +68,13 @@ class UiStore(context: Context) {
         key = "theme_text_scale",
         defaultValue = ThemeTextScale.Default,
         values = ThemeTextScale.values(),
+    )
+
+    /** UI font weight (#195). See [ThemeFontWeight] for the variable-font / API 26 caveats. */
+    var themeFontWeight: ThemeFontWeight by store.enum(
+        key = "theme_font_weight",
+        defaultValue = ThemeFontWeight.Default,
+        values = ThemeFontWeight.values(),
     )
 
     /** User-selected app language; `System` follows the device locale. */

--- a/design/src/main/res/font/manrope_bold.xml
+++ b/design/src/main/res/font/manrope_bold.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Same Manrope variable file as @font/manrope, pinned to wght 700 (#195).
+  fontVariationSettings is API 26+; older devices ignore it and render the regular weight.
+-->
+<font-family xmlns:android="http://schemas.android.com/apk/res/android">
+    <font
+        android:font="@font/manrope"
+        android:fontStyle="normal"
+        android:fontVariationSettings="'wght' 700"
+        android:fontWeight="700" />
+</font-family>

--- a/design/src/main/res/font/manrope_medium.xml
+++ b/design/src/main/res/font/manrope_medium.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Same Manrope variable file as @font/manrope, pinned to wght 500 (#195).
+  fontVariationSettings is API 26+; older devices ignore it and render the regular weight.
+-->
+<font-family xmlns:android="http://schemas.android.com/apk/res/android">
+    <font
+        android:font="@font/manrope"
+        android:fontStyle="normal"
+        android:fontVariationSettings="'wght' 500"
+        android:fontWeight="500" />
+</font-family>

--- a/design/src/main/res/font/manrope_semibold.xml
+++ b/design/src/main/res/font/manrope_semibold.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Same Manrope variable file as @font/manrope, pinned to wght 600 (#195).
+  fontVariationSettings is API 26+; older devices ignore it and render the regular weight.
+-->
+<font-family xmlns:android="http://schemas.android.com/apk/res/android">
+    <font
+        android:font="@font/manrope"
+        android:fontStyle="normal"
+        android:fontVariationSettings="'wght' 600"
+        android:fontWeight="600" />
+</font-family>

--- a/design/src/main/res/layout/design_theme_settings.xml
+++ b/design/src/main/res/layout/design_theme_settings.xml
@@ -200,6 +200,60 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
+                    android:text="@string/theme_font_weight"
+                    android:textAppearance="@style/TextAppearance.App.TitleMedium"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/font_weight_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:layout_marginTop="12dp"
+                    app:selectionRequired="true"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/font_weight_default"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/theme_font_weight_default"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/font_weight_medium"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/theme_font_weight_medium"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/font_weight_semibold"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/theme_font_weight_semibold"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/font_weight_bold"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/theme_font_weight_bold"
+                        android:textAllCaps="false" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
                     android:text="@string/home_background"
                     android:textAppearance="@style/TextAppearance.App.TitleMedium"
                     android:textColor="?attr/colorOnSurface"

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="theme_text_default">100%</string>
     <string name="theme_text_large">110%</string>
     <string name="theme_text_extra">120%</string>
+    <string name="theme_font_weight">Насыщенность шрифта</string>
+    <string name="theme_font_weight_default">Обычный</string>
+    <string name="theme_font_weight_medium">Средний</string>
+    <string name="theme_font_weight_semibold">Полужирный</string>
+    <string name="theme_font_weight_bold">Жирный</string>
     <string name="theme_reset">Сбросить тему</string>
     <string name="theme_palette_clash">ClashFest</string>
     <string name="theme_palette_blue">Синяя</string>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -1051,6 +1051,11 @@
     <string name="theme_settings">主题</string>
     <string name="theme_text_default">100%</string>
     <string name="theme_text_extra">120%</string>
+    <string name="theme_font_weight">字体粗细</string>
+    <string name="theme_font_weight_default">常规</string>
+    <string name="theme_font_weight_medium">中等</string>
+    <string name="theme_font_weight_semibold">半粗</string>
+    <string name="theme_font_weight_bold">加粗</string>
     <string name="theme_text_large">110%</string>
     <string name="theme_text_scale">文字大小</string>
     <string name="theme_text_small">90%</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -1133,6 +1133,11 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="theme_text_default">100%</string>
     <string name="theme_text_large">110%</string>
     <string name="theme_text_extra">120%</string>
+    <string name="theme_font_weight">Font weight</string>
+    <string name="theme_font_weight_default">Regular</string>
+    <string name="theme_font_weight_medium">Medium</string>
+    <string name="theme_font_weight_semibold">Semibold</string>
+    <string name="theme_font_weight_bold">Bold</string>
     <string name="theme_reset">Reset theme</string>
     <string name="theme_palette_clash">ClashFest</string>
     <string name="theme_palette_blue">Blue</string>

--- a/design/src/main/res/values/themes.xml
+++ b/design/src/main/res/values/themes.xml
@@ -535,6 +535,27 @@
         <item name="fontFamily">@font/nunito</item>
     </style>
 
+    <!--
+      Font-weight overlays (#195). Applied last in the theme chain so the chosen weight wins over
+      the base theme's @font/manrope, and only on the Manrope-based default themes — the SlothClash
+      skin keeps its own Nunito look, exactly as it already opts out of palette / dynamic color /
+      true-black. There is no overlay for ThemeFontWeight.Default: it applies nothing at all.
+    -->
+    <style name="ThemeOverlay_ClashFest_Font_Medium">
+        <item name="android:fontFamily">@font/manrope_medium</item>
+        <item name="fontFamily">@font/manrope_medium</item>
+    </style>
+
+    <style name="ThemeOverlay_ClashFest_Font_SemiBold">
+        <item name="android:fontFamily">@font/manrope_semibold</item>
+        <item name="fontFamily">@font/manrope_semibold</item>
+    </style>
+
+    <style name="ThemeOverlay_ClashFest_Font_Bold">
+        <item name="android:fontFamily">@font/manrope_bold</item>
+        <item name="fontFamily">@font/manrope_bold</item>
+    </style>
+
     <style name="ThemeOverlay_ClashFest_TrueBlack">
         <item name="homeGlowColor">@android:color/transparent</item>
         <item name="android:windowBackground">@color/theme_true_black_bg</item>


### PR DESCRIPTION
Closes #195.

Adds a **Regular / Medium / Semibold / Bold** picker to Theme settings, next to the text-scale control.

**No new font assets** — all bundled faces are variable, so the new font-family resources point at the same `manrope.ttf` and differ only in `fontVariationSettings`. `Default` applies no overlay, so an untouched install keeps a byte-identical theme.

**Applied in both theme chains**: `BaseActivity.applyDayNight` and `BrandThemeApplier.themedContextFor`, otherwise the home screen keeps the old face across soft recreates.

**SlothClash excluded** — it owns its own typography, same as it bypasses palette / dynamic color / true-black.

**Known limit:** `fontVariationSettings` needs API 26; on Android 5-7 the setting switches but the weight does not change (no crash).