### PR TITLE
chore(core): bump mihomo to v1.19.30

### DIFF
--- a/core/src/main/java/com/github/kr328/clash/core/model/Proxy.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/Proxy.kt
@@ -48,8 +48,10 @@ data class Proxy(
         Sudoku(false),
         Masque(false),
         TrustTunnel(false),
+        ShadowQuic(false),
         OpenVPN(false),
         Tailscale(false),
+        ZeroTier(false),
         GostRelay(false),
 
 
@@ -64,11 +66,17 @@ data class Proxy(
         /**
          * Decodes adapter-type names the app does not know yet to [Unknown]
          * instead of throwing. mihomo grows outbound types faster than this
-         * enum tracks them (Rematch arrived in v1.19.28; OpenVPN, Tailscale
-         * and GostRelay were already missing) — with the default enum
-         * serializer a group containing a single member of an untracked type
-         * failed the whole [com.github.kr328.clash.core.Clash.queryGroup]
-         * decode with a SerializationException and blanked the proxy screen.
+         * enum tracks them — with the default enum serializer a group
+         * containing a single member of an untracked type failed the whole
+         * [com.github.kr328.clash.core.Clash.queryGroup] decode with a
+         * SerializationException and blanked the proxy screen.
+         *
+         * The entries above mirror `AdapterType.String()` in the engine
+         * (`core/src/foss/golang/clash/constant/adapters.go`) and are in sync
+         * as of mihomo v1.19.30. Matching is case-insensitive, so only the
+         * spelling has to line up. Re-check that file after every core bump:
+         * an untracked type still works and stays selectable, it just renders
+         * without a protocol chip (`showBadge = typeName != "Unknown"`).
          */
         internal object FallbackSerializer : KSerializer<Type> {
             override val descriptor =

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -696,6 +696,13 @@ class ProfileAdapter(
         return offlinePreviewByProfile[uuid]?.get(name)?.type ?: Proxy.Type.Unknown
     }
 
+    /**
+     * YAML `type:` → [Proxy.Type]. The keys are the engine's **config** spellings from
+     * `adapter/parser.go`, which are not the same as the wire names [Proxy.Type] is
+     * modelled on (`gost-relay` here vs `GostRelay` from `AdapterType.String()`); the
+     * short aliases (`ss`, `hy2`, `wg`, …) are ours, for hand-written configs.
+     * In sync with mihomo v1.19.30 — re-check `parser.go` after every core bump.
+     */
     private fun proxyTypeFromYamlName(raw: String?): Proxy.Type = when (raw?.trim()?.lowercase()) {
         "ss", "shadowsocks" -> Proxy.Type.Shadowsocks
         "ssr", "shadowsocksr" -> Proxy.Type.ShadowsocksR
@@ -708,13 +715,22 @@ class ProfileAdapter(
         "hysteria" -> Proxy.Type.Hysteria
         "hysteria2", "hy2" -> Proxy.Type.Hysteria2
         "tuic" -> Proxy.Type.Tuic
+        "shadowquic" -> Proxy.Type.ShadowQuic
         "wireguard", "wg" -> Proxy.Type.WireGuard
         "ssh" -> Proxy.Type.Ssh
         "mieru" -> Proxy.Type.Mieru
         "anytls" -> Proxy.Type.AnyTLS
+        "sudoku" -> Proxy.Type.Sudoku
         "masque" -> Proxy.Type.Masque
         "trusttunnel" -> Proxy.Type.TrustTunnel
+        "openvpn" -> Proxy.Type.OpenVPN
+        "tailscale" -> Proxy.Type.Tailscale
+        "zerotier" -> Proxy.Type.ZeroTier
+        "gost-relay" -> Proxy.Type.GostRelay
         "direct" -> Proxy.Type.Direct
+        "reject" -> Proxy.Type.Reject
+        "dns" -> Proxy.Type.Dns
+        "rematch" -> Proxy.Type.Rematch
         else -> Proxy.Type.Unknown
     }
 
@@ -2243,14 +2259,22 @@ class ProfileAdapter(
         }
     }
 
+    /**
+     * Keyed on the **enum** name (the caller passes `p.type.name`), so `gostrelay`, not
+     * the config spelling `gost-relay`. Grouping is by protocol family, not by product:
+     * QUIC-based transports share one colour, the tunnel-style outbounds
+     * (wireguard/tailscale/zerotier/openvpn) another, TCP proxy protocols a third.
+     * An unlisted type falls back to grey rather than losing its chip.
+     */
     private fun protocolFamilyColor(typeName: String): Int = when (typeName.lowercase()) {
         "vmess", "vless" -> R.color.proto_vless
         "trojan" -> R.color.proto_trojan
         "hysteria", "hysteria2" -> R.color.proto_hysteria
-        "tuic", "anytls", "masque" -> R.color.proto_tuic
-        "shadowsocks", "shadowsocksr", "snell", "socks5" -> R.color.proto_shadowsocks
-        "http" -> R.color.proto_http
-        "wireguard", "trusttunnel" -> R.color.proto_wireguard
+        "tuic", "anytls", "masque", "shadowquic" -> R.color.proto_tuic
+        "shadowsocks", "shadowsocksr", "snell", "socks5", "mieru", "sudoku", "ssh" ->
+            R.color.proto_shadowsocks
+        "http", "gostrelay" -> R.color.proto_http
+        "wireguard", "trusttunnel", "tailscale", "zerotier", "openvpn" -> R.color.proto_wireguard
         "direct" -> R.color.proto_tcp
         else -> R.color.proto_default
     }

--- a/service/src/main/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreview.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ProxyTransportYamlPreview.kt
@@ -109,14 +109,23 @@ object ProxyTransportYamlPreview {
 
     private val HEX_CHARS = "0123456789abcdef".toCharArray()
 
+    /**
+     * `network:` means "transport" for most outbounds (ws / grpc / h2 / xhttp / tcp), but not for
+     * all of them: on a `zerotier` proxy it is the 16-hex ZeroTier network ID, which otherwise
+     * leaks into the transport chip as e.g. `0123456789ABCDEF`. Keyed on the config spelling
+     * (`adapter/parser.go`), so lowercase `zerotier`.
+     */
+    private fun networkIsTransport(type: String?): Boolean =
+        !type.equals("zerotier", ignoreCase = true)
+
     private fun extractTransportInfo(p: JsonObject): ProxyTransportInfo {
-        val network = boundedMetadata(p.stringField("network"))
+        val type = boundedMetadata(p.stringField("type"))
+        val network = if (networkIsTransport(type)) boundedMetadata(p.stringField("network")) else ""
         val tls = p.booleanField("tls")
         // Reality is signalled by a non-empty reality-opts map, with or without
         // explicit tls: true. Mihomo accepts both forms.
         val realityOpts = p["reality-opts"] as? JsonObject
         val reality = realityOpts != null && realityOpts.isNotEmpty()
-        val type = boundedMetadata(p.stringField("type"))
         return ProxyTransportInfo(
             network = network,
             tls = tls,
@@ -126,11 +135,11 @@ object ProxyTransportYamlPreview {
     }
 
     private fun extractTransportInfoFromRaw(p: Map<*, *>): ProxyTransportInfo {
-        val network = boundedMetadata(p["network"] as? String)
+        val type = boundedMetadata(p["type"] as? String)
+        val network = if (networkIsTransport(type)) boundedMetadata(p["network"] as? String) else ""
         val tls = truthy(p["tls"])
         val realityOpts = p["reality-opts"] as? Map<*, *>
         val reality = realityOpts != null && realityOpts.isNotEmpty()
-        val type = boundedMetadata(p["type"] as? String)
         return ProxyTransportInfo(
             network = network,
             tls = tls,


### PR DESCRIPTION
Bumps the pinned mihomo submodule from v1.19.29 to v1.19.30 and re-syncs both Go modules, then catches our proxy-type tables up with the adapter types the engine now ships.

## Core bump

Submodule `e26714a1` -> `ac017cdd` (exact-match tag `v1.19.30`). Both go.mod labels bumped and dependencies re-synced with `go list -mod=mod -tags foss,with_gvisor,cmfa` under `GOOS=android` (not `go mod tidy`, which cannot take build tags).

The dependency delta is not cosmetic: two brand-new modules (`metacubex/mipstack`, `metacubex/zerotier-go`), plus quic-go 0.59 -> 0.61, sing-tun 0.4.21 -> 0.4.22, bart 0.26 -> 0.29, tls 0.1.7 -> 0.1.8 and a rewritten sniffer.

## Proxy types

v1.19.30 adds a `zerotier` outbound; `shadowquic` had already been missing for a while. Neither crashed anything — `Proxy.Type.FallbackSerializer` decodes unknown adapter types to `Unknown` — but an `Unknown` node renders with **no protocol chip at all** (`showBadge = typeName != "Unknown"`).

Three tables are now in sync with the engine, each against its own source of truth:

- `Proxy.Type` <- `AdapterType.String()` (`constant/adapters.go`) — added `ShadowQuic`, `ZeroTier`
- `proxyTypeFromYamlName` <- `adapter/parser.go` config spellings — added `shadowquic`, `sudoku`, `openvpn`, `tailscale`, `zerotier`, `gost-relay`, `reject`, `dns`, `rematch`
- `protocolFamilyColor` — new families grouped with their relatives

Note the two spellings differ on purpose: the wire name is `GostRelay`, the config name is `gost-relay`, and `protocolFamilyColor` is keyed on the enum name, so `gostrelay`.

## Verification

- `go test ./native/snapshot/...` against the new core: ok
- Gradle build green, 247 service unit tests, 0 failures
- On device (Android 13): `Init core ... gitVersion: v1.19.30_a5fd5dd`, clean cold start, node picker renders group and leaf chips unchanged, Connect establishes and real traffic routes through the profile with rule-provider matches, `Sniffer is loaded and working`
- Inserting enum constants mid-list is safe: the type is serialized by name, not ordinal

Not verified on device: chips for the newly added types, since no subscription at hand contains such nodes. The mappings were checked line-by-line against the engine sources.