### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -1487,9 +1487,9 @@ class MainActivity : BaseActivity<MainDesign>() {
                     // idle=30s). Mihomo health-check writes delays into
                     // proxy.LastDelayForTestUrl synchronously when warmup
                     // finishes; without this re-query the carriage stays blank
-                    // until the timer rolls over. (FlClash side-steps the
-                    // whole class of staleness with a delay event channel —
-                    // see docs/path-b-engine-parsing.md follow-ups.)
+                    // until the timer rolls over. (A delay event channel would
+                    // side-step this whole class of staleness — see
+                    // docs/path-b-engine-parsing.md follow-ups.)
                     if (warmed.isNotEmpty()) {
                         val patches = refreshRuntimeGroupDetails(warmed)
                         if (patches.isNotEmpty()) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,11 @@ subprojects {
             minSdk = 21
             targetSdk = 35
 
-            versionName = "0.10.2"
-            versionCode = 1002000
+            versionName = "1.0.0"
+            // major * 10_000_000 + minor * 100_000 + patch * 1_000.
+            // Up to 0.10.2 the major was not encoded at all (0.10.2 -> 1_002_000), which would
+            // have made 1.0.0 compute to 0 and break updates — Android requires this to increase.
+            versionCode = 10000000
 
             resValue("string", "release_name", "v$versionName")
             resValue("integer", "release_code", "$versionCode")

--- a/core/src/main/golang/native/config/configscript/script_test.go
+++ b/core/src/main/golang/native/config/configscript/script_test.go
@@ -66,8 +66,8 @@ func TestApplyScriptPreservesUntouchedKeys(t *testing.T) {
 	}
 }
 
-// The second argument is what Clash Verge Rev passes; scripts written for FlClash take one
-// argument and must keep working.
+// Some clients pass a second argument and some do not; a script that declares one
+// parameter must keep working.
 func TestApplyScriptProfileNameArgument(t *testing.T) {
 	m := run(t, baseConfig, `function main(config, name) { config.mode = name; return config }`)
 	if m["mode"] != "profile" {

--- a/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/adapter/ProfileAdapter.kt
@@ -1645,7 +1645,7 @@ class ProfileAdapter(
     private val pingingGroupByUuid = HashMap<UUID, String>()
 
     /**
-     * FlClash-style vertical accordion of proxy-group blocks for the Profiles-tab inline panel.
+     * Vertical accordion of proxy-group blocks for the Profiles-tab inline panel.
      * Each block header toggles its own node list; several can stay open at once.
      */
     private fun renderGroupAccordion(

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -420,7 +420,7 @@
     <string name="connections_search_hint">搜索主机、进程、规则…</string>
     <string name="connections_title">连接</string>
     <string name="connections_totals_fmt">↑%1$s · ↓%2$s · %3$d 条</string>
-    <string name="effective_rules_connections_hint">若要查看实时域名与代理链（类似 Clash Verge），请开启 VPN 并在使用应用时查看核心日志。</string>
+    <string name="effective_rules_connections_hint">若要查看实时域名与代理链，请开启 VPN 并在使用应用时查看核心日志。</string>
     <string name="effective_rules_count">配置中共有 %d 条规则</string>
     <string name="effective_rules_intro">来自当前配置文件的规则（YAML 顺序）。规则模式下 Clash 自上而下匹配。本页不显示实时流量。</string>
     <string name="effective_rules_no_profile">请先选择一个已导入的配置</string>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -180,7 +180,7 @@ Presets only change <b>where</b> files are downloaded from (CDN / host). It is s
     <string name="effective_rules_title">Routing Rules</string>
     <string name="effective_rules_intro">Rules from the active profile (YAML order). In Rule mode, Clash walks this list top to bottom. This screen does not show live traffic.</string>
     <string name="effective_rules_count">%d rules in config</string>
-    <string name="effective_rules_connections_hint">For live hosts and proxy chains like Clash Verge, turn the VPN on and watch the core log while you use apps.</string>
+    <string name="effective_rules_connections_hint">To see live hosts and proxy chains, turn the VPN on and watch the core log while you use apps.</string>
     <string name="effective_rules_open_logcat">Open core log</string>
     <string name="effective_rules_no_profile">Select an imported profile first</string>
     <string name="effective_rules_search_hint">Search rules, policies, providers…</string>

--- a/docs/path-b-engine-parsing.md
+++ b/docs/path-b-engine-parsing.md
@@ -23,9 +23,8 @@ After Path B:
   derived view.
 
 This is the same pattern [kr328/ClashMetaForAndroid](https://github.com/MetaCubeX/ClashMetaForAndroid)
-already uses for `queryProviders()`, [FlClash](https://github.com/chen08209/FlClash)
-uses for every read, and [Clash Verge](https://github.com/clash-verge-rev/clash-verge-rev)
-uses via the mihomo HTTP API. We adopted it for the same reasons.
+already uses for `queryProviders()`; other clients in the ecosystem rely on it for
+every read, or reach it via the mihomo HTTP API. We adopted it for the same reasons.
 
 ## 1. The Problem We Closed
 

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -311,7 +311,7 @@ object ProfileProcessor {
                 if (configFile.isFile) {
                     val fetchedText = configFile.readText()
                     // The freshly fetched subscription is the new canonical base; persist it and
-                    // compose the captured user layer on top (Clash-Verge-Rev style overlay).
+                    // compose the captured user layer on top (overlay model).
                     File(context.processingDir, ProfileComposer.SUBSCRIPTION_FILE).writeText(fetchedText)
                     UserLayerStore.saveAt(context.processingDir, capturedLayer)
                     val geoUrls = GeoDataSources.resolve(

--- a/service/src/main/java/com/github/kr328/clash/service/util/ConfigComposer.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/ConfigComposer.kt
@@ -32,7 +32,7 @@ class ConfigScriptException(
 ) : Exception(message)
 
 /**
- * Builds the config the engine actually receives, the Clash-Verge-Rev way: take the fetched
+ * Builds the config the engine actually receives, overlay-style: take the fetched
  * subscription **as-is**, apply the user's edit layer on top with non-reconciling merge operations,
  * then harden the composed result. config-overlay-architecture, Group 3.
  *

--- a/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/RuleMapper.kt
@@ -102,7 +102,7 @@ object RuleMapper {
      * Additive composition of a USER rule layer onto a fetched subscription
      * (config-overlay-architecture, Group 3). Unlike [mergeStateIntoConfig] — which renders a
      * COMPLETE captured state and *replaces* both blocks — this keeps everything the subscription
-     * declares and only layers the user's edits on top, Clash-Verge-Rev style:
+     * declares and only layers the user's edits on top, overlay style:
      *  - the user's enabled rule-providers are **unioned** into the fetched ones (user wins on a key
      *    clash); nothing is dropped, so a provider referenced only by `dns.nameserver-policy` survives;
      *  - the user's enabled rules are **prepended** to the subscription's rules (overrides evaluated

--- a/service/src/main/java/com/github/kr328/clash/service/util/UserLayer.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/util/UserLayer.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 /**
  * The user's in-app edits for a profile, stored as **intent** separate from the subscription
  * `config.yaml` (config-overlay-architecture, Group 2). This is ClashFest's equivalent of a
- * Clash-Verge-Rev "Merge profile": the subscription stays exactly as fetched, and this layer is
+ * "merge profile": the subscription stays exactly as fetched, and this layer is
  * composed on top at apply time using only non-reconciling operations (Group 3).
  *
  * Each slot reuses an existing serializable edit model where one exists, so the editors can move


### PR DESCRIPTION
Release prep for **v1.0.0**.

## versionCode

The formula now encodes the major component:

```
major * 10_000_000 + minor * 100_000 + patch * 1_000
```

This is not cosmetic. Up to 0.10.2 the major was **not encoded at all** (`0.10.2 -> 1_002_000`), so under the old scheme `1.0.0` would have computed to **0** — Android requires versionCode to increase, so no device could have updated to it. The formula is spelled out in `build.gradle.kts` so the next major does not hit the same wall.

## Naming cleanup

Drops the remaining references to other Clash clients from user-visible strings, code comments and docs.

One of them was **user-facing**: `effective_rules_connections_hint` named another client in EN and ZH.

The reasoning behind each decision is kept — only the names are gone. The overlay model and the config-script signature are now described on their own terms rather than by comparison.

## Verification

- Build green, **314** unit tests (253 service + 61 common), 0 failures
- Debug APK builds as `clashfest-v1.0.0-alpha-*`
- **Release variant built and smoke-tested on device (Android 13)** — this is the part debug builds cannot cover:
  - installs and launches clean, `versionCode=10000000`, `versionName=1.0.0.Alpha`
  - no `ClassNotFound` / `NoSuchMethod` / `UnsatisfiedLink` anywhere in the log
  - config script **success** path: "Script runs — no problems found"
  - config script **failure** path: "The script must define function main(config) (E-61)"

That last pair is the reason the release build was smoke-tested at all: the script feature crosses IPC as kotlinx-serialized Parcelables and calls a JNI function, all of which R8 can strip or rename. Both paths survive minification.
